### PR TITLE
Fix: FF1 cannot auto-recover after service recovery

### DIFF
--- a/components/feral-watchdog/packages/cdp/cdp.go
+++ b/components/feral-watchdog/packages/cdp/cdp.go
@@ -22,9 +22,8 @@ var (
 
 const (
 	CDP_CRITICAL_CPU_TEMPERATURE_EVENT = "CriticalCPUTemperature"
-
-	MSG_URL_PREFIX                  = "file:///opt/feral/ui/launcher/index.html?step=message&message="
-	SERVICE_FAILED_TO_START_MESSAGE = "FF1 encountered an unexpected issue and has stopped working. Please reboot the device. If the problem persists, contact support@feralfile.com for assistance."
+	CDP_SERVICE_FAILED_EVENT           = "ServiceFailed"
+	DISPLAY_FERALFILE_URL              = "https://display.feralfile.com"
 
 	// CDP Methods
 	METHOD_EVALUATE = "Runtime.evaluate"
@@ -362,23 +361,50 @@ func (c *Client) Reconnect(ctx context.Context) error {
 	return c.initLocked(ctx)
 }
 
-// SendCriticalCPUTemperatureNotification sends a critical CPU temperature notification
-func (c *Client) SendCriticalCPUTemperatureNotification(ctx context.Context) error {
-	// Send the CDP command
+// sendWatchdogEvent sends a watchdog event to the website via CDP
+func (c *Client) sendWatchdogEvent(ctx context.Context, eventType string) error {
+	expression := fmt.Sprintf("window.handleWatchdogEvent(%q)", eventType)
+
 	params := map[string]interface{}{
-		"expression": fmt.Sprintf("window.handleWatchdogEvent(%q)", CDP_CRITICAL_CPU_TEMPERATURE_EVENT),
+		"expression": expression,
 	}
 
 	_, err := c.Send(METHOD_EVALUATE, params)
 	if err != nil {
 		if c.IsReconnectionError(err) {
-			return c.Reconnect(ctx)
+			if reconnErr := c.Reconnect(ctx); reconnErr != nil {
+				return fmt.Errorf("failed to reconnect: %w", reconnErr)
+			}
+			// Retry after reconnect
+			_, err = c.Send(METHOD_EVALUATE, params)
+			if err != nil {
+				return fmt.Errorf("failed to send watchdog event: %w", err)
+			}
+		} else {
+			return fmt.Errorf("failed to send watchdog event: %w", err)
 		}
-
-		return err
 	}
 
+	return nil
+}
+
+// SendCriticalCPUTemperatureNotification sends a critical CPU temperature notification
+func (c *Client) SendCriticalCPUTemperatureNotification(ctx context.Context) error {
+	err := c.sendWatchdogEvent(ctx, CDP_CRITICAL_CPU_TEMPERATURE_EVENT)
+	if err != nil {
+		return err
+	}
 	c.logger.Info("Critical CPU temperature notification sent successfully")
+	return nil
+}
+
+// SendServiceFailedEvent sends service failed event to website via CDP
+func (c *Client) SendServiceFailedEvent(ctx context.Context) error {
+	err := c.sendWatchdogEvent(ctx, CDP_SERVICE_FAILED_EVENT)
+	if err != nil {
+		return err
+	}
+	c.logger.Info("Service failed event sent successfully via CDP")
 	return nil
 }
 
@@ -403,18 +429,6 @@ func (c *Client) Navigate(ctx context.Context, url string) error {
 			return fmt.Errorf("failed to navigate to %s: %w", url, err)
 		}
 	}
-	return nil
-}
-
-// ShowServiceFailedToStartPage navigates to the service failed to start page
-func (c *Client) ShowServiceFailedToStartPage(ctx context.Context) error {
-	message := SERVICE_FAILED_TO_START_MESSAGE
-	messageURL := MSG_URL_PREFIX + message
-	err := c.Navigate(ctx, messageURL)
-	if err != nil {
-		return fmt.Errorf("failed to navigate to %s: %w", messageURL, err)
-	}
-	c.logger.Info("Navigated to", zap.String("url", messageURL))
 	return nil
 }
 

--- a/components/feral-watchdog/systemd_service.go
+++ b/components/feral-watchdog/systemd_service.go
@@ -25,17 +25,19 @@ var (
 
 // SystemdMonitor monitors systemd services
 type SystemdMonitor struct {
-	cdpClient      *cdp.Client
-	logger         *zap.Logger
-	commandHandler *CommandHandler
+	cdpClient         *cdp.Client
+	logger            *zap.Logger
+	commandHandler    *CommandHandler
+	lastServiceStates map[string]*SystemdServiceStatus // Track last state to detect recovery
 }
 
 // NewSystemdMonitor creates a new Chromium monitor instance
 func NewSystemdMonitor(cdpClient *cdp.Client, logger *zap.Logger, commandHandler *CommandHandler) *SystemdMonitor {
 	return &SystemdMonitor{
-		cdpClient:      cdpClient,
-		logger:         logger,
-		commandHandler: commandHandler,
+		cdpClient:         cdpClient,
+		logger:            logger,
+		commandHandler:    commandHandler,
+		lastServiceStates: make(map[string]*SystemdServiceStatus),
 	}
 }
 
@@ -75,17 +77,36 @@ func (m *SystemdMonitor) check(ctx context.Context) error {
 			return errors.New("service state is nil")
 		}
 
+		// Check if service just recovered (failed -> active)
+		lastState := m.lastServiceStates[service]
+		hasRecovered := lastState != nil && *lastState == SYSTEMD_SERVICE_STATUS_FAILED && *state == SYSTEMD_SERVICE_STATUS_ACTIVE
+
 		switch *state {
 		case SYSTEMD_SERVICE_STATUS_ACTIVE:
-			m.logger.Debug("Systemd: Service is active",
-				zap.String("service", service))
+			if hasRecovered {
+				m.logger.Info("Systemd: Service recovered, resume playlist",
+					zap.String("service", service))
+				if m.cdpClient != nil {
+					if err := m.cdpClient.Navigate(ctx, cdp.DISPLAY_FERALFILE_URL); err != nil {
+						m.logger.Error("Systemd: Failed to resume playlist after service recovery",
+							zap.String("service", service),
+							zap.Error(err))
+					} else {
+						m.logger.Info("Systemd: Playlist resumed after service recovery",
+							zap.String("service", service))
+					}
+				}
+			} else {
+				m.logger.Debug("Systemd: Service is active",
+					zap.String("service", service))
+			}
 		case SYSTEMD_SERVICE_STATUS_FAILED:
 			m.logger.Error("Systemd: Service is failed",
 				zap.String("service", service),
 				zap.String("dependency", service))
 			// Send service failed to start notification to website via CDP
 			if m.cdpClient != nil {
-				if err := m.cdpClient.ShowServiceFailedToStartPage(ctx); err != nil {
+				if err := m.cdpClient.SendServiceFailedEvent(ctx); err != nil {
 					m.logger.Error("Systemd: Failed to send service failed to start notification via CDP",
 						zap.String("service", service),
 						zap.Error(err))
@@ -103,6 +124,9 @@ func (m *SystemdMonitor) check(ctx context.Context) error {
 				zap.String("service", service),
 				zap.Any("state", state))
 		}
+
+		// Update last state
+		m.lastServiceStates[service] = state
 	}
 
 	return nil


### PR DESCRIPTION
- Card: https://github.com/feral-file/ffos-user/issues/94
- Description: Display the service failed error on player instead of FF1.