### PR TITLE
feat: sleep mode

### DIFF
--- a/components/feral-controld/commands/types.go
+++ b/components/feral-controld/commands/types.go
@@ -29,6 +29,7 @@ var deviceCtlCommands = map[Type]bool{
 	CMD_UPDATE_TO_LATEST:     true,
 	CMD_FACTORY_RESET:        true,
 	CMD_UPLOAD_LOGS:          true,
+	CMD_SLEEP_MODE:           true,
 }
 
 type Command struct {
@@ -58,6 +59,7 @@ const (
 	CMD_DISPLAY_PLAYLIST     Type = "displayPlaylist"
 	CMD_FACTORY_RESET        Type = "factoryReset"
 	CMD_UPLOAD_LOGS          Type = "uploadLogs"
+	CMD_SLEEP_MODE           Type = "sleepMode"
 )
 
 func (c Type) DeviceCtlCommand() bool {

--- a/components/feral-controld/devicectl/executor.go
+++ b/components/feral-controld/devicectl/executor.go
@@ -34,6 +34,15 @@ const AnalyticsToggleOffFile = "/home/feralfile/.state/analytics-toggle-off"
 // BetaFeaturesToggleOnFile is the sentinel file that enables beta features (default is off).
 const BetaFeaturesToggleOnFile = "/home/feralfile/.state/beta-features-toggle-on"
 
+// Navigation URLs
+const (
+	// LauncherLogoURL is the local launcher UI logo page
+	LauncherLogoURL = "file:///opt/feral/ui/launcher/index.html?step=logo"
+
+	// ControlAppURL is the web-based control application
+	ControlAppURL = "https://display.feralfile.com"
+)
+
 type Device struct {
 	ID       string `json:"device_id"`
 	Name     string `json:"device_name"`
@@ -148,6 +157,8 @@ func (e *executor) Execute(ctx context.Context, cmd commands.Command) (interface
 		result, err = e.factoryReset(ctx)
 	case commands.CMD_UPLOAD_LOGS:
 		result, err = e.uploadLogs(ctx, bytes)
+	case commands.CMD_SLEEP_MODE:
+		result, err = e.handleSleepMode(ctx, bytes)
 	default:
 		return nil, fmt.Errorf("invalid command: %s", cmd)
 	}
@@ -770,4 +781,206 @@ func (e *executor) uploadLogs(ctx context.Context, args []byte) (interface{}, er
 	}
 
 	return CmdOK, nil
+}
+
+// navigateToURL navigates the browser to the specified URL using CDP Page.navigate
+func (e *executor) navigateToURL(url string) error {
+	e.logger.Info("Navigating to URL", zap.String("url", url))
+	_, err := e.cdp.Send("Page.navigate", map[string]interface{}{
+		"url": url,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to navigate to %s: %w", url, err)
+	}
+	return nil
+}
+
+// sendCommandToPage sends a command to the launcher page via window.handleCDPRequest
+func (e *executor) sendCommandToPage(command commands.Command) error {
+	commandJSON, err := e.json.Marshal(command)
+	if err != nil {
+		return fmt.Errorf("failed to marshal command: %w", err)
+	}
+
+	expr := fmt.Sprintf("window.handleCDPRequest(%s)", string(commandJSON))
+	_, err = e.cdp.Send("Runtime.evaluate", map[string]interface{}{
+		"expression": expr,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to send command to page: %w", err)
+	}
+	return nil
+}
+
+func (e *executor) handleSleepMode(ctx context.Context, args []byte) (interface{}, error) {
+	var cmdArgs struct {
+		Enabled bool   `json:"enabled"`
+		Force   *bool  `json:"force,omitempty"`
+		Reason  string `json:"reason,omitempty"`
+	}
+
+	if err := e.json.Unmarshal(args, &cmdArgs); err != nil {
+		return nil, fmt.Errorf("invalid arguments: %w", err)
+	}
+
+	e.logger.Info("Sleep mode request",
+		zap.Bool("enabled", cmdArgs.Enabled),
+		zap.String("reason", cmdArgs.Reason))
+
+	s := state.GetState()
+	if s.SleepMode == nil {
+		s.SleepMode = &state.SleepModeState{}
+	}
+
+	if cmdArgs.Enabled {
+		// Enter sleep mode
+		return e.enterSleepMode(ctx, s)
+	}
+
+	// Exit sleep mode
+	return e.exitSleepMode(ctx, s)
+}
+
+func (e *executor) enterSleepMode(ctx context.Context, s *state.State) (interface{}, error) {
+	e.logger.Info("Entering sleep mode")
+
+	// Capture current player status before switching to logo
+	playerStatus, err := e.statusPoller.FetchPlayerStatus(ctx)
+	if err != nil {
+		e.logger.Warn("Failed to fetch player status before sleep", zap.Error(err))
+		// Continue anyway - we'll just show logo on wake
+	} else if playerStatus != nil && playerStatus.Command == string(commands.CMD_DISPLAY_PLAYLIST) {
+		// Store the playlist state for restoration
+		s.SleepMode.LastPlaylistURL = playerStatus.PlaylistURL
+		s.SleepMode.LastIndex = playerStatus.Index
+		s.SleepMode.LastIsPaused = playerStatus.IsPaused
+
+		// If no URL but we have a playlist object, store it
+		if playerStatus.PlaylistURL == nil && playerStatus.Playlist != nil {
+			playlistBytes, err := e.json.Marshal(playerStatus.Playlist)
+			if err == nil {
+				var playlistMap map[string]interface{}
+				if err := e.json.Unmarshal(playlistBytes, &playlistMap); err == nil {
+					s.SleepMode.LastPlaylist = playlistMap
+				}
+			}
+		}
+
+		e.logger.Info("Captured player state before sleep",
+			zap.Bool("hasPlaylistURL", playerStatus.PlaylistURL != nil),
+			zap.Bool("hasPlaylist", s.SleepMode.LastPlaylist != nil))
+	}
+
+	// Navigate Chromium to logo page
+	if err := e.navigateToURL(LauncherLogoURL); err != nil {
+		e.logger.Error("Failed to navigate to logo page", zap.Error(err))
+		return nil, err
+	}
+
+	e.logger.Info("Navigated to logo page")
+
+	// Turn off screen using script
+	//nolint:gosec
+	cmd := e.exec.CommandContext(ctx, "/home/feralfile/scripts/screen-power.sh", "sleep")
+	if err := cmd.Run(); err != nil {
+		e.logger.Error("Failed to turn off screen", zap.Error(err))
+		return nil, fmt.Errorf("failed to turn off screen: %w", err)
+	}
+
+	e.logger.Info("Screen turned off")
+
+	// Update state
+	s.SleepMode.Enabled = true
+	if err := s.Save(); err != nil {
+		e.logger.Error("Failed to save sleep mode state", zap.Error(err))
+		return nil, fmt.Errorf("failed to save state: %w", err)
+	}
+
+	return map[string]interface{}{
+		"ok":      true,
+		"enabled": true,
+	}, nil
+}
+
+func (e *executor) exitSleepMode(ctx context.Context, s *state.State) (interface{}, error) {
+	e.logger.Info("Exiting sleep mode")
+
+	// Navigate back to the control app (webapp)
+	if err := e.navigateToURL(ControlAppURL); err != nil {
+		e.logger.Error("Failed to navigate to control app", zap.Error(err))
+		// Continue anyway - we can still try to restore the playlist
+	} else {
+		e.logger.Info("Navigated to control app")
+	}
+
+	// Turn on screen using script
+	//nolint:gosec
+	cmd := e.exec.CommandContext(ctx, "/home/feralfile/scripts/screen-power.sh", "wake")
+	if err := cmd.Run(); err != nil {
+		e.logger.Error("Failed to wake screen", zap.Error(err))
+
+		// Navigate Chromium to logo page
+		if err := e.navigateToURL(LauncherLogoURL); err != nil {
+			e.logger.Error("Failed to navigate to logo page", zap.Error(err))
+			return nil, err
+		}
+
+		return nil, fmt.Errorf("failed to wake screen: %w", err)
+	}
+
+	e.logger.Info("Screen woke successfully")
+
+	// Restore playlist if we have one
+	if s.SleepMode.LastPlaylistURL != nil || s.SleepMode.LastPlaylist != nil {
+		e.logger.Info("Restoring previous playlist")
+
+		command := commands.Command{
+			Type:      commands.CMD_DISPLAY_PLAYLIST,
+			Arguments: make(map[string]interface{}),
+		}
+
+		if s.SleepMode.LastPlaylistURL != nil {
+			command.Arguments["playlistUrl"] = *s.SleepMode.LastPlaylistURL
+		} else if s.SleepMode.LastPlaylist != nil {
+			command.Arguments["dp1_call"] = s.SleepMode.LastPlaylist
+		}
+
+		// Add index and isPaused if available
+		if s.SleepMode.LastIndex != nil {
+			command.Arguments["index"] = *s.SleepMode.LastIndex
+		}
+		if s.SleepMode.LastIsPaused != nil {
+			command.Arguments["isPaused"] = *s.SleepMode.LastIsPaused
+		}
+
+		// Send command to page via CDP
+		if err := e.sendCommandToPage(command); err != nil {
+			e.logger.Error("Failed to restore playlist", zap.Error(err))
+			// Don't fail the whole command - screen is on which is the main goal
+		} else {
+			e.logger.Info("Playlist restored successfully")
+		}
+	} else {
+		e.logger.Info("No previous playlist to restore, keeping logo page")
+	}
+
+	// Update state - clear sleep mode and saved playlist
+	s.SleepMode.Enabled = false
+	s.SleepMode.LastPlaylistURL = nil
+	s.SleepMode.LastPlaylist = nil
+	s.SleepMode.LastIndex = nil
+	s.SleepMode.LastIsPaused = nil
+
+	if err := s.Save(); err != nil {
+		e.logger.Error("Failed to save sleep mode state", zap.Error(err))
+		// Don't fail - the important actions are done
+	}
+
+	// Force refresh status poller
+	e.statusPoller.ForceRefresh()
+
+	return map[string]interface{}{
+		"ok":      true,
+		"enabled": false,
+	}, nil
 }

--- a/components/feral-controld/devicectl/executor_test.go
+++ b/components/feral-controld/devicectl/executor_test.go
@@ -3050,3 +3050,371 @@ func TestExecutor_NewHandler(t *testing.T) {
 	handler := devicectl.New(mockCDP, mockDBus, mockDeviceStatus, mockStatus, mockJSON, mockOS, mockExec, mockMath, logger)
 	assert.NotNil(t, handler)
 }
+
+func TestExecutor_HandleSleepMode_EnterSleep(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	// Setup test data
+	cmd := commands.Command{
+		Type: commands.CMD_SLEEP_MODE,
+		Arguments: map[string]interface{}{
+			"enabled": true,
+		},
+	}
+
+	// Setup state
+	testState := &state.State{
+		Relayer:         &state.RelayerState{TopicID: "test-topic"},
+		ConnectedDevice: &state.Device{},
+		SleepMode:       &state.SleepModeState{},
+	}
+
+	// Mock player status
+	playlistURL := "https://example.com/playlist.json"
+	index := 5
+	isPaused := false
+	mockPlayerStatus := &status.PlayerStatus{
+		Command:     string(commands.CMD_DISPLAY_PLAYLIST),
+		PlaylistURL: &playlistURL,
+		Index:       &index,
+		IsPaused:    &isPaused,
+	}
+
+	// Mock expectations
+	// First, Execute calls Marshal on the arguments
+	ts.mockJSON.EXPECT().
+		Marshal(cmd.Arguments).
+		Return([]byte(`{"enabled":true}`), nil)
+
+	ts.mockJSON.EXPECT().
+		Unmarshal(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(data []byte, v interface{}) error {
+			// Parse the arguments
+			argMap := v.(*struct {
+				Enabled bool   `json:"enabled"`
+				Force   *bool  `json:"force,omitempty"`
+				Reason  string `json:"reason,omitempty"`
+			})
+			argMap.Enabled = true
+			return nil
+		})
+
+	ts.mockStateManager.EXPECT().GetState().Return(testState).AnyTimes()
+
+	ts.mockStatus.EXPECT().
+		FetchPlayerStatus(ts.ctx).
+		Return(mockPlayerStatus, nil)
+
+	// Expect CDP call to navigate to logo page
+	ts.mockCDP.EXPECT().
+		Send("Page.navigate", map[string]interface{}{
+			"url": devicectl.LauncherLogoURL,
+		}).
+		Return(nil, nil)
+
+	// Expect screen sleep script
+	mockCmd := ts.mockExecCmd
+	ts.mockExec.EXPECT().
+		CommandContext(ts.ctx, "/home/feralfile/scripts/screen-power.sh", "sleep").
+		Return(mockCmd)
+	mockCmd.EXPECT().Run().Return(nil)
+
+	// Expect state save
+	ts.mockStateManager.EXPECT().
+		Save(gomock.Any()).
+		DoAndReturn(func(s *state.State) error {
+			// Verify state was updated correctly
+			assert.True(t, s.SleepMode.Enabled)
+			assert.Equal(t, &playlistURL, s.SleepMode.LastPlaylistURL)
+			assert.Equal(t, &index, s.SleepMode.LastIndex)
+			assert.Equal(t, &isPaused, s.SleepMode.LastIsPaused)
+			return nil
+		})
+
+	// Execute command
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+
+	// Verify result
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	resultMap, ok := result.(map[string]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, true, resultMap["ok"])
+	assert.Equal(t, true, resultMap["enabled"])
+}
+
+func TestExecutor_HandleSleepMode_ExitSleep(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	// Setup test data
+	cmd := commands.Command{
+		Type: commands.CMD_SLEEP_MODE,
+		Arguments: map[string]interface{}{
+			"enabled": false,
+		},
+	}
+
+	// Setup state with saved playlist
+	playlistURL := "https://example.com/playlist.json"
+	index := 5
+	isPaused := false
+	testState := &state.State{
+		Relayer:         &state.RelayerState{TopicID: "test-topic"},
+		ConnectedDevice: &state.Device{},
+		SleepMode: &state.SleepModeState{
+			Enabled:         true,
+			LastPlaylistURL: &playlistURL,
+			LastIndex:       &index,
+			LastIsPaused:    &isPaused,
+		},
+	}
+
+	// Mock expectations
+	// First, Execute calls Marshal on the arguments, then playlist restoration calls Marshal again
+	ts.mockJSON.EXPECT().
+		Marshal(gomock.Any()).
+		Return([]byte(`{"enabled":false}`), nil)
+
+	ts.mockJSON.EXPECT().
+		Unmarshal(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(data []byte, v interface{}) error {
+			argMap := v.(*struct {
+				Enabled bool   `json:"enabled"`
+				Force   *bool  `json:"force,omitempty"`
+				Reason  string `json:"reason,omitempty"`
+			})
+			argMap.Enabled = false
+			return nil
+		})
+
+	ts.mockStateManager.EXPECT().GetState().Return(testState).AnyTimes()
+
+	// Expect screen wake script
+	mockWakeCmd := ts.mockExecCmd
+	ts.mockExec.EXPECT().
+		CommandContext(ts.ctx, "/home/feralfile/scripts/screen-power.sh", "wake").
+		Return(mockWakeCmd)
+	mockWakeCmd.EXPECT().Run().Return(nil)
+
+	// Expect CDP call to navigate back to control app
+	ts.mockCDP.EXPECT().
+		Send("Page.navigate", map[string]interface{}{
+			"url": devicectl.ControlAppURL,
+		}).
+		Return(nil, nil)
+
+	// Expect playlist restoration via CDP (second Marshal call for the playlist command)
+	ts.mockJSON.EXPECT().
+		Marshal(gomock.Any()).
+		DoAndReturn(func(v interface{}) ([]byte, error) {
+			// This is the second Marshal call - for the playlist restoration command
+			cmd := v.(commands.Command)
+			assert.Equal(t, commands.CMD_DISPLAY_PLAYLIST, cmd.Type)
+			assert.Equal(t, playlistURL, cmd.Arguments["playlistUrl"])
+			assert.Equal(t, index, cmd.Arguments["index"])
+			assert.Equal(t, isPaused, cmd.Arguments["isPaused"])
+			return []byte(`{"command":"displayPlaylist","request":{"playlistUrl":"https://example.com/playlist.json","index":5,"isPaused":false}}`), nil
+		})
+
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		DoAndReturn(func(method string, params map[string]interface{}) (interface{}, error) {
+			expr := params["expression"].(string)
+			assert.Contains(t, expr, "window.handleCDPRequest")
+			assert.Contains(t, expr, "displayPlaylist")
+			return nil, nil
+		})
+
+	// Expect state save
+	ts.mockStateManager.EXPECT().
+		Save(gomock.Any()).
+		DoAndReturn(func(s *state.State) error {
+			// Verify state was cleared
+			assert.False(t, s.SleepMode.Enabled)
+			assert.Nil(t, s.SleepMode.LastPlaylistURL)
+			assert.Nil(t, s.SleepMode.LastPlaylist)
+			assert.Nil(t, s.SleepMode.LastIndex)
+			assert.Nil(t, s.SleepMode.LastIsPaused)
+			return nil
+		})
+
+	// Expect status poller refresh
+	ts.mockStatus.EXPECT().ForceRefresh()
+
+	// Execute command
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+
+	// Verify result
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	resultMap, ok := result.(map[string]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, true, resultMap["ok"])
+	assert.Equal(t, false, resultMap["enabled"])
+}
+
+func TestExecutor_HandleSleepMode_EnterSleep_NoPlaylist(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	// Setup test data
+	cmd := commands.Command{
+		Type: commands.CMD_SLEEP_MODE,
+		Arguments: map[string]interface{}{
+			"enabled": true,
+		},
+	}
+
+	// Setup state
+	testState := &state.State{
+		Relayer:         &state.RelayerState{TopicID: "test-topic"},
+		ConnectedDevice: &state.Device{},
+		SleepMode:       &state.SleepModeState{},
+	}
+
+	// Mock player status with no playlist
+	mockPlayerStatus := &status.PlayerStatus{
+		Command: "checkStatus",
+	}
+
+	// Mock expectations
+	// First, Execute calls Marshal on the arguments
+	ts.mockJSON.EXPECT().
+		Marshal(cmd.Arguments).
+		Return([]byte(`{"enabled":true}`), nil)
+
+	ts.mockJSON.EXPECT().
+		Unmarshal(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(data []byte, v interface{}) error {
+			argMap := v.(*struct {
+				Enabled bool   `json:"enabled"`
+				Force   *bool  `json:"force,omitempty"`
+				Reason  string `json:"reason,omitempty"`
+			})
+			argMap.Enabled = true
+			return nil
+		})
+
+	ts.mockStateManager.EXPECT().GetState().Return(testState).AnyTimes()
+
+	ts.mockStatus.EXPECT().
+		FetchPlayerStatus(ts.ctx).
+		Return(mockPlayerStatus, nil)
+
+	// Expect CDP call to navigate to logo page
+	ts.mockCDP.EXPECT().
+		Send("Page.navigate", map[string]interface{}{
+			"url": devicectl.LauncherLogoURL,
+		}).
+		Return(nil, nil)
+
+	// Expect screen sleep script
+	mockCmd := ts.mockExecCmd
+	ts.mockExec.EXPECT().
+		CommandContext(ts.ctx, "/home/feralfile/scripts/screen-power.sh", "sleep").
+		Return(mockCmd)
+	mockCmd.EXPECT().Run().Return(nil)
+
+	// Expect state save
+	ts.mockStateManager.EXPECT().
+		Save(gomock.Any()).
+		DoAndReturn(func(s *state.State) error {
+			// Verify state - no playlist saved
+			assert.True(t, s.SleepMode.Enabled)
+			assert.Nil(t, s.SleepMode.LastPlaylistURL)
+			return nil
+		})
+
+	// Execute command
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+
+	// Verify result
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	resultMap, ok := result.(map[string]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, true, resultMap["ok"])
+	assert.Equal(t, true, resultMap["enabled"])
+}
+
+func TestExecutor_HandleSleepMode_ExitSleep_NoSavedPlaylist(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	// Setup test data
+	cmd := commands.Command{
+		Type: commands.CMD_SLEEP_MODE,
+		Arguments: map[string]interface{}{
+			"enabled": false,
+		},
+	}
+
+	// Setup state with no saved playlist
+	testState := &state.State{
+		Relayer:         &state.RelayerState{TopicID: "test-topic"},
+		ConnectedDevice: &state.Device{},
+		SleepMode: &state.SleepModeState{
+			Enabled: true,
+		},
+	}
+
+	// Mock expectations
+	// First, Execute calls Marshal on the arguments
+	ts.mockJSON.EXPECT().
+		Marshal(cmd.Arguments).
+		Return([]byte(`{"enabled":false}`), nil)
+
+	ts.mockJSON.EXPECT().
+		Unmarshal(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(data []byte, v interface{}) error {
+			argMap := v.(*struct {
+				Enabled bool   `json:"enabled"`
+				Force   *bool  `json:"force,omitempty"`
+				Reason  string `json:"reason,omitempty"`
+			})
+			argMap.Enabled = false
+			return nil
+		})
+
+	ts.mockStateManager.EXPECT().GetState().Return(testState).AnyTimes()
+
+	// Expect screen wake script
+	mockWakeCmd := ts.mockExecCmd
+	ts.mockExec.EXPECT().
+		CommandContext(ts.ctx, "/home/feralfile/scripts/screen-power.sh", "wake").
+		Return(mockWakeCmd)
+	mockWakeCmd.EXPECT().Run().Return(nil)
+
+	// Expect CDP call to navigate back to control app
+	ts.mockCDP.EXPECT().
+		Send("Page.navigate", map[string]interface{}{
+			"url": devicectl.ControlAppURL,
+		}).
+		Return(nil, nil)
+
+	// No playlist restoration CDP call expected since there's no playlist to restore
+
+	// Expect state save
+	ts.mockStateManager.EXPECT().
+		Save(gomock.Any()).
+		DoAndReturn(func(s *state.State) error {
+			assert.False(t, s.SleepMode.Enabled)
+			return nil
+		})
+
+	// Expect status poller refresh
+	ts.mockStatus.EXPECT().ForceRefresh()
+
+	// Execute command
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+
+	// Verify result
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	resultMap, ok := result.(map[string]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, true, resultMap["ok"])
+	assert.Equal(t, false, resultMap["enabled"])
+}

--- a/components/feral-controld/state/state.go
+++ b/components/feral-controld/state/state.go
@@ -25,9 +25,19 @@ func (r *RelayerState) IsReady() bool {
 	return r.TopicID != ""
 }
 
+// SleepModeState stores the sleep mode status and the last player state before sleep
+type SleepModeState struct {
+	Enabled         bool                   `json:"enabled"`
+	LastPlaylistURL *string                `json:"lastPlaylistURL,omitempty"`
+	LastPlaylist    map[string]interface{} `json:"lastPlaylist,omitempty"`
+	LastIndex       *int                   `json:"lastIndex,omitempty"`
+	LastIsPaused    *bool                  `json:"lastIsPaused,omitempty"`
+}
+
 type State struct {
-	ConnectedDevice *Device       `json:"connectedDevice"`
-	Relayer         *RelayerState `json:"relayer"`
+	ConnectedDevice *Device         `json:"connectedDevice"`
+	Relayer         *RelayerState   `json:"relayer"`
+	SleepMode       *SleepModeState `json:"sleepMode,omitempty"`
 }
 
 //go:generate mockgen -source=state.go -destination=../mocks/state.go -package=mocks -mock_names=StateManager=MockStateManager
@@ -80,6 +90,7 @@ func (m *defaultStateManager) Load(logger *zap.Logger) (*State, error) {
 		return &State{
 			Relayer:         &RelayerState{},
 			ConnectedDevice: &Device{},
+			SleepMode:       &SleepModeState{},
 		}, nil
 	} else if err != nil {
 		return nil, fmt.Errorf("failed to read state file: %w", err)
@@ -89,6 +100,7 @@ func (m *defaultStateManager) Load(logger *zap.Logger) (*State, error) {
 		return &State{
 			Relayer:         &RelayerState{},
 			ConnectedDevice: &Device{},
+			SleepMode:       &SleepModeState{},
 		}, nil
 	}
 
@@ -139,6 +151,7 @@ func (m *defaultStateManager) GetState() *State {
 		m.state = &State{
 			Relayer:         &RelayerState{},
 			ConnectedDevice: &Device{},
+			SleepMode:       &SleepModeState{},
 		}
 	}
 	return m.state

--- a/components/feral-controld/status/device_status.go
+++ b/components/feral-controld/status/device_status.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	constants "github.com/feral-file/ffos-user/components/feral-controld/constant"
+	"github.com/feral-file/ffos-user/components/feral-controld/state"
 	"github.com/feral-file/ffos-user/components/feral-controld/wrapper"
 
 	"golang.org/x/sync/errgroup"
@@ -50,12 +51,17 @@ type DeviceStatusResponse struct {
 	LatestVersion       string `json:"latestVersion,omitempty"`
 	AnalyticsDisabled   bool   `json:"analyticsDisabled,omitempty"`
 	BetaFeaturesEnabled bool   `json:"betaFeaturesEnabled,omitempty"`
+	Sleep               bool   `json:"sleep"`
 }
 
 // GetStatus retrieves comprehensive device status information
 // This function can be used by both command handlers and status polling
 func (d deviceStatus) GetStatus(ctx context.Context) (*DeviceStatusResponse, error) {
 	response := &DeviceStatusResponse{}
+
+	// Check sleep mode state
+	sleepModeState := state.GetState().SleepMode
+	isSleeping := sleepModeState != nil && sleepModeState.Enabled
 
 	// Use errgroup for parallel execution
 	g, ctx := errgroup.WithContext(ctx)
@@ -186,6 +192,7 @@ func (d deviceStatus) GetStatus(ctx context.Context) (*DeviceStatusResponse, err
 	response.LatestVersion = latestVersion
 	response.AnalyticsDisabled = analyticsDisabled
 	response.BetaFeaturesEnabled = betaFeaturesEnabled
+	response.Sleep = isSleeping
 
 	return response, nil
 }

--- a/components/feral-sys-monitord/metric/metric.go
+++ b/components/feral-sys-monitord/metric/metric.go
@@ -186,6 +186,20 @@ func (p *SysResMonitor) tick(ctx context.Context, interval time.Duration, fns ..
 	}
 }
 
+func (p *SysResMonitor) isSleepMode() bool {
+	stateFile := "/home/feralfile/.state/controld.state"
+	data, err := os.ReadFile(stateFile)
+	if err != nil {
+		return false
+	}
+
+	// Quick check for sleep mode without full JSON parsing to avoid dependency on feral-controld's types
+	content := string(data)
+	// Remove all whitespace for easier matching
+	compact := strings.Join(strings.Fields(content), "")
+	return strings.Contains(compact, "\"sleepMode\":{\"enabled\":true")
+}
+
 func detectCPUType() SystemType {
 	file, err := os.Open("/proc/cpuinfo")
 	if err != nil {
@@ -636,6 +650,11 @@ func (p *SysResMonitor) monitorUptime(_ context.Context) error {
 }
 
 func (p *SysResMonitor) monitorScreen(ctx context.Context) error {
+	if p.isSleepMode() {
+		p.logger.Debug("Skipping screen monitor in sleep mode")
+		return nil
+	}
+
 	// Resolution and refresh rate
 	cmd := exec.CommandContext(ctx, "wlr-randr")
 	var stderr bytes.Buffer

--- a/users/feralfile/.file_permissions.sh
+++ b/users/feralfile/.file_permissions.sh
@@ -5,4 +5,5 @@ chmod +x /home/feralfile/scripts/cdp-ready-check.sh
 chmod +x /home/feralfile/scripts/display-restore.sh
 chmod +x /home/feralfile/scripts/run-vmagent.sh
 chmod +x /home/feralfile/scripts/ota-update-success-check.sh
+chmod +x /home/feralfile/scripts/screen-power.sh
 sudo chmod +x /usr/local/bin/vmagent-prod

--- a/users/feralfile/scripts/display-restore.sh
+++ b/users/feralfile/scripts/display-restore.sh
@@ -1,12 +1,26 @@
 #!/bin/bash
 
 STATE_FILE="/home/feralfile/.state/screen-orientation"
+CONTROLD_STATE_FILE="/home/feralfile/.state/controld.state"
 
 get_rotation() {
     if [ -f "$STATE_FILE" ]; then
         cat "$STATE_FILE"
     else
         echo "normal"
+    fi
+}
+
+is_sleep_mode() {
+    if [ ! -f "$CONTROLD_STATE_FILE" ]; then
+        return 1  # Not in sleep mode if state file doesn't exist
+    fi
+    
+    # Check if sleep mode is enabled in the state file
+    if grep -q '"sleepMode":{[^}]*"enabled":true' "$CONTROLD_STATE_FILE" 2>/dev/null; then
+        return 0  # In sleep mode
+    else
+        return 1  # Not in sleep mode
     fi
 }
 
@@ -85,6 +99,13 @@ udevadm monitor --kernel --subsystem-match=drm | while read -r line; do
     if [[ "$line" == *"change"* ]]; then
         # Wait a bit for kernel to update status files
         sleep 0.3
+        
+        # Skip processing if device is in sleep mode
+        if is_sleep_mode; then
+            echo "$(date '+%F %T') [DEBUG] Skipping display event processing - device is in sleep mode"
+            continue
+        fi
+        
         # Check if any display is connected
         status=$(cat /sys/class/drm/card*-*/status 2>/dev/null | grep -m1 "^connected$")
         [ -n "$status" ] && status="connected"

--- a/users/feralfile/scripts/screen-power.sh
+++ b/users/feralfile/scripts/screen-power.sh
@@ -13,7 +13,13 @@ ACTION="${1:-}"
 case "$ACTION" in
     sleep)
         echo "$(date '+%F %T') [INFO] Turning off screen with ddcutil..."
-        sudo ddcutil --noverify setvcp D6 02
+        # Samsung Frame TVs often have issues with DDC/CI. 
+        # We try to set the power state, but also use wlr-randr as a fallback.
+        # --noscantable helps avoid "EDID has changed" errors by not scanning all buses.
+        sudo ddcutil --noverify --noscantable setvcp D6 02 || echo "$(date '+%F %T') [WARN] ddcutil sleep failed"
+        
+        echo "$(date '+%F %T') [INFO] Turning off display signal with wlr-randr..."
+        wlr-randr --output HDMI-A-1 --off
         echo "$(date '+%F %T') [INFO] Screen sleep complete"
         ;;
     
@@ -23,15 +29,16 @@ case "$ACTION" in
         
         # Wait for display to initialize DDC/CI interface
         # The I2C bus and monitor need time to be ready for communication
+        # Samsung TVs often need more time to wake up the DDC interface
         echo "$(date '+%F %T') [INFO] Waiting for display to initialize..."
-        sleep 1.5
+        sleep 3
         
         echo "$(date '+%F %T') [INFO] Turning on screen with ddcutil..."
-        # Retry once if first attempt fails (common on first wake)
-        if ! sudo ddcutil --noverify setvcp D6 01 2>/dev/null; then
-            echo "$(date '+%F %T') [WARN] First ddcutil attempt failed, retrying after delay..."
+        # Retry with increased delay and --noscantable
+        if ! sudo ddcutil --noverify --noscantable setvcp D6 01 2>/dev/null; then
+            echo "$(date '+%F %T') [WARN] First ddcutil attempt failed, retrying after additional delay..."
             sleep 2
-            sudo ddcutil --noverify setvcp D6 01
+            sudo ddcutil --noverify --noscantable --retry 3 setvcp D6 01 || true
         fi
         echo "$(date '+%F %T') [INFO] Screen wake complete"
         ;;

--- a/users/feralfile/scripts/screen-power.sh
+++ b/users/feralfile/scripts/screen-power.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# Screen Power Management Script
+# Controls display and monitor power state
+#
+# Usage: screen-power.sh [sleep|wake]
+#
+
+set -e
+
+ACTION="${1:-}"
+
+case "$ACTION" in
+    sleep)
+        echo "$(date '+%F %T') [INFO] Turning off screen with ddcutil..."
+        sudo ddcutil --noverify setvcp D6 02
+        echo "$(date '+%F %T') [INFO] Screen sleep complete"
+        ;;
+    
+    wake)
+        echo "$(date '+%F %T') [INFO] Turning on display with wlr-randr..."
+        wlr-randr --output HDMI-A-1 --on
+        
+        # Wait for display to initialize DDC/CI interface
+        # The I2C bus and monitor need time to be ready for communication
+        echo "$(date '+%F %T') [INFO] Waiting for display to initialize..."
+        sleep 1.5
+        
+        echo "$(date '+%F %T') [INFO] Turning on screen with ddcutil..."
+        # Retry once if first attempt fails (common on first wake)
+        if ! sudo ddcutil --noverify setvcp D6 01 2>/dev/null; then
+            echo "$(date '+%F %T') [WARN] First ddcutil attempt failed, retrying after delay..."
+            sleep 2
+            sudo ddcutil --noverify setvcp D6 01
+        fi
+        echo "$(date '+%F %T') [INFO] Screen wake complete"
+        ;;
+    
+    *)
+        echo "Usage: $0 {sleep|wake}"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/users/feralfile/system-config/45-ddcutil-i2c.rules
+++ b/users/feralfile/system-config/45-ddcutil-i2c.rules
@@ -1,0 +1,14 @@
+# Udev rules for ddcutil I2C access without sudo
+# This file should be installed to: /etc/udev/rules.d/45-ddcutil-i2c.rules
+#
+# After installation, reload udev rules:
+#   sudo udevadm control --reload-rules
+#   sudo udevadm trigger
+#
+# Then reboot or replug the monitor
+
+# Grant i2c group access to all I2C devices
+KERNEL=="i2c-[0-9]*", GROUP="i2c", MODE="0660"
+
+# Alternative: Grant specific user access (replace USER with actual username)
+# KERNEL=="i2c-[0-9]*", OWNER="feralfile", MODE="0660"

--- a/users/feralfile/system-config/DDCUTIL-SETUP.md
+++ b/users/feralfile/system-config/DDCUTIL-SETUP.md
@@ -1,0 +1,122 @@
+# DDC/CI Display Control Setup (ddcutil)
+
+This document describes how to configure the system to allow `ddcutil` commands to control monitor power and settings without requiring password prompts.
+
+## Prerequisites
+
+- `ddcutil` installed: `sudo pacman -S ddcutil`
+- Monitor that supports DDC/CI (most modern displays do)
+- Connected via DisplayPort or HDMI
+
+## Option 1: Udev Rules + I2C Group (Recommended)
+
+This approach grants permission via Linux device groups.
+
+### 1. Load i2c-dev kernel module
+
+```bash
+echo i2c-dev | sudo tee /etc/modules-load.d/i2c-dev.conf
+sudo modprobe i2c-dev
+```
+
+### 2. Create i2c group and add user
+
+```bash
+sudo groupadd --system i2c
+sudo usermod -aG i2c feralfile
+```
+
+### 3. Install udev rules
+
+```bash
+sudo cp system-config/45-ddcutil-i2c.rules /etc/udev/rules.d/
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+
+### 4. Reboot or re-login
+
+```bash
+# Either reboot
+sudo reboot
+
+# Or logout and login again for group membership to take effect
+```
+
+### 5. Verify
+
+```bash
+# Should work without sudo now
+ddcutil detect
+ddcutil getvcp D6  # Get power state
+```
+
+## Option 2: Passwordless Sudo (Fallback)
+
+If Option 1 doesn't work or you need a quick solution:
+
+### 1. Validate and install sudoers file
+
+```bash
+# Validate syntax first (important!)
+sudo visudo -c -f system-config/ddcutil-sudoers
+
+# If validation passes, install it
+sudo cp system-config/ddcutil-sudoers /etc/sudoers.d/ddcutil
+sudo chmod 0440 /etc/sudoers.d/ddcutil
+```
+
+### 2. Verify
+
+```bash
+# Should not prompt for password
+sudo ddcutil detect
+```
+
+## Troubleshooting
+
+### Check if your monitor supports DDC/CI
+
+```bash
+ddcutil detect
+```
+
+If no displays are detected, your monitor may not support DDC/CI or the connection type (e.g., VGA) doesn't support it.
+
+### Check i2c devices
+
+```bash
+ls -l /dev/i2c-*
+```
+
+Should show devices owned by `i2c` group (Option 1) or accessible to your user.
+
+### Check group membership
+
+```bash
+groups feralfile
+```
+
+Should include `i2c` if using Option 1.
+
+### Test without code
+
+```bash
+# Turn off display
+ddcutil setvcp D6 02
+
+# Turn on display
+ddcutil setvcp D6 01
+```
+
+## VCP Code Reference
+
+- `D6 02` = Power off (standby)
+- `D6 01` = Power on
+- `D6 04` = Power off (hard off, if supported)
+
+## Notes
+
+- The `--noverify` flag in the code skips DDC verification for faster execution
+- DDC commands can take 50-200ms to execute
+- Some monitors may take additional time to actually power on/off after the command

--- a/users/feralfile/system-config/ddcutil-sudoers
+++ b/users/feralfile/system-config/ddcutil-sudoers
@@ -1,0 +1,12 @@
+# Sudoers configuration for passwordless ddcutil access
+# This file should be installed to: /etc/sudoers.d/ddcutil
+#
+# Installation:
+#   sudo visudo -c -f /path/to/this/file  # Validate syntax first
+#   sudo cp /path/to/this/file /etc/sudoers.d/ddcutil
+#   sudo chmod 0440 /etc/sudoers.d/ddcutil
+#
+# This allows the feralfile user to run ddcutil without a password prompt
+
+# Allow feralfile user to run ddcutil without password
+feralfile ALL=(ALL) NOPASSWD: /usr/bin/ddcutil


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a device sleep mode with display power control and stateful restore, plus status/monitoring integration and supporting scripts.
> 
> - **New command**: `CMD_SLEEP_MODE` handled in `executor` to enter/exit sleep; navigates (`LauncherLogoURL`/`ControlAppURL`), powers screen via `/home/feralfile/scripts/screen-power.sh`, and captures/restores `displayPlaylist` (URL/object, index, pause state) via CDP
> - **Persistent state**: Adds `SleepModeState` to `state.State`; saved/cleared on sleep/wake
> - **Status API**: `DeviceStatusResponse` includes `sleep` flag derived from state
> - **Monitoring**: `feral-sys-monitord` skips screen metrics while asleep (lightweight state-file check)
> - **Display handling**: `display-restore.sh` ignores DRM events during sleep; `.file_permissions.sh` executes flag for new script
> - **System scripts/config**: Adds `screen-power.sh` (ddcutil + wlr-randr), udev rule and docs for ddcutil permissions, optional sudoers file
> - **Tests**: Extensive unit tests for sleep enter/exit paths and playlist restoration
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3eb15216785862d8faa1b3aaec7d747f3286346b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->