### PR TITLE
fix(reliability): avoid startup panics

### DIFF
--- a/components/feral-controld/main.go
+++ b/components/feral-controld/main.go
@@ -83,7 +83,8 @@ func main() {
 	// Initialize basic logger first for config loading
 	basicLogger, err := logger.New(debug)
 	if err != nil {
-		panic("Failed to initialize logger: " + err.Error())
+		fmt.Fprintf(go_os.Stderr, "Failed to initialize logger: %s\n", err)
+		go_os.Exit(1)
 	}
 	defer func() {
 		_ = basicLogger.Sync()

--- a/components/feral-setupd/src/dbus_utils.rs
+++ b/components/feral-setupd/src/dbus_utils.rs
@@ -2,12 +2,12 @@ use dbus::arg::Append;
 use dbus::blocking::{BlockingSender, Connection};
 use dbus::channel::Sender;
 use dbus::message::Message;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::task;
 
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 
 use crate::constant;
 
@@ -112,9 +112,15 @@ fn receive_internal<'a>(
     // Closure that will send the acknowledgement when called
     let ack = move || {
         println!("DBUS: Sending ack signal '{member}_ack' to {object_path}, {interface}");
-        let mut ack_msg = Message::new_signal(object_path, interface, format!("{member}_ack"))
-            .map_err(anyhow::Error::msg)
-            .unwrap();
+        let ack_msg = Message::new_signal(object_path, interface, format!("{member}_ack"))
+            .map_err(anyhow::Error::msg);
+        let mut ack_msg = match ack_msg {
+            Ok(ack_msg) => ack_msg,
+            Err(error) => {
+                eprintln!("DBUS: Failed to build ack signal: {error}");
+                return;
+            }
+        };
         ack_msg = ack_msg.append1("");
         if conn.send(ack_msg).is_err() {
             // Failed to send ack signal doesn't matter, just log an error
@@ -136,11 +142,19 @@ pub fn listen_for_signal(
     let interface = interface.to_string();
     let member = member.to_string();
     task::spawn_blocking(move || {
-        let conn = Connection::new_session().expect("DBUS: failed to create connection");
+        let conn = match Connection::new_session() {
+            Ok(conn) => conn,
+            Err(error) => {
+                eprintln!("DBUS: failed to create connection: {error}");
+                return;
+            }
+        };
         let rule =
             format!("type='signal',interface='{interface}',member='{member}',path='{object_path}'");
-        conn.add_match_no_cb(&rule)
-            .expect("DBUS: failed to add match");
+        if let Err(error) = conn.add_match_no_cb(&rule) {
+            eprintln!("DBUS: failed to add match: {error}");
+            return;
+        }
 
         println!("DBUS: Listening for '{member}' signal in a background thread");
         while !stop.load(Ordering::Relaxed) {

--- a/components/feral-setupd/src/dbus_utils.rs
+++ b/components/feral-setupd/src/dbus_utils.rs
@@ -5,9 +5,10 @@ use dbus::message::Message;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use tokio::sync::oneshot;
 use tokio::task;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 
 use crate::constant;
 
@@ -131,31 +132,33 @@ fn receive_internal<'a>(
     Ok((msg, ack))
 }
 
-pub fn listen_for_signal(
+pub async fn listen_for_signal(
     object_path: &str,
     interface: &str,
     member: &str,
     stop: Arc<AtomicBool>,
     cb: ListenCallback,
-) {
+) -> Result<()> {
     let object_path = object_path.to_string();
     let interface = interface.to_string();
     let member = member.to_string();
+    let (tx, rx) = oneshot::channel();
     task::spawn_blocking(move || {
         let conn = match Connection::new_session() {
             Ok(conn) => conn,
             Err(error) => {
-                eprintln!("DBUS: failed to create connection: {error}");
+                let _ = tx.send(Err(anyhow!("DBUS: failed to create connection: {error}")));
                 return;
             }
         };
         let rule =
             format!("type='signal',interface='{interface}',member='{member}',path='{object_path}'");
         if let Err(error) = conn.add_match_no_cb(&rule) {
-            eprintln!("DBUS: failed to add match: {error}");
+            let _ = tx.send(Err(anyhow!("DBUS: failed to add match: {error}")));
             return;
         }
 
+        let _ = tx.send(Ok(()));
         println!("DBUS: Listening for '{member}' signal in a background thread");
         while !stop.load(Ordering::Relaxed) {
             if let Ok((msg, ack)) = receive_internal(
@@ -170,6 +173,10 @@ pub fn listen_for_signal(
             }
         }
     });
+
+    rx.await
+        .context("DBUS: listener startup channel closed")??;
+    Ok(())
 }
 
 /// Sends a blocking D‑Bus method call and returns the reply `Message`.

--- a/components/feral-setupd/src/dbus_utils.rs
+++ b/components/feral-setupd/src/dbus_utils.rs
@@ -2,13 +2,13 @@ use dbus::arg::Append;
 use dbus::blocking::{BlockingSender, Connection};
 use dbus::channel::Sender;
 use dbus::message::Message;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 use tokio::sync::oneshot;
 use tokio::task;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 
 use crate::constant;
 

--- a/components/feral-setupd/src/main.rs
+++ b/components/feral-setupd/src/main.rs
@@ -51,10 +51,13 @@ pub enum UpdateExecution {
 
 #[inline]
 fn unix_s() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_secs() as i64
+    match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => duration.as_secs() as i64,
+        Err(error) => {
+            eprintln!("MAIN: System time is before UNIX_EPOCH: {error:?}");
+            0
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -114,17 +117,25 @@ fn main() {
         },
     ));
 
-    tokio::runtime::Builder::new_multi_thread()
+    let runtime = match tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
-        .unwrap()
-        .block_on(async {
-            if let Err(e) = run().await {
-                eprintln!("MAIN: Error running feral-setupd: {e:#?}");
-                let error: &dyn std::error::Error = e.as_ref();
-                sentry::capture_error(error);
-            }
-        });
+    {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            eprintln!("MAIN: Failed to build tokio runtime: {error:?}");
+            sentry::capture_message("failed to build tokio runtime", sentry::Level::Error);
+            return;
+        }
+    };
+
+    runtime.block_on(async {
+        if let Err(e) = run().await {
+            eprintln!("MAIN: Error running feral-setupd: {e:#?}");
+            let error: &dyn std::error::Error = e.as_ref();
+            sentry::capture_error(error);
+        }
+    });
 }
 
 async fn run() -> Result<()> {

--- a/components/feral-setupd/src/main.rs
+++ b/components/feral-setupd/src/main.rs
@@ -125,7 +125,7 @@ fn main() {
         Err(error) => {
             eprintln!("MAIN: Failed to build tokio runtime: {error:?}");
             sentry::capture_message("failed to build tokio runtime", sentry::Level::Error);
-            return;
+            std::process::exit(1);
         }
     };
 
@@ -134,6 +134,7 @@ fn main() {
             eprintln!("MAIN: Error running feral-setupd: {e:#?}");
             let error: &dyn std::error::Error = e.as_ref();
             sentry::capture_error(error);
+            std::process::exit(1);
         }
     });
 }
@@ -155,7 +156,7 @@ async fn run() -> Result<()> {
     updater::spawn_remote_version_refresher();
 
     // Setup D-Bus listeners
-    let stop_dbus_listener = setup_dbus_listeners(&app_state, &chrome);
+    let stop_dbus_listener = setup_dbus_listeners(&app_state, &chrome).await?;
 
     // If the device used to be able to connect to the internet
     // It's likely that it will have internet again really soon
@@ -339,7 +340,10 @@ async fn startup_with_internet(
     on_startup_with_internet(app_state.clone(), chrome.clone()).await
 }
 
-fn setup_dbus_listeners(app_state: &Arc<AppState>, chrome: &Arc<Cdp>) -> Arc<AtomicBool> {
+async fn setup_dbus_listeners(
+    app_state: &Arc<AppState>,
+    chrome: &Arc<Cdp>,
+) -> Result<Arc<AtomicBool>> {
     // Listen for QRCode switch signal
     let qrcode_switch_cb = callbacks::create_qrcode_switch_cb(app_state.clone(), chrome.clone());
     let stop_dbus_listener = Arc::new(AtomicBool::new(false));
@@ -349,7 +353,8 @@ fn setup_dbus_listeners(app_state: &Arc<AppState>, chrome: &Arc<Cdp>) -> Arc<Ato
         constant::DBUS_EVENT_QRCODE_SWITCH,
         stop_dbus_listener.clone(),
         qrcode_switch_cb,
-    );
+    )
+    .await?;
 
     // Listen for factory reset signal
     let factory_reset_cb =
@@ -360,7 +365,8 @@ fn setup_dbus_listeners(app_state: &Arc<AppState>, chrome: &Arc<Cdp>) -> Arc<Ato
         constant::DBUS_EVENT_FACTORY_RESET,
         stop_dbus_listener.clone(),
         factory_reset_cb,
-    );
+    )
+    .await?;
 
     // Listen for upload logs signal
     let upload_logs_cb = callbacks::create_upload_logs_dbus_cb(app_state.clone());
@@ -370,7 +376,8 @@ fn setup_dbus_listeners(app_state: &Arc<AppState>, chrome: &Arc<Cdp>) -> Arc<Ato
         constant::DBUS_EVENT_UPLOAD_LOGS,
         stop_dbus_listener.clone(),
         upload_logs_cb,
-    );
+    )
+    .await?;
 
     // Listen for system update signal
     let system_update_cb =
@@ -381,9 +388,10 @@ fn setup_dbus_listeners(app_state: &Arc<AppState>, chrome: &Arc<Cdp>) -> Arc<Ato
         constant::DBUS_EVENT_SYSTEM_UPDATE,
         stop_dbus_listener.clone(),
         system_update_cb,
-    );
+    )
+    .await?;
 
-    stop_dbus_listener
+    Ok(stop_dbus_listener)
 }
 
 async fn internet_setup_successfully_cb(

--- a/components/feral-setupd/src/wifi_utils.rs
+++ b/components/feral-setupd/src/wifi_utils.rs
@@ -123,7 +123,9 @@ impl SSIDsCacher {
                         println!("SSIDsCacher: returning last error");
                         // We take the error here
                         // The next call to `get()` will trigger a new refresh
-                        return Err(st.last_error.take().unwrap());
+                        if let Some(error) = st.last_error.take() {
+                            return Err(error);
+                        }
                     }
 
                     println!("SSIDsCacher: triggering refresh");

--- a/components/feral-sys-monitord/main.go
+++ b/components/feral-sys-monitord/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -32,7 +33,8 @@ func main() {
 	// Initialize logger with debug enabled for development
 	log, err := logger.New(debug)
 	if err != nil {
-		panic("Failed to initialize logger: " + err.Error())
+		fmt.Fprintf(os.Stderr, "Failed to initialize logger: %s\n", err)
+		os.Exit(1)
 	}
 	defer func() {
 		_ = log.Sync()

--- a/components/feral-watchdog/main.go
+++ b/components/feral-watchdog/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"os/signal"
 	"sync"
@@ -38,7 +39,8 @@ func main() {
 	// Initialize logger with debug enabled for development
 	log, err := logger.New(debug)
 	if err != nil {
-		panic("Failed to initialize logger: " + err.Error())
+		fmt.Fprintf(os.Stderr, "Failed to initialize logger: %s\n", err)
+		os.Exit(1)
 	}
 	defer func() {
 		_ = log.Sync()

--- a/users/feralfile/.start-services.sh
+++ b/users/feralfile/.start-services.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
 VOLUME_FILE="/home/feralfile/.state/saved-volume"
 if [ ! -f "$VOLUME_FILE" ]; then
     # First boot: set default volume to 63%

--- a/users/feralfile/.start-services.sh
+++ b/users/feralfile/.start-services.sh
@@ -25,7 +25,9 @@ if systemctl --user is-enabled "feral-watchdog.service" >/dev/null 2>&1; then
 fi
 
 mkdir -p /home/feralfile/.config/systemd/user/
-sudo mount /home/feralfile/systemd-services/ /home/feralfile/.config/systemd/user/ -o bind
+if ! mountpoint -q /home/feralfile/.config/systemd/user/; then
+    sudo mount /home/feralfile/systemd-services/ /home/feralfile/.config/systemd/user/ -o bind
+fi
 
 systemctl --user daemon-reload
 systemctl --user start system-ready.target


### PR DESCRIPTION
## Summary
- replace panic/unwrap paths in startup flows with logged errors and clean exits
- harden D-Bus helper to avoid crashing background listeners
- make service startup script fail fast with bash strict mode

## Testing
- not run (startup/logging changes only)