### PR TITLE
Add SSH access control for devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,3 +203,15 @@ ffos-user/develop → ffos build → R2/{develop}/
 ### No GitHub Actions Required
 
 This repository is purely for source code and data. All build logic is handled by the FFOS repository.
+
+### Sync components to a device (dev)
+
+Use the component sync helpers to push local changes to an FF1 over SSH (key-based).
+
+```bash
+# Default host + key
+make -C components sync-feral-controld
+
+# Override host or key
+REMOTE_HOST=ff1-03vdu3x1.local REMOTE_KEY=~/.ssh/id_ed25519 make -C components sync-feral-controld
+```

--- a/components/Makefile
+++ b/components/Makefile
@@ -1,6 +1,7 @@
 # Default REMOTE_HOST if not provided
 REMOTE_HOST ?= 192.168.31.91
 REMOTE_DIR ?= /home/feralfile/src/components
+REMOTE_KEY ?= ~/.ssh/id_ed25519
 SYNC_SCRIPT := ./scripts/sync-to-device.sh
 
 .PHONY: sync-feral-setupd

--- a/components/feral-controld/commands/types.go
+++ b/components/feral-controld/commands/types.go
@@ -31,6 +31,7 @@ var deviceCtlCommands = map[Type]bool{
 	CMD_UPLOAD_LOGS:          true,
 	CMD_SET_VOLUME:           true,
 	CMD_TOGGLE_MUTE:          true,
+	CMD_SSH_ACCESS:           true,
 }
 
 type Command struct {
@@ -62,6 +63,7 @@ const (
 	CMD_UPLOAD_LOGS          Type = "uploadLogs"
 	CMD_SET_VOLUME           Type = "setVolume"
 	CMD_TOGGLE_MUTE          Type = "toggleMute"
+	CMD_SSH_ACCESS           Type = "sshAccess"
 )
 
 func (c Type) DeviceCtlCommand() bool {

--- a/components/feral-controld/constant/constant.go
+++ b/components/feral-controld/constant/constant.go
@@ -7,4 +7,7 @@ const (
 	SCREEN_ORIENTATION_FILE = "/home/feralfile/.state/screen-orientation"
 	STATE_FILE              = "/home/feralfile/.state/controld.state"
 	CONFIG_FILE             = "/home/feralfile/.config/controld.json"
+
+	SSH_AUTHORIZED_KEYS_FILE = "/home/feralfile/.ssh/authorized_keys"
+	SSH_DISABLE_UNIT         = "ff1-ssh-disable"
 )

--- a/components/feral-controld/devicectl/executor.go
+++ b/components/feral-controld/devicectl/executor.go
@@ -811,6 +811,9 @@ func (e *executor) writeAuthorizedKey(publicKey string) error {
 }
 
 func (e *executor) scheduleSshDisable(ctx context.Context, ttlSeconds int) error {
+	// Kill active SSH sessions first, then stop the listener.
+	// pkill may exit non-zero if no matching processes exist, so we ignore its exit code with "|| true".
+	disableCmd := "pkill -u feralfile sshd || true; systemctl stop sshd.service"
 	return e.runSudoCommand(
 		ctx,
 		"systemd-run",
@@ -818,9 +821,9 @@ func (e *executor) scheduleSshDisable(ctx context.Context, ttlSeconds int) error
 		constants.SSH_DISABLE_UNIT,
 		"--on-active",
 		fmt.Sprintf("%ds", ttlSeconds),
-		"/usr/bin/systemctl",
-		"stop",
-		"sshd.service",
+		"/bin/bash",
+		"-c",
+		disableCmd,
 	)
 }
 

--- a/components/feral-controld/devicectl/executor.go
+++ b/components/feral-controld/devicectl/executor.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/feral-file/godbus"
 	"go.uber.org/zap"
@@ -155,6 +156,8 @@ func (e *executor) Execute(ctx context.Context, cmd commands.Command) (interface
 		result, err = e.setVolume(ctx, bytes)
 	case commands.CMD_TOGGLE_MUTE:
 		result, err = e.toggleMute(ctx)
+	case commands.CMD_SSH_ACCESS:
+		result, err = e.setSshAccess(ctx, bytes)
 	default:
 		return nil, fmt.Errorf("invalid command: %s", cmd)
 	}
@@ -712,6 +715,117 @@ func (e *executor) setBetaFeaturesToggle(_ context.Context, args []byte) (interf
 	e.logger.Info("Beta features disabled (toggle file removed)", zap.String("path", BetaFeaturesToggleOnFile))
 
 	return CmdOK, nil
+}
+
+func (e *executor) setSshAccess(ctx context.Context, args []byte) (interface{}, error) {
+	var cmdArgs struct {
+		Enabled    bool   `json:"enabled"`
+		PublicKey  string `json:"publicKey"`
+		TTLSeconds *int   `json:"ttlSeconds"`
+	}
+	if err := e.json.Unmarshal(args, &cmdArgs); err != nil {
+		return nil, fmt.Errorf("invalid arguments: %w", err)
+	}
+
+	if cmdArgs.Enabled {
+		if strings.TrimSpace(cmdArgs.PublicKey) == "" {
+			return nil, fmt.Errorf("publicKey is required to enable SSH")
+		}
+		if err := e.writeAuthorizedKey(cmdArgs.PublicKey); err != nil {
+			return nil, fmt.Errorf("failed to write authorized key: %w", err)
+		}
+		if err := e.clearSshDisableTimer(ctx); err != nil {
+			return nil, fmt.Errorf("failed to clear SSH disable timer: %w", err)
+		}
+		if err := e.runSudoCommand(ctx, "systemctl", "start", "sshd.service"); err != nil {
+			return nil, fmt.Errorf("failed to start SSH service: %w", err)
+		}
+
+		ttlSeconds := normalizeSshTtlSeconds(cmdArgs.TTLSeconds)
+		var expiresAt *time.Time
+		if ttlSeconds > 0 {
+			expiresAtValue := time.Now().Add(time.Duration(ttlSeconds) * time.Second)
+			expiresAt = &expiresAtValue
+			if err := e.scheduleSshDisable(ctx, ttlSeconds); err != nil {
+				return nil, fmt.Errorf("failed to schedule SSH disable: %w", err)
+			}
+		}
+
+		return map[string]interface{}{
+			"enabled":    true,
+			"ttlSeconds": ttlSeconds,
+			"expiresAt":  expiresAt,
+		}, nil
+	}
+
+	if err := e.clearSshDisableTimer(ctx); err != nil {
+		return nil, fmt.Errorf("failed to clear SSH disable timer: %w", err)
+	}
+	if err := e.runSudoCommand(ctx, "systemctl", "stop", "sshd.service"); err != nil {
+		return nil, fmt.Errorf("failed to stop SSH service: %w", err)
+	}
+	if err := e.removeFileIfExists(constants.SSH_AUTHORIZED_KEYS_FILE); err != nil {
+		return nil, fmt.Errorf("failed to remove authorized keys: %w", err)
+	}
+
+	return map[string]interface{}{
+		"enabled": false,
+	}, nil
+}
+
+func normalizeSshTtlSeconds(ttlSeconds *int) int {
+	if ttlSeconds == nil {
+		return 0
+	}
+	if *ttlSeconds <= 0 {
+		return 0
+	}
+	if *ttlSeconds > 86400 {
+		return 86400
+	}
+	return *ttlSeconds
+}
+
+func (e *executor) writeAuthorizedKey(publicKey string) error {
+	sshDir := filepath.Dir(constants.SSH_AUTHORIZED_KEYS_FILE)
+	if err := e.os.MkdirAll(sshDir, 0700); err != nil {
+		return err
+	}
+	key := strings.TrimSpace(publicKey)
+	if !strings.HasSuffix(key, "\n") {
+		key += "\n"
+	}
+	return e.os.WriteFile(constants.SSH_AUTHORIZED_KEYS_FILE, []byte(key), 0600)
+}
+
+func (e *executor) scheduleSshDisable(ctx context.Context, ttlSeconds int) error {
+	return e.runSudoCommand(
+		ctx,
+		"systemd-run",
+		"--unit",
+		constants.SSH_DISABLE_UNIT,
+		"--on-active",
+		fmt.Sprintf("%ds", ttlSeconds),
+		"/usr/bin/systemctl",
+		"stop",
+		"sshd.service",
+	)
+}
+
+func (e *executor) clearSshDisableTimer(ctx context.Context) error {
+	_ = e.runSudoCommand(ctx, "systemctl", "stop", constants.SSH_DISABLE_UNIT+".timer")
+	_ = e.runSudoCommand(ctx, "systemctl", "stop", constants.SSH_DISABLE_UNIT+".service")
+	_ = e.runSudoCommand(ctx, "systemctl", "reset-failed", constants.SSH_DISABLE_UNIT+".service")
+	return nil
+}
+
+func (e *executor) runSudoCommand(ctx context.Context, command string, args ...string) error {
+	cmd := e.exec.CommandContext(ctx, "sudo", append([]string{command}, args...)...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return nil
 }
 
 func (e *executor) removeFileIfExists(path string) error {

--- a/components/feral-controld/devicectl/executor.go
+++ b/components/feral-controld/devicectl/executor.go
@@ -747,6 +747,18 @@ func (e *executor) setSshAccess(ctx context.Context, args []byte) (interface{}, 
 			expiresAtValue := time.Now().Add(time.Duration(ttlSeconds) * time.Second)
 			expiresAt = &expiresAtValue
 			if err := e.scheduleSshDisable(ctx, ttlSeconds); err != nil {
+				e.logger.Error("Failed to schedule SSH disable timer, rolling back SSH access",
+					zap.Error(err),
+					zap.Int("ttlSeconds", ttlSeconds))
+
+				if stopErr := e.runSudoCommand(ctx, "systemctl", "stop", "sshd.service"); stopErr != nil {
+					e.logger.Error("Rollback failed: could not stop sshd service", zap.Error(stopErr))
+				}
+
+				if removeErr := e.removeFileIfExists(constants.SSH_AUTHORIZED_KEYS_FILE); removeErr != nil {
+					e.logger.Error("Rollback failed: could not remove authorized_keys", zap.Error(removeErr))
+				}
+
 				return nil, fmt.Errorf("failed to schedule SSH disable: %w", err)
 			}
 		}

--- a/components/feral-controld/devicectl/executor.go
+++ b/components/feral-controld/devicectl/executor.go
@@ -738,6 +738,10 @@ func (e *executor) setSshAccess(ctx context.Context, args []byte) (interface{}, 
 			return nil, fmt.Errorf("failed to clear SSH disable timer: %w", err)
 		}
 		if err := e.runSudoCommand(ctx, "systemctl", "start", "sshd.service"); err != nil {
+			e.logger.Error("Failed to start SSH service, rolling back SSH access", zap.Error(err))
+			if removeErr := e.removeFileIfExists(constants.SSH_AUTHORIZED_KEYS_FILE); removeErr != nil {
+				e.logger.Error("Rollback failed: could not remove authorized_keys", zap.Error(removeErr))
+			}
 			return nil, fmt.Errorf("failed to start SSH service: %w", err)
 		}
 

--- a/components/feral-controld/devicectl/executor_test.go
+++ b/components/feral-controld/devicectl/executor_test.go
@@ -2424,6 +2424,206 @@ func TestExecutor_BetaFeaturesToggle_Disable_Success(t *testing.T) {
 	assert.Equal(t, devicectl.CmdOK, result)
 }
 
+func TestExecutor_SshAccess_Enable_RequiresPublicKey(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	cmd := commands.Command{
+		Type: commands.CMD_SSH_ACCESS,
+		Arguments: map[string]interface{}{
+			"enabled":   true,
+			"publicKey": " ",
+		},
+	}
+
+	ts.mockJSON.EXPECT().
+		Marshal(cmd.Arguments).
+		Return([]byte(`{"enabled":true,"publicKey":" "}`), nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(`{"enabled":true,"publicKey":" "}`), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			args := v.(*struct {
+				Enabled    bool   `json:"enabled"`
+				PublicKey  string `json:"publicKey"`
+				TTLSeconds *int   `json:"ttlSeconds"`
+			})
+			args.Enabled = true
+			args.PublicKey = " "
+			return nil
+		})
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "publicKey is required")
+}
+
+func TestExecutor_SshAccess_Enable_CapsTtlAndSchedulesDisable(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	cmd := commands.Command{
+		Type: commands.CMD_SSH_ACCESS,
+		Arguments: map[string]interface{}{
+			"enabled":    true,
+			"publicKey":  "ssh-ed25519 AAAA-test",
+			"ttlSeconds": 90000,
+		},
+	}
+
+	ts.mockJSON.EXPECT().
+		Marshal(cmd.Arguments).
+		Return([]byte(`{"enabled":true,"publicKey":"ssh-ed25519 AAAA-test","ttlSeconds":90000}`), nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal(
+			[]byte(`{"enabled":true,"publicKey":"ssh-ed25519 AAAA-test","ttlSeconds":90000}`),
+			gomock.Any(),
+		).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			args := v.(*struct {
+				Enabled    bool   `json:"enabled"`
+				PublicKey  string `json:"publicKey"`
+				TTLSeconds *int   `json:"ttlSeconds"`
+			})
+			ttl := 90000
+			args.Enabled = true
+			args.PublicKey = "ssh-ed25519 AAAA-test"
+			args.TTLSeconds = &ttl
+			return nil
+		})
+
+	sshDir := filepath.Dir(constants.SSH_AUTHORIZED_KEYS_FILE)
+	ts.mockOS.EXPECT().
+		MkdirAll(sshDir, os.FileMode(0700)).
+		Return(nil)
+	ts.mockOS.EXPECT().
+		WriteFile(constants.SSH_AUTHORIZED_KEYS_FILE, gomock.Any(), os.FileMode(0600)).
+		DoAndReturn(func(_ string, data []byte, _ os.FileMode) error {
+			assert.Contains(t, string(data), "ssh-ed25519 AAAA-test")
+			return nil
+		})
+
+	gomock.InOrder(
+		ts.mockExec.EXPECT().
+			CommandContext(ts.ctx, "sudo", "systemctl", "stop", constants.SSH_DISABLE_UNIT+".timer").
+			Return(ts.mockExecCmd),
+		ts.mockExecCmd.EXPECT().
+			CombinedOutput().
+			Return([]byte(""), nil),
+		ts.mockExec.EXPECT().
+			CommandContext(ts.ctx, "sudo", "systemctl", "stop", constants.SSH_DISABLE_UNIT+".service").
+			Return(ts.mockExecCmd),
+		ts.mockExecCmd.EXPECT().
+			CombinedOutput().
+			Return([]byte(""), nil),
+		ts.mockExec.EXPECT().
+			CommandContext(ts.ctx, "sudo", "systemctl", "reset-failed", constants.SSH_DISABLE_UNIT+".service").
+			Return(ts.mockExecCmd),
+		ts.mockExecCmd.EXPECT().
+			CombinedOutput().
+			Return([]byte(""), nil),
+		ts.mockExec.EXPECT().
+			CommandContext(ts.ctx, "sudo", "systemctl", "start", "sshd.service").
+			Return(ts.mockExecCmd),
+		ts.mockExecCmd.EXPECT().
+			CombinedOutput().
+			Return([]byte(""), nil),
+		ts.mockExec.EXPECT().
+			CommandContext(
+				ts.ctx,
+				"sudo",
+				"systemd-run",
+				"--unit",
+				constants.SSH_DISABLE_UNIT,
+				"--on-active",
+				"86400s",
+				"/usr/bin/systemctl",
+				"stop",
+				"sshd.service",
+			).
+			Return(ts.mockExecCmd),
+		ts.mockExecCmd.EXPECT().
+			CombinedOutput().
+			Return([]byte(""), nil),
+	)
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.NoError(t, err)
+
+	response, ok := result.(map[string]interface{})
+	if assert.True(t, ok) {
+		assert.Equal(t, true, response["enabled"])
+		assert.Equal(t, 86400, response["ttlSeconds"])
+	}
+}
+
+func TestExecutor_SshAccess_Disable_StopsService(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	cmd := commands.Command{
+		Type: commands.CMD_SSH_ACCESS,
+		Arguments: map[string]interface{}{
+			"enabled": false,
+		},
+	}
+
+	ts.mockJSON.EXPECT().
+		Marshal(cmd.Arguments).
+		Return([]byte(`{"enabled":false}`), nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(`{"enabled":false}`), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			args := v.(*struct {
+				Enabled    bool   `json:"enabled"`
+				PublicKey  string `json:"publicKey"`
+				TTLSeconds *int   `json:"ttlSeconds"`
+			})
+			args.Enabled = false
+			return nil
+		})
+
+	ts.mockOS.EXPECT().
+		IsNotExist(gomock.Any()).
+		Return(true).
+		AnyTimes()
+
+	gomock.InOrder(
+		ts.mockExec.EXPECT().
+			CommandContext(ts.ctx, "sudo", "systemctl", "stop", constants.SSH_DISABLE_UNIT+".timer").
+			Return(ts.mockExecCmd),
+		ts.mockExecCmd.EXPECT().
+			CombinedOutput().
+			Return([]byte(""), nil),
+		ts.mockExec.EXPECT().
+			CommandContext(ts.ctx, "sudo", "systemctl", "stop", constants.SSH_DISABLE_UNIT+".service").
+			Return(ts.mockExecCmd),
+		ts.mockExecCmd.EXPECT().
+			CombinedOutput().
+			Return([]byte(""), nil),
+		ts.mockExec.EXPECT().
+			CommandContext(ts.ctx, "sudo", "systemctl", "reset-failed", constants.SSH_DISABLE_UNIT+".service").
+			Return(ts.mockExecCmd),
+		ts.mockExecCmd.EXPECT().
+			CombinedOutput().
+			Return([]byte(""), nil),
+		ts.mockExec.EXPECT().
+			CommandContext(ts.ctx, "sudo", "systemctl", "stop", "sshd.service").
+			Return(ts.mockExecCmd),
+		ts.mockExecCmd.EXPECT().
+			CombinedOutput().
+			Return([]byte(""), nil),
+	)
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.NoError(t, err)
+
+	response, ok := result.(map[string]interface{})
+	if assert.True(t, ok) {
+		assert.Equal(t, false, response["enabled"])
+	}
+}
+
 func TestExecutor_Shutdown_Success(t *testing.T) {
 	ts := setup(t)
 	defer ts.teardown()

--- a/components/feral-controld/devicectl/executor_test.go
+++ b/components/feral-controld/devicectl/executor_test.go
@@ -2537,9 +2537,9 @@ func TestExecutor_SshAccess_Enable_CapsTtlAndSchedulesDisable(t *testing.T) {
 				constants.SSH_DISABLE_UNIT,
 				"--on-active",
 				"86400s",
-				"/usr/bin/systemctl",
-				"stop",
-				"sshd.service",
+				"/bin/bash",
+				"-c",
+				"pkill -u feralfile sshd || true; systemctl stop sshd.service",
 			).
 			Return(ts.mockExecCmd),
 		ts.mockExecCmd.EXPECT().


### PR DESCRIPTION
## Summary
- Add `sshAccess` device control command to manage authorized keys, start/stop sshd, and schedule TTL auto-disable
- Add unit tests covering missing keys, TTL capping, and disable flow
- Switch dev sync script + docs to key-based SSH

## Testing
- `go test ./...`