### PR TITLE
Add FF1 version probe endpoints for compatibility checks

### DIFF
--- a/components/feral-controld/hub/hub.go
+++ b/components/feral-controld/hub/hub.go
@@ -2,14 +2,17 @@ package hub
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
+	"os"
 	"time"
 
 	"go.uber.org/zap"
 
 	"github.com/feral-file/ffos-user/components/feral-controld/commandrouter"
 	"github.com/feral-file/ffos-user/components/feral-controld/commands"
+	"github.com/feral-file/ffos-user/components/feral-controld/constant"
 	"github.com/feral-file/ffos-user/components/feral-controld/helper"
 	"github.com/feral-file/ffos-user/components/feral-controld/logger"
 	"github.com/feral-file/ffos-user/components/feral-controld/wrapper"
@@ -37,6 +40,7 @@ type hub struct {
 	wsHandler  ws.WS
 	cmdHandler commandrouter.Handler
 	json       wrapper.JSON
+	readConfig func() ([]byte, error)
 }
 
 func New(
@@ -65,6 +69,7 @@ func New(
 		json:       json,
 		server:     server,
 		logger:     logger,
+		readConfig: defaultReadFF1Config,
 	}
 	h.routes()
 	return h
@@ -78,7 +83,14 @@ func (h *hub) routes() {
 	}
 
 	mux.HandleFunc("/api/cast", h.handleCast)
+	mux.HandleFunc("/api/version", h.handleVersion)
+	mux.HandleFunc("/api/info", h.handleInfo)
+	mux.HandleFunc("/api/status", h.handleStatus)
 	mux.HandleFunc("/api/notification", h.handleNotification)
+}
+
+func defaultReadFF1Config() ([]byte, error) {
+	return os.ReadFile(constant.FF1_CONFIG_FILE)
 }
 
 // Start starts the HTTP server
@@ -144,6 +156,98 @@ func (h *hub) handleCast(w http.ResponseWriter, r *http.Request) {
 		h.logger.Warn("Failed to respond with JSON", zap.Error(err))
 		return
 	}
+}
+
+// handleVersion handles GET /api/version endpoint
+func (h *hub) handleVersion(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	payload, err := h.readFF1VersionPayload()
+	if err != nil {
+		h.logger.Error("Failed to read FF1 version", zap.Error(err))
+		http.Error(w, "Failed to read FF1 config", http.StatusInternalServerError)
+		return
+	}
+
+	err = h.respondJSON(w, http.StatusOK, map[string]any{"version": payload})
+	if err != nil {
+		h.logger.Warn("Failed to respond with JSON", zap.Error(err))
+		return
+	}
+}
+
+// handleInfo handles GET /api/info endpoint
+func (h *hub) handleInfo(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	payload, err := h.readFF1VersionPayload()
+	if err != nil {
+		h.logger.Error("Failed to read FF1 version", zap.Error(err))
+		http.Error(w, "Failed to read FF1 config", http.StatusInternalServerError)
+		return
+	}
+
+	response := map[string]any{
+		"ff1Version": payload,
+		"version":    payload,
+	}
+
+	err = h.respondJSON(w, http.StatusOK, response)
+	if err != nil {
+		h.logger.Warn("Failed to respond with JSON", zap.Error(err))
+		return
+	}
+}
+
+// handleStatus handles GET /api/status endpoint
+func (h *hub) handleStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	payload, err := h.readFF1VersionPayload()
+	if err != nil {
+		h.logger.Error("Failed to read FF1 version", zap.Error(err))
+		http.Error(w, "Failed to read FF1 config", http.StatusInternalServerError)
+		return
+	}
+
+	response := map[string]any{
+		"device":           map[string]string{"version": payload},
+		"installedVersion": payload,
+		"ff1Version":       payload,
+		"osVersion":        payload,
+	}
+
+	err = h.respondJSON(w, http.StatusOK, response)
+	if err != nil {
+		h.logger.Warn("Failed to respond with JSON", zap.Error(err))
+		return
+	}
+}
+
+func (h *hub) readFF1VersionPayload() (string, error) {
+	configJSON, err := h.readConfig()
+	if err != nil {
+		return "", err
+	}
+
+	var payload struct {
+		Version string `json:"version"`
+	}
+
+	if err := json.Unmarshal(configJSON, &payload); err != nil {
+		return "", err
+	}
+
+	return payload.Version, nil
 }
 
 // handleNotification handles GET /api/notification endpoint and upgrades to WebSocket

--- a/components/feral-controld/hub/hub_test.go
+++ b/components/feral-controld/hub/hub_test.go
@@ -70,6 +70,20 @@ func (ts *testSetup) teardown() {
 	ts.ctrl.Finish()
 }
 
+func withFF1ConfigReadError(ts *testSetup, readErr error) {
+	hubImpl := ts.hub.(*hub)
+	hubImpl.readConfig = func() ([]byte, error) {
+		return nil, readErr
+	}
+}
+
+func withFF1Config(ts *testSetup, rawJSON string) {
+	hubImpl := ts.hub.(*hub)
+	hubImpl.readConfig = func() ([]byte, error) {
+		return []byte(rawJSON), nil
+	}
+}
+
 func TestNew(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -565,6 +579,98 @@ func TestHandleCast_ProcessNilResult(t *testing.T) {
 
 	// Verify the response - should return 204 No Content
 	assert.Equal(t, http.StatusNoContent, w.Code)
+}
+
+func TestHandleVersion_Success(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	withFF1Config(ts, `{"version":"1.2.3"}`)
+
+	hubImpl := ts.hub.(*hub)
+	hubImpl.json = wrapper.NewJSON()
+
+	req, err := http.NewRequest("GET", "/api/version", nil)
+	assert.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	hubImpl.handleVersion(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	assert.Contains(t, w.Body.String(), `"version":"1.2.3"`)
+}
+
+func TestHandleVersion_InvalidMethod(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	req, err := http.NewRequest("POST", "/api/version", strings.NewReader("{}"))
+	assert.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	hubImpl := ts.hub.(*hub)
+	hubImpl.handleVersion(w, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+func TestHandleVersion_ConfigReadFailure(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	withFF1ConfigReadError(ts, errors.New("config read failed"))
+
+	hubImpl := ts.hub.(*hub)
+	hubImpl.json = wrapper.NewJSON()
+
+	req, err := http.NewRequest("GET", "/api/version", nil)
+	assert.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	hubImpl.handleVersion(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestHandleInfo_Success(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	withFF1Config(ts, `{"version":"2.0.0"}`)
+
+	hubImpl := ts.hub.(*hub)
+	hubImpl.json = wrapper.NewJSON()
+
+	req, err := http.NewRequest("GET", "/api/info", nil)
+	assert.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	hubImpl.handleInfo(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	assert.Contains(t, w.Body.String(), `"ff1Version":"2.0.0"`)
+}
+
+func TestHandleStatus_Success(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	withFF1Config(ts, `{"version":"3.0.0"}`)
+
+	hubImpl := ts.hub.(*hub)
+	hubImpl.json = wrapper.NewJSON()
+
+	req, err := http.NewRequest("GET", "/api/status", nil)
+	assert.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	hubImpl.handleStatus(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	assert.Contains(t, w.Body.String(), `"installedVersion":"3.0.0"`)
 }
 
 func TestHandleNotification_Success(t *testing.T) {


### PR DESCRIPTION
## Summary
- Added read-only FF1 version metadata endpoints to `feral-controld` hub so clients can detect OS version reliably:
  - `GET /api/version`
  - `GET /api/info`
  - `GET /api/status`
- Version payload is sourced from `FF1_CONFIG_FILE` (`/home/feralfile/ff1-config.json`) and returned in shapes consumed by client-side probing.
- Added targeted hub tests for endpoint success, method validation, and config-read failure paths in `components/feral-controld/hub/hub_test.go`.

## Testing
- `go test ./...` in `components/feral-controld`

## Context
- This change supports the FF1 CLI compatibility preflight work in `feral-file/ff1-cli` by making version probing deterministic across supported devices.
