### PR TITLE
Add local player override for FF1 testing

### DIFF
--- a/components/feral-connectd/cmd/castshim/main.go
+++ b/components/feral-connectd/cmd/castshim/main.go
@@ -1,0 +1,305 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+type castEnvelope struct {
+	Command string          `json:"command"`
+	Request json.RawMessage `json:"request"`
+}
+
+type displayPlaylistRequest struct {
+	DP1Call     json.RawMessage `json:"dp1_call,omitempty"`
+	Playlist    json.RawMessage `json:"playlist,omitempty"`
+	PlaylistURL string          `json:"playlistUrl,omitempty"`
+	Intent      json.RawMessage `json:"intent,omitempty"`
+}
+
+type cdpClient struct {
+	endpoint string
+	nextID   int64
+}
+
+func newCDPClient(endpoint string) *cdpClient {
+	return &cdpClient{endpoint: strings.TrimRight(endpoint, "/")}
+}
+
+func (c *cdpClient) evaluate(ctx context.Context, expression string) (map[string]any, error) {
+	wsURL, err := c.pageWebSocketURL(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, _, err := websocket.DefaultDialer.DialContext(ctx, wsURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cdp dial: %w", err)
+	}
+	defer conn.Close()
+
+	id := atomic.AddInt64(&c.nextID, 1)
+	msg := map[string]any{
+		"id":     id,
+		"method": "Runtime.evaluate",
+		"params": map[string]any{
+			"expression": expression,
+		},
+	}
+	if err := conn.WriteJSON(msg); err != nil {
+		return nil, fmt.Errorf("cdp write: %w", err)
+	}
+
+	for {
+		var resp struct {
+			ID     int64 `json:"id"`
+			Result struct {
+				Result struct {
+					Type    string `json:"type"`
+					Subtype string `json:"subtype,omitempty"`
+					Value   any    `json:"value"`
+				} `json:"result"`
+			} `json:"result"`
+		}
+		if err := conn.ReadJSON(&resp); err != nil {
+			return nil, fmt.Errorf("cdp read: %w", err)
+		}
+		if resp.ID != id {
+			continue
+		}
+		switch resp.Result.Result.Type {
+		case "":
+			return nil, nil
+		case "string":
+			var out map[string]any
+			if err := json.Unmarshal([]byte(resp.Result.Result.Value.(string)), &out); err != nil {
+				return nil, fmt.Errorf("cdp decode: %w", err)
+			}
+			return out, nil
+		case "object":
+			if m, ok := resp.Result.Result.Value.(map[string]any); ok {
+				return m, nil
+			}
+			raw, err := json.Marshal(resp.Result.Result.Value)
+			if err != nil {
+				return nil, fmt.Errorf("cdp marshal object: %w", err)
+			}
+			var out map[string]any
+			if err := json.Unmarshal(raw, &out); err != nil {
+				return nil, fmt.Errorf("cdp decode object: %w", err)
+			}
+			return out, nil
+		default:
+			return nil, fmt.Errorf("unexpected cdp result type: %s", resp.Result.Result.Type)
+		}
+	}
+}
+
+func (c *cdpClient) pageWebSocketURL(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.endpoint+"/json", nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetch targets: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read targets: %w", err)
+	}
+	var targets []struct {
+		Type                 string `json:"type"`
+		WebSocketDebuggerURL string `json:"webSocketDebuggerUrl"`
+	}
+	if err := json.Unmarshal(body, &targets); err != nil {
+		return "", fmt.Errorf("decode targets: %w", err)
+	}
+	for _, t := range targets {
+		if t.Type == "page" && t.WebSocketDebuggerURL != "" {
+			return t.WebSocketDebuggerURL, nil
+		}
+	}
+	return "", fmt.Errorf("no page websocket target found")
+}
+
+func main() {
+	addr := envOr("CAST_SHIM_ADDR", ":1111")
+	cdpEndpoint := envOr("CAST_SHIM_CDP_ENDPOINT", "http://127.0.0.1:9222")
+
+	mux := http.NewServeMux()
+	client := newCDPClient(cdpEndpoint)
+
+	mux.HandleFunc("/api/cast", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var env castEnvelope
+		if err := json.NewDecoder(r.Body).Decode(&env); err != nil {
+			http.Error(w, "Invalid JSON payload", http.StatusBadRequest)
+			return
+		}
+
+		switch env.Command {
+		case "getDeviceStatus":
+			writeJSON(w, http.StatusOK, getDeviceStatus())
+		case "displayPlaylist":
+			result, err := handleDisplayPlaylist(r.Context(), client, env.Request)
+			if err != nil {
+				log.Printf("displayPlaylist failed: %v", err)
+				http.Error(w, "Failed to process cast request", http.StatusInternalServerError)
+				return
+			}
+			if result == nil {
+				result = map[string]any{"message": map[string]any{"ok": true}}
+			}
+			writeJSON(w, http.StatusOK, result)
+		default:
+			http.Error(w, "Unsupported command", http.StatusNotImplemented)
+		}
+	})
+
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	log.Printf("cast shim listening on %s (cdp=%s)", addr, cdpEndpoint)
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatal(err)
+	}
+}
+
+func handleDisplayPlaylist(ctx context.Context, client *cdpClient, rawRequest json.RawMessage) (map[string]any, error) {
+	var req displayPlaylistRequest
+	if err := json.Unmarshal(rawRequest, &req); err != nil {
+		return nil, fmt.Errorf("decode request: %w", err)
+	}
+
+	payloadRequest := map[string]any{}
+	if len(bytes.TrimSpace(req.DP1Call)) > 0 && string(bytes.TrimSpace(req.DP1Call)) != "null" {
+		var raw any
+		if err := json.Unmarshal(req.DP1Call, &raw); err != nil {
+			return nil, fmt.Errorf("decode dp1_call: %w", err)
+		}
+		payloadRequest["dp1_call"] = raw
+	}
+	if _, exists := payloadRequest["dp1_call"]; !exists && len(bytes.TrimSpace(req.Playlist)) > 0 && string(bytes.TrimSpace(req.Playlist)) != "null" {
+		var raw any
+		if err := json.Unmarshal(req.Playlist, &raw); err != nil {
+			return nil, fmt.Errorf("decode playlist: %w", err)
+		}
+		payloadRequest["dp1_call"] = raw
+	}
+	if req.PlaylistURL != "" {
+		payloadRequest["playlistUrl"] = req.PlaylistURL
+	}
+	if len(bytes.TrimSpace(req.Intent)) > 0 && string(bytes.TrimSpace(req.Intent)) != "null" {
+		var intent any
+		if err := json.Unmarshal(req.Intent, &intent); err != nil {
+			return nil, fmt.Errorf("decode intent: %w", err)
+		}
+		payloadRequest["intent"] = intent
+	} else {
+		payloadRequest["intent"] = map[string]any{"action": "now_display"}
+	}
+
+	payload := map[string]any{
+		"messageID": fmt.Sprintf("cast-shim-%d", time.Now().UnixNano()),
+		"message": map[string]any{
+			"command": "displayPlaylist",
+			"request": payloadRequest,
+		},
+	}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal payload: %w", err)
+	}
+
+	return client.evaluate(ctx, fmt.Sprintf("window.handleCDPRequest(%s)", payloadJSON))
+}
+
+func getDeviceStatus() map[string]any {
+	return map[string]any{
+		"screenRotation":   currentRotation(),
+		"connectedWifi":    currentWifi(),
+		"installedVersion": currentVersion(),
+		"latestVersion":    currentVersion(),
+	}
+}
+
+func currentRotation() string {
+	data, err := os.ReadFile("/home/feralfile/.config/screen-orientation")
+	if err != nil {
+		return "landscape"
+	}
+	value := strings.TrimSpace(string(data))
+	switch value {
+	case "portrait", "landscape", "normal", "90", "180", "270":
+		if value == "normal" || value == "180" {
+			return "landscape"
+		}
+		if value == "90" || value == "270" {
+			return "portrait"
+		}
+		return value
+	default:
+		return "landscape"
+	}
+}
+
+func currentWifi() string {
+	out, err := exec.Command("iwgetid", "-r").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func currentVersion() string {
+	cmds := [][]string{
+		{"pacman", "-Q", "feral-controld"},
+		{"pacman", "-Q", "feral-setupd"},
+	}
+	for _, args := range cmds {
+		out, err := exec.Command(args[0], args[1:]...).Output()
+		if err != nil {
+			continue
+		}
+		parts := strings.Fields(strings.TrimSpace(string(out)))
+		if len(parts) >= 2 {
+			return parts[1]
+		}
+	}
+	return "1.0.10"
+}
+
+func envOr(key, fallback string) string {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/components/feral-setupd/src/constant.rs
+++ b/components/feral-setupd/src/constant.rs
@@ -41,6 +41,7 @@ pub const BLE_ERR_CODE_UNKNOWN_ERROR: u8 = 255;
 pub const CDP_URL: &str = "http://127.0.0.1:9222/json";
 pub const CDP_ID_START: u64 = 1_000_000;
 pub const WEBAPP_URL: &str = "https://display.feralfile.com";
+pub const WEBAPP_URL_OVERRIDE_PATH: &str = "/home/feralfile/.config/webapp-url";
 pub const QRCODE_URL_PREFIX: &str = "file:///opt/feral/ui/launcher/index.html?step=qr&device_id=";
 pub const MSG_URL_PREFIX: &str = "file:///opt/feral/ui/launcher/index.html?step=message&message=";
 pub const WELCOME_MSG: &str = "Welcome to the Portal (FF-X1)";

--- a/components/feral-setupd/src/main.rs
+++ b/components/feral-setupd/src/main.rs
@@ -17,6 +17,7 @@ use ble::Ble;
 use cache::Cache;
 use cdp::Cdp;
 use connectivity::Connectivity;
+use std::fs;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
@@ -426,22 +427,29 @@ async fn on_startup_with_internet(app_state: Arc<AppState>, chrome: Arc<Cdp>) {
     // We should not proceed with the normal flow any more
     // The device needs to automatically restart to apply the update
     // So we just return
-    match updater::is_update_required().await {
-        Ok(true) => {
-            let _ = update(app_state.clone(), chrome.clone()).await;
-            return;
+    if has_webapp_override() {
+        println!(
+            "MAIN: Webapp override detected at {}, skipping updater gate",
+            constant::WEBAPP_URL_OVERRIDE_PATH
+        );
+    } else {
+        match updater::is_update_required().await {
+            Ok(true) => {
+                let _ = update(app_state.clone(), chrome.clone()).await;
+                return;
+            }
+            Err(e) => {
+                eprintln!("MAIN: Error checking for update: {e}");
+                let _ = show_message(
+                    &chrome,
+                    &app_state,
+                    constant::UPDATER_FAILED_TO_CHECK_VERSION_MSG,
+                )
+                .await;
+                return;
+            }
+            Ok(false) => {}
         }
-        Err(e) => {
-            eprintln!("MAIN: Error checking for update: {e}");
-            let _ = show_message(
-                &chrome,
-                &app_state,
-                constant::UPDATER_FAILED_TO_CHECK_VERSION_MSG,
-            )
-            .await;
-            return;
-        }
-        Ok(false) => {}
     }
 
     // Otherwise, proceed with the normal flow
@@ -489,13 +497,31 @@ async fn show_webapp(app_state: &Arc<AppState>, chrome: &Arc<Cdp>) -> Result<()>
     // This is to avoid Err Network Changed from Chrome
     time::sleep(Duration::from_millis(constant::WIFI_WEBAPP_DELAY)).await;
 
+    let webapp_url = resolve_webapp_url();
+
     chrome
-        .navigate(constant::WEBAPP_URL)
+        .navigate(&webapp_url)
         .await
-        .with_context(|| format!("navigating to {}", constant::WEBAPP_URL))?;
-    println!("MAIN: Navigated to {}", constant::WEBAPP_URL);
+        .with_context(|| format!("navigating to {}", webapp_url))?;
+    println!("MAIN: Navigated to {}", webapp_url);
     *page = Page::WebApp(unix_s());
     Ok(())
+}
+
+fn resolve_webapp_url() -> String {
+    if let Ok(value) = fs::read_to_string(constant::WEBAPP_URL_OVERRIDE_PATH) {
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+    constant::WEBAPP_URL.to_string()
+}
+
+fn has_webapp_override() -> bool {
+    fs::read_to_string(constant::WEBAPP_URL_OVERRIDE_PATH)
+        .map(|value| !value.trim().is_empty())
+        .unwrap_or(false)
 }
 
 async fn show_message(chrome: &Arc<Cdp>, app_state: &Arc<AppState>, message: &str) -> Result<()> {

--- a/users/feralfile/.config/systemd/user/ff-player-local.service
+++ b/users/feralfile/.config/systemd/user/ff-player-local.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Local FF Player Static Server
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/home/feralfile/scripts/serve-local-player.sh
+WorkingDirectory=/home/feralfile
+StandardOutput=append:/home/feralfile/.logs/ff-player-local.log
+StandardError=append:/home/feralfile/.logs/ff-player-local.log
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=default.target

--- a/users/feralfile/scripts/disable-local-player.sh
+++ b/users/feralfile/scripts/disable-local-player.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+OVERRIDE_PATH="/home/feralfile/.config/webapp-url"
+
+rm -f "$OVERRIDE_PATH"
+systemctl --user stop ff-player-local.service || true
+systemctl --user disable ff-player-local.service || true
+systemctl --user restart feral-setupd.service
+
+echo "disabled local ff-player override"

--- a/users/feralfile/scripts/install-local-player.sh
+++ b/users/feralfile/scripts/install-local-player.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+
+SOURCE_PATH="${1:-}"
+PLAYER_ROOT="/home/feralfile/.local/share/ff-player/current"
+PLAYER_URL="${PLAYER_URL:-http://127.0.0.1:8314}"
+OVERRIDE_PATH="/home/feralfile/.config/webapp-url"
+
+if [[ -z "$SOURCE_PATH" ]]; then
+  echo "usage: $0 <ff-player-export-dir-or-tgz>" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$PLAYER_ROOT")"
+rm -rf "$PLAYER_ROOT"
+mkdir -p "$PLAYER_ROOT"
+
+if [[ -d "$SOURCE_PATH" ]]; then
+  cp -R "$SOURCE_PATH"/. "$PLAYER_ROOT"/
+elif [[ -f "$SOURCE_PATH" ]]; then
+  tar -xzf "$SOURCE_PATH" -C "$PLAYER_ROOT"
+else
+  echo "source path not found: $SOURCE_PATH" >&2
+  exit 1
+fi
+
+printf '%s\n' "$PLAYER_URL" > "$OVERRIDE_PATH"
+
+systemctl --user daemon-reload
+systemctl --user enable --now ff-player-local.service
+systemctl --user restart ff-player-local.service
+systemctl --user restart feral-setupd.service
+
+echo "installed local ff-player bundle to $PLAYER_ROOT"
+echo "webapp override set to $PLAYER_URL"

--- a/users/feralfile/scripts/serve-local-player.sh
+++ b/users/feralfile/scripts/serve-local-player.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+PLAYER_ROOT="${PLAYER_ROOT:-/home/feralfile/.local/share/ff-player/current}"
+PLAYER_HOST="${PLAYER_HOST:-127.0.0.1}"
+PLAYER_PORT="${PLAYER_PORT:-8314}"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required to serve the local ff-player bundle" >&2
+  exit 1
+fi
+
+if [[ ! -d "$PLAYER_ROOT" ]]; then
+  echo "local ff-player bundle not found at $PLAYER_ROOT" >&2
+  exit 1
+fi
+
+exec python3 -m http.server "$PLAYER_PORT" \
+  --bind "$PLAYER_HOST" \
+  --directory "$PLAYER_ROOT"


### PR DESCRIPTION
## Summary
Adds a narrow local-player override path on FF1 for intermission-note hardware testing.

## What changed
- let `feral-setupd` honor a local webapp-url override before falling back to the hosted player URL
- add local-player install/serve/disable scripts and a user service
- add a cast shim for local FF1 testing

## Why
This makes it possible to test the updated `ff-player` bundle directly on one FF1 without waiting for the broader device-local player architecture work.

## Validation
- `cargo check` for `feral-setupd` using a temp target dir
- `go test ./...` in `components/feral-connectd`