### PR TITLE
Fix controld keyboard CDP payloads

### DIFF
--- a/components/feral-controld/devicectl/executor.go
+++ b/components/feral-controld/devicectl/executor.go
@@ -370,6 +370,8 @@ func (e *executor) handleKeyboardEvent(args []byte) (interface{}, error) {
 		return nil, fmt.Errorf("invalid arguments: %w", err)
 	}
 
+	// The remote keyboard payload uses a constrained numeric code set:
+	// standard phone-keyboard characters plus a small special-key subset.
 	keyEvent := e.keyboardEventForCode(cmdArgs.Code)
 	if keyEvent == nil {
 		return nil, fmt.Errorf("unsupported keyboard event code: %d", cmdArgs.Code)

--- a/components/feral-controld/devicectl/executor.go
+++ b/components/feral-controld/devicectl/executor.go
@@ -439,14 +439,6 @@ func (e *executor) keyboardEventForCode(keyCode int) *keyboardEvent {
 		return &keyboardEvent{key: "Escape", code: "Escape"}
 	case 8:
 		return &keyboardEvent{key: "Backspace", code: "Backspace"}
-	case 37:
-		return &keyboardEvent{key: "ArrowLeft", code: "ArrowLeft"}
-	case 38:
-		return &keyboardEvent{key: "ArrowUp", code: "ArrowUp"}
-	case 39:
-		return &keyboardEvent{key: "ArrowRight", code: "ArrowRight"}
-	case 40:
-		return &keyboardEvent{key: "ArrowDown", code: "ArrowDown"}
 	}
 
 	if keyCode < 32 || keyCode > 126 {

--- a/components/feral-controld/devicectl/executor.go
+++ b/components/feral-controld/devicectl/executor.go
@@ -454,23 +454,96 @@ func (e *executor) keyboardEventForCode(keyCode int) *keyboardEvent {
 		return nil
 	}
 
-	key := string(rune(keyCode))
-	code := keyCodeToCodeName(keyCode)
-	return &keyboardEvent{key: key, code: code, text: key}
+	key, code, text := printableASCIIKeyEvent(keyCode)
+	if code == "" {
+		e.logger.Warn("Unhandled printable keyboard event code", zap.Int("code", keyCode))
+		return nil
+	}
+	return &keyboardEvent{key: key, code: code, text: text}
 }
 
-func keyCodeToCodeName(keyCode int) string {
-	switch {
-	case keyCode >= 65 && keyCode <= 90:
-		return "Key" + string(rune(keyCode))
-	case keyCode >= 97 && keyCode <= 122:
-		return "Key" + strings.ToUpper(string(rune(keyCode)))
-	case keyCode >= 48 && keyCode <= 57:
-		return "Digit" + string(rune(keyCode))
+func printableASCIIKeyEvent(keyCode int) (key string, code string, text string) {
+	switch keyCode {
+	case 32:
+		return " ", "Space", " "
+	case 33:
+		return "!", "Digit1", "!"
+	case 34:
+		return "\"", "Quote", "\""
+	case 35:
+		return "#", "Digit3", "#"
+	case 36:
+		return "$", "Digit4", "$"
+	case 37:
+		return "%", "Digit5", "%"
+	case 38:
+		return "&", "Digit7", "&"
+	case 39:
+		return "'", "Quote", "'"
+	case 40:
+		return "(", "Digit9", "("
+	case 41:
+		return ")", "Digit0", ")"
+	case 42:
+		return "*", "Digit8", "*"
+	case 43:
+		return "+", "Equal", "+"
+	case 44:
+		return ",", "Comma", ","
+	case 45:
+		return "-", "Minus", "-"
+	case 46:
+		return ".", "Period", "."
+	case 47:
+		return "/", "Slash", "/"
+	case 48, 49, 50, 51, 52, 53, 54, 55, 56, 57:
+		return string(rune(keyCode)), "Digit" + string(rune(keyCode)), string(rune(keyCode))
+	case 58:
+		return ":", "Semicolon", ":"
+	case 59:
+		return ";", "Semicolon", ";"
+	case 60:
+		return "<", "Comma", "<"
+	case 61:
+		return "=", "Equal", "="
+	case 62:
+		return ">", "Period", ">"
+	case 63:
+		return "?", "Slash", "?"
+	case 64:
+		return "@", "Digit2", "@"
+	case 65, 66, 67, 68, 69, 70, 71, 72, 73, 74,
+		75, 76, 77, 78, 79, 80, 81, 82, 83, 84,
+		85, 86, 87, 88, 89, 90:
+		return string(rune(keyCode)), "Key" + string(rune(keyCode)), string(rune(keyCode))
+	case 91:
+		return "[", "BracketLeft", "["
+	case 92:
+		return "\\", "Backslash", "\\"
+	case 93:
+		return "]", "BracketRight", "]"
+	case 94:
+		return "^", "Digit6", "^"
+	case 95:
+		return "_", "Minus", "_"
+	case 96:
+		return "`", "Backquote", "`"
+	case 97, 98, 99, 100, 101, 102, 103, 104, 105, 106,
+		107, 108, 109, 110, 111, 112, 113, 114, 115, 116,
+		117, 118, 119, 120, 121, 122:
+		upper := strings.ToUpper(string(rune(keyCode)))
+		return string(rune(keyCode)), "Key" + upper, string(rune(keyCode))
+	case 123:
+		return "{", "BracketLeft", "{"
+	case 124:
+		return "|", "Backslash", "|"
+	case 125:
+		return "}", "BracketRight", "}"
+	case 126:
+		return "~", "Backquote", "~"
 	default:
-		return "Key" + string(rune(keyCode))
+		return "", "", ""
 	}
-
 }
 
 func (e *executor) initializeScreenDimensions() {

--- a/components/feral-controld/devicectl/executor.go
+++ b/components/feral-controld/devicectl/executor.go
@@ -750,32 +750,6 @@ func (e *executor) handleMouseTapEvent() (interface{}, error) {
 	return CmdOK, nil
 }
 
-func (e *executor) mapToYdoKey(keyCode int) string {
-	switch keyCode {
-	case 32:
-		return "space"
-	case 9:
-		return "tab"
-	case 13:
-		return "return"
-	case 27:
-		return "escape"
-	case 8:
-		return "backspace"
-	case 37:
-		return "left"
-	case 38:
-		return "up"
-	case 39:
-		return "right"
-	case 40:
-		return "down"
-	default:
-		e.logger.Warn("Unhandled key code", zap.Int("code", keyCode))
-		return ""
-	}
-}
-
 func (e *executor) shutdown(ctx context.Context) (interface{}, error) {
 	e.logger.Info("Executing shutdown command")
 

--- a/components/feral-controld/devicectl/executor.go
+++ b/components/feral-controld/devicectl/executor.go
@@ -370,43 +370,107 @@ func (e *executor) handleKeyboardEvent(args []byte) (interface{}, error) {
 		return nil, fmt.Errorf("invalid arguments: %w", err)
 	}
 
-	// Always map special keys first
-	keyName := e.mapToYdoKey(cmdArgs.Code)
-	isPrintable := false
-	if keyName == "" && cmdArgs.Code >= 32 && cmdArgs.Code <= 126 {
-		keyName = string(rune(cmdArgs.Code))
-		isPrintable = true
+	keyEvent := e.keyboardEventForCode(cmdArgs.Code)
+	if keyEvent == nil {
+		return nil, fmt.Errorf("unsupported keyboard event code: %d", cmdArgs.Code)
 	}
 
-	e.logger.Info("Keyboard event", zap.Int("code", cmdArgs.Code), zap.String("key", keyName))
+	e.logger.Info("Keyboard event",
+		zap.Int("code", cmdArgs.Code),
+		zap.String("key", keyEvent.key),
+		zap.String("code_name", keyEvent.code))
 
-	// Prepare CDP command to dispatch a key event
-	keyEventParams := map[string]interface{}{
+	keyDownParams := map[string]interface{}{
 		"type":                  "keyDown",
 		"windowsVirtualKeyCode": cmdArgs.Code,
-		"key":                   keyName,
-		"text":                  keyName,
-		"unmodifiedText":        keyName,
 		"nativeVirtualKeyCode":  cmdArgs.Code,
+		"key":                   keyEvent.key,
+		"code":                  keyEvent.code,
+	}
+	if keyEvent.text != "" {
+		keyDownParams["text"] = keyEvent.text
+		keyDownParams["unmodifiedText"] = keyEvent.text
 	}
 
-	// Send key directly via CDP
-	_, err = e.cdp.Send("Input.dispatchKeyEvent", keyEventParams)
+	_, err = e.cdp.Send("Input.dispatchKeyEvent", keyDownParams)
 	if err != nil {
 		e.logger.Error("Failed to send key via CDP", zap.Error(err))
 		return nil, fmt.Errorf("failed to send keyboard event: %w", err)
 	}
 
-	// Only send keyUp for printable ASCII (not for special keys)
-	if isPrintable {
-		keyEventParams["type"] = "keyUp"
-		_, err := e.cdp.Send("Input.dispatchKeyEvent", keyEventParams)
-		if err != nil {
-			e.logger.Error("Failed to send keyUp via CDP", zap.Error(err))
-		}
+	keyUpParams := map[string]interface{}{
+		"type":                  "keyUp",
+		"windowsVirtualKeyCode": cmdArgs.Code,
+		"nativeVirtualKeyCode":  cmdArgs.Code,
+		"key":                   keyEvent.key,
+		"code":                  keyEvent.code,
+	}
+	if keyEvent.text != "" {
+		keyUpParams["text"] = keyEvent.text
+		keyUpParams["unmodifiedText"] = keyEvent.text
+	}
+
+	_, err = e.cdp.Send("Input.dispatchKeyEvent", keyUpParams)
+	if err != nil {
+		e.logger.Error("Failed to send keyUp via CDP", zap.Error(err))
 	}
 
 	return CmdOK, nil
+}
+
+type keyboardEvent struct {
+	key  string
+	code string
+	text string
+}
+
+// keyboardEventForCode translates the remote command's numeric code into the
+// browser-facing values Chromium expects. This is intentionally a CDP-level
+// approximation of keyboard input, not an OS/kernel keyboard injection path.
+func (e *executor) keyboardEventForCode(keyCode int) *keyboardEvent {
+	switch keyCode {
+	case 32:
+		return &keyboardEvent{key: " ", code: "Space", text: " "}
+	case 9:
+		return &keyboardEvent{key: "Tab", code: "Tab"}
+	case 13:
+		return &keyboardEvent{key: "Enter", code: "Enter"}
+	case 27:
+		return &keyboardEvent{key: "Escape", code: "Escape"}
+	case 8:
+		return &keyboardEvent{key: "Backspace", code: "Backspace"}
+	case 37:
+		return &keyboardEvent{key: "ArrowLeft", code: "ArrowLeft"}
+	case 38:
+		return &keyboardEvent{key: "ArrowUp", code: "ArrowUp"}
+	case 39:
+		return &keyboardEvent{key: "ArrowRight", code: "ArrowRight"}
+	case 40:
+		return &keyboardEvent{key: "ArrowDown", code: "ArrowDown"}
+	}
+
+	if keyCode < 32 || keyCode > 126 {
+		e.logger.Warn("Unhandled keyboard event code", zap.Int("code", keyCode))
+		return nil
+	}
+
+	key := string(rune(keyCode))
+	code := keyCodeToCodeName(keyCode)
+	return &keyboardEvent{key: key, code: code, text: key}
+}
+
+func keyCodeToCodeName(keyCode int) string {
+	switch {
+	case keyCode >= 65 && keyCode <= 90:
+		return "Key" + string(rune(keyCode))
+	case keyCode >= 97 && keyCode <= 122:
+		return "Key" + strings.ToUpper(string(rune(keyCode)))
+	case keyCode >= 48 && keyCode <= 57:
+		return "Digit" + string(rune(keyCode))
+	default:
+		return "Key" + string(rune(keyCode))
+	}
+
 }
 
 func (e *executor) initializeScreenDimensions() {

--- a/components/feral-controld/devicectl/executor_test.go
+++ b/components/feral-controld/devicectl/executor_test.go
@@ -491,6 +491,10 @@ func TestExecutor_KeyboardEvent_Success(t *testing.T) {
 		{name: "Number0", keyCode: 48, expected: map[string]interface{}{"key": "0", "code": "Digit0", "text": "0", "unmodifiedText": "0"}, wantText: true},
 		{name: "Exclamation", keyCode: 33, expected: map[string]interface{}{"key": "!", "code": "Digit1", "text": "!", "unmodifiedText": "!"}, wantText: true},
 		{name: "AtSign", keyCode: 64, expected: map[string]interface{}{"key": "@", "code": "Digit2", "text": "@", "unmodifiedText": "@"}, wantText: true},
+		{name: "Percent", keyCode: 37, expected: map[string]interface{}{"key": "%", "code": "Digit5", "text": "%", "unmodifiedText": "%"}, wantText: true},
+		{name: "Ampersand", keyCode: 38, expected: map[string]interface{}{"key": "&", "code": "Digit7", "text": "&", "unmodifiedText": "&"}, wantText: true},
+		{name: "Apostrophe", keyCode: 39, expected: map[string]interface{}{"key": "'", "code": "Quote", "text": "'", "unmodifiedText": "'"}, wantText: true},
+		{name: "LeftParen", keyCode: 40, expected: map[string]interface{}{"key": "(", "code": "Digit9", "text": "(", "unmodifiedText": "("}, wantText: true},
 		{name: "Underscore", keyCode: 95, expected: map[string]interface{}{"key": "_", "code": "Minus", "text": "_", "unmodifiedText": "_"}, wantText: true},
 		{name: "Tilde", keyCode: 126, expected: map[string]interface{}{"key": "~", "code": "Backquote", "text": "~", "unmodifiedText": "~"}, wantText: true},
 		{name: "Space", keyCode: 32, expected: map[string]interface{}{"key": " ", "code": "Space", "text": " ", "unmodifiedText": " "}, wantText: true},
@@ -498,10 +502,6 @@ func TestExecutor_KeyboardEvent_Success(t *testing.T) {
 		{name: "Enter", keyCode: 13, expected: map[string]interface{}{"key": "Enter", "code": "Enter"}, wantText: false},
 		{name: "Escape", keyCode: 27, expected: map[string]interface{}{"key": "Escape", "code": "Escape"}, wantText: false},
 		{name: "Backspace", keyCode: 8, expected: map[string]interface{}{"key": "Backspace", "code": "Backspace"}, wantText: false},
-		{name: "ArrowLeft", keyCode: 37, expected: map[string]interface{}{"key": "ArrowLeft", "code": "ArrowLeft"}, wantText: false},
-		{name: "ArrowUp", keyCode: 38, expected: map[string]interface{}{"key": "ArrowUp", "code": "ArrowUp"}, wantText: false},
-		{name: "ArrowRight", keyCode: 39, expected: map[string]interface{}{"key": "ArrowRight", "code": "ArrowRight"}, wantText: false},
-		{name: "ArrowDown", keyCode: 40, expected: map[string]interface{}{"key": "ArrowDown", "code": "ArrowDown"}, wantText: false},
 	}
 
 	for _, tc := range testCases {
@@ -744,10 +744,10 @@ func TestExecutor_KeyboardEvent_Errors(t *testing.T) {
 			},
 			wantErr: "failed to send keyboard event",
 		},
-		{
-			name: "Special key keyUp failure is ignored",
-			setupFunc: func(ts *testSetup) {
-				keyCode := 13 // Enter
+	{
+		name: "Special key keyUp failure is ignored",
+		setupFunc: func(ts *testSetup) {
+			keyCode := 13 // Enter
 
 				ts.mockJSON.EXPECT().
 					Marshal(gomock.Any()).
@@ -783,6 +783,24 @@ func TestExecutor_KeyboardEvent_Errors(t *testing.T) {
 					})
 			},
 			wantErr: "",
+		},
+		{
+			name: "Unsupported key code fails",
+			setupFunc: func(ts *testSetup) {
+				ts.mockJSON.EXPECT().
+					Marshal(gomock.Any()).
+					Return([]byte(`{"code":31}`), nil)
+				ts.mockJSON.EXPECT().
+					Unmarshal(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(data []byte, v interface{}) error {
+						args := v.(*struct {
+							Code int `json:"code"`
+						})
+						args.Code = 31
+						return nil
+					})
+			},
+			wantErr: "unsupported keyboard event code",
 		},
 	}
 

--- a/components/feral-controld/devicectl/executor_test.go
+++ b/components/feral-controld/devicectl/executor_test.go
@@ -64,7 +64,7 @@ func setup(t *testing.T) *testSetup {
 	state.InjectStateManagerForTesting(mockStateManager)
 
 	// Use a real panelDDC backed by mockExec so that DDC executor tests can
-	// keep mocking ddcutil subprocess calls through mockExec.CommandContext
+	// keep mocking ddcutil subprocess calls through mockExec.CommandContext.
 	panelDDC := ddc.New(mockExec, logger)
 
 	// Create executor with mocks

--- a/components/feral-controld/devicectl/executor_test.go
+++ b/components/feral-controld/devicectl/executor_test.go
@@ -489,7 +489,10 @@ func TestExecutor_KeyboardEvent_Success(t *testing.T) {
 		{name: "LetterA", keyCode: 65, expected: map[string]interface{}{"key": "A", "code": "KeyA", "text": "A", "unmodifiedText": "A"}, wantText: true},
 		{name: "Letterz", keyCode: 122, expected: map[string]interface{}{"key": "z", "code": "KeyZ", "text": "z", "unmodifiedText": "z"}, wantText: true},
 		{name: "Number0", keyCode: 48, expected: map[string]interface{}{"key": "0", "code": "Digit0", "text": "0", "unmodifiedText": "0"}, wantText: true},
-		{name: "Tilde", keyCode: 126, expected: map[string]interface{}{"key": "~", "code": "Key~", "text": "~", "unmodifiedText": "~"}, wantText: true},
+		{name: "Exclamation", keyCode: 33, expected: map[string]interface{}{"key": "!", "code": "Digit1", "text": "!", "unmodifiedText": "!"}, wantText: true},
+		{name: "AtSign", keyCode: 64, expected: map[string]interface{}{"key": "@", "code": "Digit2", "text": "@", "unmodifiedText": "@"}, wantText: true},
+		{name: "Underscore", keyCode: 95, expected: map[string]interface{}{"key": "_", "code": "Minus", "text": "_", "unmodifiedText": "_"}, wantText: true},
+		{name: "Tilde", keyCode: 126, expected: map[string]interface{}{"key": "~", "code": "Backquote", "text": "~", "unmodifiedText": "~"}, wantText: true},
 		{name: "Space", keyCode: 32, expected: map[string]interface{}{"key": " ", "code": "Space", "text": " ", "unmodifiedText": " "}, wantText: true},
 		{name: "Tab", keyCode: 9, expected: map[string]interface{}{"key": "Tab", "code": "Tab"}, wantText: false},
 		{name: "Enter", keyCode: 13, expected: map[string]interface{}{"key": "Enter", "code": "Enter"}, wantText: false},
@@ -572,6 +575,38 @@ func TestExecutor_KeyboardEvent_Success(t *testing.T) {
 			assert.Equal(t, devicectl.CmdOK, result)
 		})
 	}
+}
+
+func TestExecutor_KeyboardEvent_UnsupportedCode(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	cmd := commands.Command{
+		Type: commands.CMD_KEYBOARD_EVENT,
+		Arguments: map[string]interface{}{
+			"code": 31,
+		},
+	}
+
+	arguments := `{"code":31}`
+
+	ts.mockJSON.EXPECT().
+		Marshal(cmd.Arguments).
+		Return([]byte(arguments), nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(arguments), gomock.Any()).
+		DoAndReturn(func(data []byte, v interface{}) error {
+			args := v.(*struct {
+				Code int `json:"code"`
+			})
+			args.Code = 31
+			return nil
+		})
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "unsupported keyboard event code")
 }
 
 func TestExecutor_KeyboardEvent_Errors(t *testing.T) {

--- a/components/feral-controld/devicectl/executor_test.go
+++ b/components/feral-controld/devicectl/executor_test.go
@@ -477,9 +477,6 @@ func TestExecutor_DeviceStatus_Error(t *testing.T) {
 }
 
 func TestExecutor_KeyboardEvent_Success(t *testing.T) {
-	ts := setup(t)
-	defer ts.teardown()
-
 	testCases := []struct {
 		name     string
 		keyCode  int
@@ -744,10 +741,10 @@ func TestExecutor_KeyboardEvent_Errors(t *testing.T) {
 			},
 			wantErr: "failed to send keyboard event",
 		},
-	{
-		name: "Special key keyUp failure is ignored",
-		setupFunc: func(ts *testSetup) {
-			keyCode := 13 // Enter
+		{
+			name: "Special key keyUp failure is ignored",
+			setupFunc: func(ts *testSetup) {
+				keyCode := 13 // Enter
 
 				ts.mockJSON.EXPECT().
 					Marshal(gomock.Any()).
@@ -809,28 +806,24 @@ func TestExecutor_KeyboardEvent_Errors(t *testing.T) {
 			ts := setup(t)
 			defer ts.teardown()
 
-			// Setup test data
 			cmd := commands.Command{
 				Type: commands.CMD_KEYBOARD_EVENT,
 				Arguments: map[string]interface{}{
-					"code": 65, // Default value, overridden in setupFunc if needed
+					"code": 65,
 				},
 			}
 
-			// Setup error condition
 			tt.setupFunc(ts)
 
-			// Execute the method under test
 			result, err := ts.executor.Execute(ts.ctx, cmd)
 
-			// Assert error occurred and contains expected message or success
 			if tt.wantErr != "" {
-				assert.Error(t, err, "expected error, got %v", err)
-				assert.Contains(t, err.Error(), tt.wantErr, "expected error message to contain %q, got %q", tt.wantErr, err.Error())
-				assert.Nil(t, result, "expected nil result on error")
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Nil(t, result)
 			} else {
-				assert.NoError(t, err, "expected no error, got %v", err)
-				assert.Equal(t, devicectl.CmdOK, result, "expected CmdOK result on success")
+				assert.NoError(t, err)
+				assert.Equal(t, devicectl.CmdOK, result)
 			}
 		})
 	}

--- a/components/feral-controld/devicectl/executor_test.go
+++ b/components/feral-controld/devicectl/executor_test.go
@@ -769,7 +769,7 @@ func TestExecutor_KeyboardEvent_Errors(t *testing.T) {
 						assert.Equal(t, " ", params["text"])
 						assert.Equal(t, " ", params["unmodifiedText"])
 						return nil, errors.New("cdp keyDown failed")
-				})
+					})
 			},
 			wantErr: "failed to send keyboard event",
 		},

--- a/components/feral-controld/devicectl/executor_test.go
+++ b/components/feral-controld/devicectl/executor_test.go
@@ -64,7 +64,7 @@ func setup(t *testing.T) *testSetup {
 	state.InjectStateManagerForTesting(mockStateManager)
 
 	// Use a real panelDDC backed by mockExec so that DDC executor tests can
-	// keep mocking ddcutil subprocess calls through mockExec.CommandContext.
+	// keep mocking ddcutil subprocess calls through mockExec.CommandContext
 	panelDDC := ddc.New(mockExec, logger)
 
 	// Create executor with mocks

--- a/components/feral-controld/devicectl/executor_test.go
+++ b/components/feral-controld/devicectl/executor_test.go
@@ -481,43 +481,31 @@ func TestExecutor_KeyboardEvent_Success(t *testing.T) {
 	defer ts.teardown()
 
 	testCases := []struct {
-		name           string
-		keyCode        int
-		expectedKey    string
-		shouldGetKeyUp bool
-		description    string
+		name     string
+		keyCode  int
+		expected map[string]interface{}
+		wantText bool
 	}{
-		// Printable ASCII characters (should get keyUp)
-		{name: "LetterA", keyCode: 65, expectedKey: "A", shouldGetKeyUp: true, description: "Uppercase A"},
-		{name: "LetterZ", keyCode: 90, expectedKey: "Z", shouldGetKeyUp: true, description: "Uppercase Z"},
-		{name: "Lettera", keyCode: 97, expectedKey: "a", shouldGetKeyUp: true, description: "Lowercase a"},
-		{name: "Letterz", keyCode: 122, expectedKey: "z", shouldGetKeyUp: true, description: "Lowercase z"},
-		{name: "Number0", keyCode: 48, expectedKey: "0", shouldGetKeyUp: true, description: "Number 0"},
-		{name: "Number9", keyCode: 57, expectedKey: "9", shouldGetKeyUp: true, description: "Number 9"},
-		{name: "Tilde", keyCode: 126, expectedKey: "~", shouldGetKeyUp: true, description: "Tilde character (max printable ASCII)"},
-
-		// Special keys that should NOT get keyUp (fixed behavior)
-		{name: "Space", keyCode: 32, expectedKey: "space", shouldGetKeyUp: false, description: "Space key (special key, no keyUp)"},
-		{name: "Tab", keyCode: 9, expectedKey: "tab", shouldGetKeyUp: false, description: "Tab key (special key, no keyUp)"},
-		{name: "Enter", keyCode: 13, expectedKey: "return", shouldGetKeyUp: false, description: "Enter key (special key, no keyUp)"},
-		{name: "Escape", keyCode: 27, expectedKey: "escape", shouldGetKeyUp: false, description: "Escape key (special key, no keyUp)"},
-		{name: "Backspace", keyCode: 8, expectedKey: "backspace", shouldGetKeyUp: false, description: "Backspace key (special key, no keyUp)"},
-
-		// Arrow keys now correctly mapped (fixed behavior)
-		{name: "ArrowLeft", keyCode: 37, expectedKey: "left", shouldGetKeyUp: false, description: "Left arrow (special key, no keyUp)"},
-		{name: "ArrowUp", keyCode: 38, expectedKey: "up", shouldGetKeyUp: false, description: "Up arrow (special key, no keyUp)"},
-		{name: "ArrowRight", keyCode: 39, expectedKey: "right", shouldGetKeyUp: false, description: "Right arrow (special key, no keyUp)"},
-		{name: "ArrowDown", keyCode: 40, expectedKey: "down", shouldGetKeyUp: false, description: "Down arrow (special key, no keyUp)"},
-
-		// Edge cases
-		{name: "BelowPrintable", keyCode: 31, expectedKey: "", shouldGetKeyUp: false, description: "Below printable ASCII range"},
-		{name: "AbovePrintable", keyCode: 127, expectedKey: "", shouldGetKeyUp: false, description: "Above printable ASCII range"},
-		{name: "UnknownKey", keyCode: 999, expectedKey: "", shouldGetKeyUp: false, description: "Unknown key code"},
+		{name: "LetterA", keyCode: 65, expected: map[string]interface{}{"key": "A", "code": "KeyA", "text": "A", "unmodifiedText": "A"}, wantText: true},
+		{name: "Letterz", keyCode: 122, expected: map[string]interface{}{"key": "z", "code": "KeyZ", "text": "z", "unmodifiedText": "z"}, wantText: true},
+		{name: "Number0", keyCode: 48, expected: map[string]interface{}{"key": "0", "code": "Digit0", "text": "0", "unmodifiedText": "0"}, wantText: true},
+		{name: "Tilde", keyCode: 126, expected: map[string]interface{}{"key": "~", "code": "Key~", "text": "~", "unmodifiedText": "~"}, wantText: true},
+		{name: "Space", keyCode: 32, expected: map[string]interface{}{"key": " ", "code": "Space", "text": " ", "unmodifiedText": " "}, wantText: true},
+		{name: "Tab", keyCode: 9, expected: map[string]interface{}{"key": "Tab", "code": "Tab"}, wantText: false},
+		{name: "Enter", keyCode: 13, expected: map[string]interface{}{"key": "Enter", "code": "Enter"}, wantText: false},
+		{name: "Escape", keyCode: 27, expected: map[string]interface{}{"key": "Escape", "code": "Escape"}, wantText: false},
+		{name: "Backspace", keyCode: 8, expected: map[string]interface{}{"key": "Backspace", "code": "Backspace"}, wantText: false},
+		{name: "ArrowLeft", keyCode: 37, expected: map[string]interface{}{"key": "ArrowLeft", "code": "ArrowLeft"}, wantText: false},
+		{name: "ArrowUp", keyCode: 38, expected: map[string]interface{}{"key": "ArrowUp", "code": "ArrowUp"}, wantText: false},
+		{name: "ArrowRight", keyCode: 39, expected: map[string]interface{}{"key": "ArrowRight", "code": "ArrowRight"}, wantText: false},
+		{name: "ArrowDown", keyCode: 40, expected: map[string]interface{}{"key": "ArrowDown", "code": "ArrowDown"}, wantText: false},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Setup test data
+			ts := setup(t)
+			defer ts.teardown()
+
 			cmd := commands.Command{
 				Type: commands.CMD_KEYBOARD_EVENT,
 				Arguments: map[string]interface{}{
@@ -527,12 +515,10 @@ func TestExecutor_KeyboardEvent_Success(t *testing.T) {
 
 			arguments := fmt.Sprintf(`{"code":%d}`, tc.keyCode)
 
-			// Mock JSON marshaling
 			ts.mockJSON.EXPECT().
 				Marshal(cmd.Arguments).
 				Return([]byte(arguments), nil)
 
-			// Mock JSON unmarshaling
 			ts.mockJSON.EXPECT().
 				Unmarshal([]byte(arguments), gomock.Any()).
 				DoAndReturn(func(data []byte, v interface{}) error {
@@ -543,37 +529,44 @@ func TestExecutor_KeyboardEvent_Success(t *testing.T) {
 					return nil
 				})
 
-			// Mock CDP Send for keyDown
-			ts.mockCDP.EXPECT().
+			first := ts.mockCDP.EXPECT().
 				Send("Input.dispatchKeyEvent", gomock.Any()).
 				DoAndReturn(func(method string, params map[string]interface{}) (interface{}, error) {
-					// Verify keyDown parameters
 					assert.Equal(t, "keyDown", params["type"])
 					assert.Equal(t, tc.keyCode, params["windowsVirtualKeyCode"])
-					assert.Equal(t, tc.expectedKey, params["key"])
-					assert.Equal(t, tc.expectedKey, params["text"])
-					assert.Equal(t, tc.expectedKey, params["unmodifiedText"])
 					assert.Equal(t, tc.keyCode, params["nativeVirtualKeyCode"])
+					for k, v := range tc.expected {
+						assert.Equal(t, v, params[k], "unexpected value for %s", k)
+					}
+					if tc.wantText {
+						assert.Equal(t, tc.expected["text"], params["text"])
+						assert.Equal(t, tc.expected["unmodifiedText"], params["unmodifiedText"])
+					} else {
+						assert.NotContains(t, params, "text")
+						assert.NotContains(t, params, "unmodifiedText")
+					}
 					return nil, nil
 				})
 
-			// Mock CDP Send for keyUp (only if shouldGetKeyUp is true)
-			if tc.shouldGetKeyUp {
-				ts.mockCDP.EXPECT().
-					Send("Input.dispatchKeyEvent", gomock.Any()).
-					DoAndReturn(func(method string, params map[string]interface{}) (interface{}, error) {
-						// Verify keyUp parameters
-						assert.Equal(t, "keyUp", params["type"])
-						assert.Equal(t, tc.keyCode, params["windowsVirtualKeyCode"])
-						assert.Equal(t, tc.expectedKey, params["key"])
-						assert.Equal(t, tc.expectedKey, params["text"])
-						assert.Equal(t, tc.expectedKey, params["unmodifiedText"])
-						assert.Equal(t, tc.keyCode, params["nativeVirtualKeyCode"])
-						return nil, nil
-					})
-			}
+			ts.mockCDP.EXPECT().
+				Send("Input.dispatchKeyEvent", gomock.Any()).
+				DoAndReturn(func(method string, params map[string]interface{}) (interface{}, error) {
+					assert.Equal(t, "keyUp", params["type"])
+					assert.Equal(t, tc.keyCode, params["windowsVirtualKeyCode"])
+					assert.Equal(t, tc.keyCode, params["nativeVirtualKeyCode"])
+					for k, v := range tc.expected {
+						assert.Equal(t, v, params[k], "unexpected value for %s", k)
+					}
+					if tc.wantText {
+						assert.Equal(t, tc.expected["text"], params["text"])
+						assert.Equal(t, tc.expected["unmodifiedText"], params["unmodifiedText"])
+					} else {
+						assert.NotContains(t, params, "text")
+						assert.NotContains(t, params, "unmodifiedText")
+					}
+					return nil, nil
+				}).After(first)
 
-			// Execute command
 			result, err := ts.executor.Execute(ts.ctx, cmd)
 			assert.NoError(t, err)
 			assert.Equal(t, devicectl.CmdOK, result)
@@ -617,7 +610,6 @@ func TestExecutor_KeyboardEvent_Errors(t *testing.T) {
 			setupFunc: func(ts *testSetup) {
 				keyCode := 65 // 'A' - printable ASCII
 
-				// Mock JSON operations success
 				ts.mockJSON.EXPECT().
 					Marshal(gomock.Any()).
 					Return([]byte(`{"code":65}`), nil)
@@ -631,14 +623,13 @@ func TestExecutor_KeyboardEvent_Errors(t *testing.T) {
 						return nil
 					})
 
-				// Mock CDP Send for keyDown to fail
 				ts.mockCDP.EXPECT().
 					Send("Input.dispatchKeyEvent", gomock.Any()).
 					DoAndReturn(func(method string, params map[string]interface{}) (interface{}, error) {
-						// Verify keyDown parameters
 						assert.Equal(t, "keyDown", params["type"])
 						assert.Equal(t, keyCode, params["windowsVirtualKeyCode"])
 						assert.Equal(t, "A", params["key"])
+						assert.Equal(t, "KeyA", params["code"])
 						return nil, errors.New("cdp keyDown failed")
 					})
 			},
@@ -649,7 +640,6 @@ func TestExecutor_KeyboardEvent_Errors(t *testing.T) {
 			setupFunc: func(ts *testSetup) {
 				keyCode := 65 // 'A' - printable ASCII
 
-				// Mock JSON operations success
 				ts.mockJSON.EXPECT().
 					Marshal(gomock.Any()).
 					Return([]byte(`{"code":65}`), nil)
@@ -663,36 +653,35 @@ func TestExecutor_KeyboardEvent_Errors(t *testing.T) {
 						return nil
 					})
 
-				// Mock CDP Send for keyDown success
 				ts.mockCDP.EXPECT().
 					Send("Input.dispatchKeyEvent", gomock.Any()).
 					DoAndReturn(func(method string, params map[string]interface{}) (interface{}, error) {
-						// Verify keyDown parameters
 						assert.Equal(t, "keyDown", params["type"])
 						assert.Equal(t, keyCode, params["windowsVirtualKeyCode"])
 						assert.Equal(t, "A", params["key"])
+						assert.Equal(t, "KeyA", params["code"])
+						assert.Equal(t, "A", params["text"])
+						assert.Equal(t, "A", params["unmodifiedText"])
 						return nil, nil
 					})
 
-				// Mock CDP Send for keyUp to fail (but command should still succeed)
 				ts.mockCDP.EXPECT().
 					Send("Input.dispatchKeyEvent", gomock.Any()).
 					DoAndReturn(func(method string, params map[string]interface{}) (interface{}, error) {
-						// Verify keyUp parameters
 						assert.Equal(t, "keyUp", params["type"])
 						assert.Equal(t, keyCode, params["windowsVirtualKeyCode"])
 						assert.Equal(t, "A", params["key"])
+						assert.Equal(t, "KeyA", params["code"])
 						return nil, errors.New("cdp keyUp failed")
 					})
 			},
-			wantErr: "", // Should succeed despite keyUp failure
+			wantErr: "",
 		},
 		{
 			name: "CDP keyDown failure for special key",
 			setupFunc: func(ts *testSetup) {
 				keyCode := 32 // Space - special key (no keyUp)
 
-				// Mock JSON operations success
 				ts.mockJSON.EXPECT().
 					Marshal(gomock.Any()).
 					Return([]byte(`{"code":32}`), nil)
@@ -706,19 +695,59 @@ func TestExecutor_KeyboardEvent_Errors(t *testing.T) {
 						return nil
 					})
 
-				// Mock CDP Send for keyDown to fail
 				ts.mockCDP.EXPECT().
 					Send("Input.dispatchKeyEvent", gomock.Any()).
 					DoAndReturn(func(method string, params map[string]interface{}) (interface{}, error) {
-						// Verify keyDown parameters
 						assert.Equal(t, "keyDown", params["type"])
 						assert.Equal(t, keyCode, params["windowsVirtualKeyCode"])
-						assert.Equal(t, "space", params["key"])
+						assert.Equal(t, " ", params["key"])
+						assert.Equal(t, "Space", params["code"])
+						assert.Equal(t, " ", params["text"])
+						assert.Equal(t, " ", params["unmodifiedText"])
 						return nil, errors.New("cdp keyDown failed")
 					})
-				// No keyUp expected for special keys
 			},
 			wantErr: "failed to send keyboard event",
+		},
+		{
+			name: "Special key keyUp failure is ignored",
+			setupFunc: func(ts *testSetup) {
+				keyCode := 13 // Enter
+
+				ts.mockJSON.EXPECT().
+					Marshal(gomock.Any()).
+					Return([]byte(`{"code":13}`), nil)
+				ts.mockJSON.EXPECT().
+					Unmarshal(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(data []byte, v interface{}) error {
+						args := v.(*struct {
+							Code int `json:"code"`
+						})
+						args.Code = keyCode
+						return nil
+					})
+
+				ts.mockCDP.EXPECT().
+					Send("Input.dispatchKeyEvent", gomock.Any()).
+					DoAndReturn(func(method string, params map[string]interface{}) (interface{}, error) {
+						assert.Equal(t, "keyDown", params["type"])
+						assert.Equal(t, "Enter", params["key"])
+						assert.Equal(t, "Enter", params["code"])
+						assert.NotContains(t, params, "text")
+						assert.NotContains(t, params, "unmodifiedText")
+						return nil, nil
+					})
+
+				ts.mockCDP.EXPECT().
+					Send("Input.dispatchKeyEvent", gomock.Any()).
+					DoAndReturn(func(method string, params map[string]interface{}) (interface{}, error) {
+						assert.Equal(t, "keyUp", params["type"])
+						assert.Equal(t, "Enter", params["key"])
+						assert.Equal(t, "Enter", params["code"])
+						return nil, errors.New("cdp keyUp failed")
+					})
+			},
+			wantErr: "",
 		},
 	}
 

--- a/components/feral-controld/devicectl/executor_test.go
+++ b/components/feral-controld/devicectl/executor_test.go
@@ -606,6 +606,38 @@ func TestExecutor_KeyboardEvent_UnsupportedCode(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported keyboard event code")
 }
 
+func TestExecutor_KeyboardEvent_UnsupportedPrintablePunctuation(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	cmd := commands.Command{
+		Type: commands.CMD_KEYBOARD_EVENT,
+		Arguments: map[string]interface{}{
+			"code": 127,
+		},
+	}
+
+	arguments := `{"code":127}`
+
+	ts.mockJSON.EXPECT().
+		Marshal(cmd.Arguments).
+		Return([]byte(arguments), nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(arguments), gomock.Any()).
+		DoAndReturn(func(data []byte, v interface{}) error {
+			args := v.(*struct {
+				Code int `json:"code"`
+			})
+			args.Code = 127
+			return nil
+		})
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "unsupported keyboard event code")
+}
+
 func TestExecutor_KeyboardEvent_Errors(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -737,7 +769,7 @@ func TestExecutor_KeyboardEvent_Errors(t *testing.T) {
 						assert.Equal(t, " ", params["text"])
 						assert.Equal(t, " ", params["unmodifiedText"])
 						return nil, errors.New("cdp keyDown failed")
-					})
+				})
 			},
 			wantErr: "failed to send keyboard event",
 		},


### PR DESCRIPTION
Fixes feral-file/feralfile-app#2591.

This updates `feral-controld` keyboard event translation so printable ASCII codes map to the correct DOM key/code/text values, which allows free-text phrases to be entered through the FF1 interact keyboard without dropping supported characters.

Tests cover printable character mapping and unsupported code handling.