### PR TITLE
feat(controld): expose Chrome display URL on device status

### DIFF
--- a/components/feral-controld/AGENTS.md
+++ b/components/feral-controld/AGENTS.md
@@ -39,7 +39,7 @@ This component is the highest-risk Go daemon for accidental architectural sprawl
 - `dbus` owns the D-Bus client and the controld handler. The handler exports `GetRelayerTopicID` RPC. It also defines the member constants for signals sent to setupd.
 - `relayer` manages the WebSocket relayer connection (ping every 15s, pong wait 3s). It classifies errors as permanent, transient, or busy.
 - `cdp` is the Chrome DevTools Protocol client (WebSocket to `127.0.0.1:9222`). Commands are sent via `Runtime.evaluate` calling `window.handleCDPRequest(payload)`.
-- `status` owns the device status collector (`DeviceStatus`) and the status poller. The poller polls CDP for player status and drives notifications to the web app.
+- `status` owns the device status collector (`DeviceStatus`) and the status poller. The poller polls CDP for player status and drives notifications to the web app. `DeviceStatus.GetStatus` includes best-effort `displayURL` (Chromium page URL from DevTools `/json`) on `device_status` notifications; player status carries playback/UI state from `checkStatus` only.
 - `hub` exposes a local WebSocket server on `0.0.0.0:1111` (only when `enableHub` is true in config). Uses the same `commandrouter` as the relayer. Also serves Prometheus metrics at this address.
 - `mdns` advertises the device on the local network. mDNS starts/stops in response to connectivity changes from D-Bus.
 - `oom-recovery` (`OOMRecoverer`): on startup, compares `/var/lib/oom_state/chromium-oom-kill-count` against a handled-count file. If unhandled OOM kills exist, it polls (every 2s, up to 60 retries) until the webapp is responsive, then sends `CMD_DISPLAY_DEFAULT_PLAYLIST` to resume playback, then writes the handled-count. Suppresses player notifications during recovery.

--- a/components/feral-controld/cdp/cdp.go
+++ b/components/feral-controld/cdp/cdp.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"sync"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"go.uber.org/zap"
@@ -94,6 +96,10 @@ func (c *cdp) Initialized() bool {
 func (c *cdp) Init(ctx context.Context) error {
 	c.logger.Info("Initializing CDP", zap.String("endpoint", c.endpoint))
 
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	// Ensure the relayer is not connected
 	c.mu.Lock()
 	if c.conn != nil {
@@ -101,8 +107,17 @@ func (c *cdp) Init(ctx context.Context) error {
 		return ErrAlreadyInitialized
 	}
 
-	// Fetch JSON with websocket debugger URL
-	resp, err := c.httpClient.Get(c.endpoint + "/json")
+	// Fetch JSON with websocket debugger URL. Use a request bound to ctx (plus a cap) so
+	// this step respects cancellation; raw http.Get ignores the request context and can
+	// block for the shared client's default timeout.
+	fetchCtx, fetchCancel := context.WithTimeout(ctx, initDebugTargetsFetchTimeout)
+	defer fetchCancel()
+	req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, c.endpoint+"/json", nil)
+	if err != nil {
+		c.mu.Unlock()
+		return fmt.Errorf("failed to build debug targets request: %w", err)
+	}
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		c.mu.Unlock()
 		return fmt.Errorf("failed to fetch debug targets: %w", err)
@@ -186,12 +201,30 @@ func (c *cdp) Init(ctx context.Context) error {
 	return nil
 }
 
+// initDebugTargetsFetchTimeout caps the /json fetch during CDP Init. Parent ctx
+// cancellation still applies; the cap avoids an uncancelled 30s client stall when
+// ctx has no deadline.
+const initDebugTargetsFetchTimeout = 15 * time.Second
+
+// pageNavigationURLFetchTimeout bounds the best-effort /json probe. Without this,
+// a hung Chromium devtools endpoint could block until the shared HTTP client's
+// 30s timeout, stalling DeviceStatus polling and downstream notifications.
+const pageNavigationURLFetchTimeout = 5 * time.Second
+
 func (c *cdp) PageNavigationURL(ctx context.Context) (string, error) {
 	if err := ctx.Err(); err != nil {
 		return "", err
 	}
 
-	resp, err := c.httpClient.Get(c.endpoint + "/json")
+	ctx, cancel := context.WithTimeout(ctx, pageNavigationURLFetchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.endpoint+"/json", nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to build debug targets request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch debug targets: %w", err)
 	}

--- a/components/feral-controld/cdp/cdp.go
+++ b/components/feral-controld/cdp/cdp.go
@@ -38,6 +38,7 @@ type CDP interface {
 	Init(ctx context.Context) error
 	Send(method string, params map[string]interface{}) (interface{}, error)
 	NoLogSend(method string, params map[string]interface{}) (interface{}, error)
+	PageNavigationURL(ctx context.Context) (string, error)
 	Close()
 	Initialized() bool
 }
@@ -183,6 +184,54 @@ func (c *cdp) Init(ctx context.Context) error {
 	}()
 
 	return nil
+}
+
+func (c *cdp) PageNavigationURL(ctx context.Context) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	resp, err := c.httpClient.Get(c.endpoint + "/json")
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch debug targets: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			c.logger.Warn("Failed to close response body", zap.Error(err))
+		}
+	}()
+
+	body, err := c.io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read targets: %w", err)
+	}
+
+	var targets []struct {
+		Type string `json:"type"`
+		URL  string `json:"url"`
+	}
+	if err := c.json.Unmarshal(body, &targets); err != nil {
+		return "", fmt.Errorf("invalid targets format: %w", err)
+	}
+	c.logger.Debug("Fetched CDP targets for navigation URL", zap.Int("target_count", len(targets)))
+
+	pageTargets := make([]string, 0, len(targets))
+	for _, t := range targets {
+		if t.Type == "page" {
+			pageTargets = append(pageTargets, t.URL)
+		}
+	}
+	c.logger.Debug("Filtered CDP page targets for navigation URL", zap.Int("page_target_count", len(pageTargets)))
+
+	if len(pageTargets) == 0 {
+		return "", ErrNoPageTargetFound
+	}
+
+	if len(pageTargets) > 1 {
+		return "", ErrMultiplePageTargetsFound
+	}
+
+	return pageTargets[0], nil
 }
 
 // Send sends a raw CDP JSON-RPC message with logging

--- a/components/feral-controld/cdp/cdp.go
+++ b/components/feral-controld/cdp/cdp.go
@@ -201,10 +201,11 @@ func (c *cdp) Init(ctx context.Context) error {
 	return nil
 }
 
-// initDebugTargetsFetchTimeout caps the /json fetch during CDP Init. Parent ctx
-// cancellation still applies; the cap avoids an uncancelled 30s client stall when
-// ctx has no deadline.
-const initDebugTargetsFetchTimeout = 15 * time.Second
+// initDebugTargetsFetchTimeout matches the shared HTTP client round-trip limit so
+// bootstrap /json discovery stays aligned with prior Get behavior while the request
+// remains context-driven (see Init). A shorter cap caused false Init failures when
+// Chromium answered /json between that cap and the client timeout (cold boot / recovery).
+const initDebugTargetsFetchTimeout = wrapper.HTTPClientTimeout
 
 // pageNavigationURLFetchTimeout bounds the best-effort /json probe. Without this,
 // a hung Chromium devtools endpoint could block until the shared HTTP client's

--- a/components/feral-controld/cdp/cdp_test.go
+++ b/components/feral-controld/cdp/cdp_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )
@@ -132,6 +133,72 @@ func TestClient_Init_Success(t *testing.T) {
 	assert.True(t, ts.client.Initialized(), "expected client to be initialized")
 
 	// Properly close the client to prevent goroutine leaks
+	ts.client.Close()
+}
+
+// TestClient_Init_BootstrapFetchDeadlineMatchesSharedHTTPClient guards against
+// regressing to a short-only cap (e.g. 15s): slow /json responses must still be
+// able to succeed up to the shared HTTP client budget (F1/F2).
+func TestClient_Init_BootstrapFetchDeadlineMatchesSharedHTTPClient(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	const targetWS = "ws://localhost:9222/devtools/page/123"
+	responseBody := fmt.Sprintf(`[{"type":"page","title":"t","webSocketDebuggerUrl":"%s"}]`, targetWS)
+	responseBodyBytes := []byte(responseBody)
+
+	var gotReq *http.Request
+	ts.mockHTTP.EXPECT().
+		Do(gomock.Any()).
+		DoAndReturn(func(req *http.Request) (*http.Response, error) {
+			gotReq = req
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(strings.NewReader(responseBody)),
+			}, nil
+		}).
+		Times(1)
+
+	ts.mockIO.EXPECT().
+		ReadAll(gomock.Any()).
+		Return(responseBodyBytes, nil).
+		Times(1)
+
+	ts.mockJSON.EXPECT().
+		Unmarshal(responseBodyBytes, gomock.Any()).
+		DoAndReturn(func(data []byte, v interface{}) error {
+			targets := v.(*[]struct {
+				Type                 string `json:"type"`
+				Title                string `json:"title"`
+				WebSocketDebuggerURL string `json:"webSocketDebuggerUrl"`
+			})
+			*targets = []struct {
+				Type                 string `json:"type"`
+				Title                string `json:"title"`
+				WebSocketDebuggerURL string `json:"webSocketDebuggerUrl"`
+			}{
+				{Type: "page", Title: "t", WebSocketDebuggerURL: targetWS},
+			}
+			return nil
+		}).
+		Times(1)
+
+	ts.mockDialer.EXPECT().
+		DialContext(ts.ctx, targetWS, nil).
+		Return(ts.mockConn, nil, nil).
+		Times(1)
+
+	ts.mockConn.EXPECT().Close().Return(nil).AnyTimes()
+
+	err := ts.client.Init(ts.ctx)
+	assert.NoError(t, err)
+
+	require.NotNil(t, gotReq)
+	deadline, ok := gotReq.Context().Deadline()
+	assert.True(t, ok, "bootstrap /json request should carry a deadline")
+	assert.Greater(t, time.Until(deadline), 20*time.Second,
+		"deadline should allow slow /json up to the shared HTTP client limit (not a ~15s-only cap)")
+
 	ts.client.Close()
 }
 

--- a/components/feral-controld/cdp/cdp_test.go
+++ b/components/feral-controld/cdp/cdp_test.go
@@ -78,9 +78,9 @@ func TestClient_Init_Success(t *testing.T) {
 		Body:       io.NopCloser(strings.NewReader(responseBody)),
 	}
 
-	// Expect http.Get to return mock response
+	// Expect http.Do to return mock response
 	ts.mockHTTP.EXPECT().
-		Get(gomock.Any()).
+		Do(gomock.Any()).
 		Return(mockResponse, nil).
 		Times(1)
 
@@ -151,9 +151,9 @@ func TestClient_Init_Error(t *testing.T) {
 					Body:       io.NopCloser(strings.NewReader(responseBody)),
 				}
 
-				// Expect http.Get to return mock response
+				// Expect http.Do to return mock response
 				ts.mockHTTP.EXPECT().
-					Get(gomock.Any()).
+					Do(gomock.Any()).
 					Return(mockResponse, nil).
 					Times(1)
 
@@ -204,9 +204,9 @@ func TestClient_Init_Error(t *testing.T) {
 		{
 			name: "HTTP GET error",
 			setupFunc: func(ts *testSetup) {
-				// Expect http.Get to return error
+				// Expect http.Do to return error
 				ts.mockHTTP.EXPECT().
-					Get(gomock.Any()).
+					Do(gomock.Any()).
 					Return(nil, fmt.Errorf("connection refused")).
 					Times(1)
 			},
@@ -220,9 +220,9 @@ func TestClient_Init_Error(t *testing.T) {
 					Body:       io.NopCloser(strings.NewReader("")),
 				}
 
-				// Expect http.Get to return mock response
+				// Expect http.Do to return mock response
 				ts.mockHTTP.EXPECT().
-					Get(gomock.Any()).
+					Do(gomock.Any()).
 					Return(mockResponse, nil).
 					Times(1)
 
@@ -243,9 +243,9 @@ func TestClient_Init_Error(t *testing.T) {
 					Body:       io.NopCloser(strings.NewReader(responseBody)),
 				}
 
-				// Expect http.Get to return mock response
+				// Expect http.Do to return mock response
 				ts.mockHTTP.EXPECT().
-					Get(gomock.Any()).
+					Do(gomock.Any()).
 					Return(mockResponse, nil).
 					Times(1)
 
@@ -272,9 +272,9 @@ func TestClient_Init_Error(t *testing.T) {
 					Body:       io.NopCloser(strings.NewReader(responseBody)),
 				}
 
-				// Expect http.Get to return mock response
+				// Expect http.Do to return mock response
 				ts.mockHTTP.EXPECT().
-					Get(gomock.Any()).
+					Do(gomock.Any()).
 					Return(mockResponse, nil).
 					Times(1)
 
@@ -321,9 +321,9 @@ func TestClient_Init_Error(t *testing.T) {
 					Body:       io.NopCloser(strings.NewReader(responseBody)),
 				}
 
-				// Expect http.Get to return mock response
+				// Expect http.Do to return mock response
 				ts.mockHTTP.EXPECT().
-					Get(gomock.Any()).
+					Do(gomock.Any()).
 					Return(mockResponse, nil).
 					Times(1)
 
@@ -372,9 +372,9 @@ func TestClient_Init_Error(t *testing.T) {
 					Body:       io.NopCloser(strings.NewReader(responseBody)),
 				}
 
-				// Expect http.Get to return mock response
+				// Expect http.Do to return mock response
 				ts.mockHTTP.EXPECT().
-					Get(gomock.Any()).
+					Do(gomock.Any()).
 					Return(mockResponse, nil).
 					Times(1)
 
@@ -447,9 +447,9 @@ func TestClient_Init_Async(t *testing.T) {
 		Body:       io.NopCloser(strings.NewReader(responseBody)),
 	}
 
-	// Expect http.Get to return mock response - only one connection should succeed
+	// Expect http.Do to return mock response - only one connection should succeed
 	ts.mockHTTP.EXPECT().
-		Get(gomock.Any()).
+		Do(gomock.Any()).
 		Return(mockResponse, nil).
 		Times(1)
 
@@ -555,9 +555,9 @@ func TestClient_Init_ContextCanceled(t *testing.T) {
 		Body:       io.NopCloser(strings.NewReader(responseBody)),
 	}
 
-	// Expect http.Get to return mock response
+	// Expect http.Do to return mock response
 	ts.mockHTTP.EXPECT().
-		Get(gomock.Any()).
+		Do(gomock.Any()).
 		Return(mockResponse, nil).
 		Times(1)
 
@@ -642,7 +642,7 @@ func TestClient_Send_Success(t *testing.T) {
 
 	// Setup initialization expectations
 	ts.mockHTTP.EXPECT().
-		Get(gomock.Any()).
+		Do(gomock.Any()).
 		Return(mockResponse, nil).
 		Times(1)
 
@@ -798,7 +798,7 @@ func TestClient_Send_Error(t *testing.T) {
 
 				// Expect HTTP GET to return response body
 				ts.mockHTTP.EXPECT().
-					Get(gomock.Any()).
+					Do(gomock.Any()).
 					Return(mockResponse, nil).Times(1)
 
 				// Expect io.ReadAll to return response body
@@ -859,7 +859,7 @@ func TestClient_Send_Error(t *testing.T) {
 
 				// Expect HTTP GET to return response body
 				ts.mockHTTP.EXPECT().
-					Get(gomock.Any()).
+					Do(gomock.Any()).
 					Return(mockResponse, nil).
 					Times(1)
 
@@ -929,7 +929,7 @@ func TestClient_Send_Error(t *testing.T) {
 
 				// Expect HTTP GET to return response body
 				ts.mockHTTP.EXPECT().
-					Get(gomock.Any()).
+					Do(gomock.Any()).
 					Return(mockResponse, nil).
 					Times(1)
 
@@ -1005,7 +1005,7 @@ func TestClient_Send_Error(t *testing.T) {
 
 				// Expect HTTP GET to return response body
 				ts.mockHTTP.EXPECT().
-					Get(gomock.Any()).
+					Do(gomock.Any()).
 					Return(mockResponse, nil).
 					Times(1)
 
@@ -1086,7 +1086,7 @@ func TestClient_Send_Error(t *testing.T) {
 
 				// Expect HTTP GET to return response body
 				ts.mockHTTP.EXPECT().
-					Get(gomock.Any()).
+					Do(gomock.Any()).
 					Return(mockResponse, nil).
 					Times(1)
 
@@ -1188,7 +1188,7 @@ func TestClient_Send_Error(t *testing.T) {
 
 				// Expect HTTP GET to return response body
 				ts.mockHTTP.EXPECT().
-					Get(gomock.Any()).
+					Do(gomock.Any()).
 					Return(mockResponse, nil).
 					Times(1)
 
@@ -1296,7 +1296,7 @@ func TestClient_Send_Error(t *testing.T) {
 
 				// Expect HTTP GET to return response body
 				ts.mockHTTP.EXPECT().
-					Get(gomock.Any()).
+					Do(gomock.Any()).
 					Return(mockResponse, nil).
 					Times(1)
 
@@ -1433,7 +1433,7 @@ func TestClient_Send_Async(t *testing.T) {
 
 	// Setup initialization expectations
 	ts.mockHTTP.EXPECT().
-		Get(gomock.Any()).
+		Do(gomock.Any()).
 		Return(mockResponse, nil).
 		Times(1)
 
@@ -1678,7 +1678,7 @@ func TestClient_Close_Success(t *testing.T) {
 
 	// Setup initialization expectations
 	ts.mockHTTP.EXPECT().
-		Get(gomock.Any()).
+		Do(gomock.Any()).
 		Return(mockResponse, nil).
 		Times(1)
 
@@ -1755,7 +1755,7 @@ func TestClient_Close_Error(t *testing.T) {
 
 	// Setup initialization expectations
 	ts.mockHTTP.EXPECT().
-		Get(gomock.Any()).
+		Do(gomock.Any()).
 		Return(mockResponse, nil).
 		Times(1)
 

--- a/components/feral-controld/cdp/page_navigation_url_test.go
+++ b/components/feral-controld/cdp/page_navigation_url_test.go
@@ -8,9 +8,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/feral-file/ffos-user/components/feral-controld/cdp"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/feral-file/ffos-user/components/feral-controld/cdp"
 )
 
 func TestPageNavigationURL_Success(t *testing.T) {

--- a/components/feral-controld/cdp/page_navigation_url_test.go
+++ b/components/feral-controld/cdp/page_navigation_url_test.go
@@ -2,6 +2,7 @@ package cdp_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -139,4 +140,33 @@ func TestPageNavigationURL_ContextCanceled(t *testing.T) {
 
 	_, err := ts.client.PageNavigationURL(ctx)
 	assert.ErrorContains(t, err, context.Canceled.Error(), fmt.Sprintf("expected context canceled, got %v", err))
+}
+
+func TestPageNavigationURL_HTTPGetError(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	ts.mockHTTP.EXPECT().Get(gomock.Any()).Return(nil, errors.New("connection refused")).Times(1)
+
+	_, err := ts.client.PageNavigationURL(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch debug targets")
+}
+
+func TestPageNavigationURL_ReadAllError(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	responseBody := `[]`
+	mockResponse := &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(responseBody)),
+	}
+
+	ts.mockHTTP.EXPECT().Get(gomock.Any()).Return(mockResponse, nil).Times(1)
+	ts.mockIO.EXPECT().ReadAll(mockResponse.Body).Return(nil, errors.New("read failed")).Times(1)
+
+	_, err := ts.client.PageNavigationURL(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read targets")
 }

--- a/components/feral-controld/cdp/page_navigation_url_test.go
+++ b/components/feral-controld/cdp/page_navigation_url_test.go
@@ -26,7 +26,7 @@ func TestPageNavigationURL_Success(t *testing.T) {
 		Body:       io.NopCloser(strings.NewReader(responseBody)),
 	}
 
-	ts.mockHTTP.EXPECT().Get(gomock.Any()).Return(mockResponse, nil).Times(1)
+	ts.mockHTTP.EXPECT().Do(gomock.Any()).Return(mockResponse, nil).Times(1)
 	ts.mockIO.EXPECT().ReadAll(mockResponse.Body).Return(bodyBytes, nil).Times(1)
 	ts.mockJSON.EXPECT().
 		Unmarshal(bodyBytes, gomock.Any()).
@@ -64,7 +64,7 @@ func TestPageNavigationURL_NoPageTarget(t *testing.T) {
 		Body:       io.NopCloser(strings.NewReader(responseBody)),
 	}
 
-	ts.mockHTTP.EXPECT().Get(gomock.Any()).Return(mockResponse, nil).Times(1)
+	ts.mockHTTP.EXPECT().Do(gomock.Any()).Return(mockResponse, nil).Times(1)
 	ts.mockIO.EXPECT().ReadAll(mockResponse.Body).Return(bodyBytes, nil).Times(1)
 	ts.mockJSON.EXPECT().
 		Unmarshal(bodyBytes, gomock.Any()).
@@ -101,7 +101,7 @@ func TestPageNavigationURL_MultiplePageTargets(t *testing.T) {
 		Body:       io.NopCloser(strings.NewReader(responseBody)),
 	}
 
-	ts.mockHTTP.EXPECT().Get(gomock.Any()).Return(mockResponse, nil).Times(1)
+	ts.mockHTTP.EXPECT().Do(gomock.Any()).Return(mockResponse, nil).Times(1)
 	ts.mockIO.EXPECT().ReadAll(mockResponse.Body).Return(bodyBytes, nil).Times(1)
 	ts.mockJSON.EXPECT().
 		Unmarshal(bodyBytes, gomock.Any()).
@@ -146,7 +146,7 @@ func TestPageNavigationURL_HTTPGetError(t *testing.T) {
 	ts := setup(t)
 	defer ts.teardown()
 
-	ts.mockHTTP.EXPECT().Get(gomock.Any()).Return(nil, errors.New("connection refused")).Times(1)
+	ts.mockHTTP.EXPECT().Do(gomock.Any()).Return(nil, errors.New("connection refused")).Times(1)
 
 	_, err := ts.client.PageNavigationURL(context.Background())
 	assert.Error(t, err)
@@ -163,7 +163,7 @@ func TestPageNavigationURL_ReadAllError(t *testing.T) {
 		Body:       io.NopCloser(strings.NewReader(responseBody)),
 	}
 
-	ts.mockHTTP.EXPECT().Get(gomock.Any()).Return(mockResponse, nil).Times(1)
+	ts.mockHTTP.EXPECT().Do(gomock.Any()).Return(mockResponse, nil).Times(1)
 	ts.mockIO.EXPECT().ReadAll(mockResponse.Body).Return(nil, errors.New("read failed")).Times(1)
 
 	_, err := ts.client.PageNavigationURL(context.Background())

--- a/components/feral-controld/cdp/page_navigation_url_test.go
+++ b/components/feral-controld/cdp/page_navigation_url_test.go
@@ -1,0 +1,141 @@
+package cdp_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/feral-file/ffos-user/components/feral-controld/cdp"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPageNavigationURL_Success(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	responseBody := `[{"type":"page","title":"QR Onboarding","url":"file:///opt/feral/ui/launcher/index.html?step=qr","webSocketDebuggerUrl":"ws://localhost:9222/devtools/page/1"}]`
+	bodyBytes := []byte(responseBody)
+	mockResponse := &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(responseBody)),
+	}
+
+	ts.mockHTTP.EXPECT().Get(gomock.Any()).Return(mockResponse, nil).Times(1)
+	ts.mockIO.EXPECT().ReadAll(mockResponse.Body).Return(bodyBytes, nil).Times(1)
+	ts.mockJSON.EXPECT().
+		Unmarshal(bodyBytes, gomock.Any()).
+		DoAndReturn(func(data []byte, v interface{}) error {
+			targets := v.(*[]struct {
+				Type string `json:"type"`
+				URL  string `json:"url"`
+			})
+			*targets = []struct {
+				Type string `json:"type"`
+				URL  string `json:"url"`
+			}{
+				{
+					Type: "page",
+					URL:  "file:///opt/feral/ui/launcher/index.html?step=qr",
+				},
+			}
+			return nil
+		}).
+		Times(1)
+
+	url, err := ts.client.PageNavigationURL(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, "file:///opt/feral/ui/launcher/index.html?step=qr", url)
+}
+
+func TestPageNavigationURL_NoPageTarget(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	responseBody := `[{"type":"worker","title":"","url":"","webSocketDebuggerUrl":"ws://localhost:9222/devtools/page/2"}]`
+	bodyBytes := []byte(responseBody)
+	mockResponse := &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(responseBody)),
+	}
+
+	ts.mockHTTP.EXPECT().Get(gomock.Any()).Return(mockResponse, nil).Times(1)
+	ts.mockIO.EXPECT().ReadAll(mockResponse.Body).Return(bodyBytes, nil).Times(1)
+	ts.mockJSON.EXPECT().
+		Unmarshal(bodyBytes, gomock.Any()).
+		DoAndReturn(func(data []byte, v interface{}) error {
+			targets := v.(*[]struct {
+				Type string `json:"type"`
+				URL  string `json:"url"`
+			})
+			*targets = []struct {
+				Type string `json:"type"`
+				URL  string `json:"url"`
+			}{
+				{
+					Type: "worker",
+					URL:  "",
+				},
+			}
+			return nil
+		}).
+		Times(1)
+
+	_, err := ts.client.PageNavigationURL(context.Background())
+	assert.ErrorIs(t, err, cdp.ErrNoPageTargetFound)
+}
+
+func TestPageNavigationURL_MultiplePageTargets(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	responseBody := `[{"type":"page","title":"A","url":"https://a","webSocketDebuggerUrl":"ws://localhost:9222/devtools/page/1"},{"type":"page","title":"B","url":"https://b","webSocketDebuggerUrl":"ws://localhost:9222/devtools/page/2"}]`
+	bodyBytes := []byte(responseBody)
+	mockResponse := &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(responseBody)),
+	}
+
+	ts.mockHTTP.EXPECT().Get(gomock.Any()).Return(mockResponse, nil).Times(1)
+	ts.mockIO.EXPECT().ReadAll(mockResponse.Body).Return(bodyBytes, nil).Times(1)
+	ts.mockJSON.EXPECT().
+		Unmarshal(bodyBytes, gomock.Any()).
+		DoAndReturn(func(data []byte, v interface{}) error {
+			targets := v.(*[]struct {
+				Type string `json:"type"`
+				URL  string `json:"url"`
+			})
+			*targets = []struct {
+				Type string `json:"type"`
+				URL  string `json:"url"`
+			}{
+				{
+					Type: "page",
+					URL:  "https://a",
+				},
+				{
+					Type: "page",
+					URL:  "https://b",
+				},
+			}
+			return nil
+		}).
+		Times(1)
+
+	_, err := ts.client.PageNavigationURL(context.Background())
+	assert.ErrorIs(t, err, cdp.ErrMultiplePageTargetsFound)
+}
+
+func TestPageNavigationURL_ContextCanceled(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := ts.client.PageNavigationURL(ctx)
+	assert.ErrorContains(t, err, context.Canceled.Error(), fmt.Sprintf("expected context canceled, got %v", err))
+}

--- a/components/feral-controld/main.go
+++ b/components/feral-controld/main.go
@@ -379,7 +379,7 @@ func initializeApp(
 	dbusClient := godbus.NewDBusClient(context, logger, dbusName, dbusOpts...)
 
 	// DeviceStatus
-	deviceStatus := status.NewDeviceStatus(json, os, exec, httpClient, io)
+	deviceStatus := status.NewDeviceStatus(json, os, exec, httpClient, io, cdp)
 
 	// DDC panel
 	ddcPanel := ddc.New(exec, logger)

--- a/components/feral-controld/mocks/cdp.go
+++ b/components/feral-controld/mocks/cdp.go
@@ -89,6 +89,21 @@ func (mr *MockCDPMockRecorder) NoLogSend(method, params interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NoLogSend", reflect.TypeOf((*MockCDP)(nil).NoLogSend), method, params)
 }
 
+// PageNavigationURL mocks base method.
+func (m *MockCDP) PageNavigationURL(ctx context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PageNavigationURL", ctx)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PageNavigationURL indicates an expected call of PageNavigationURL.
+func (mr *MockCDPMockRecorder) PageNavigationURL(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PageNavigationURL", reflect.TypeOf((*MockCDP)(nil).PageNavigationURL), ctx)
+}
+
 // Send mocks base method.
 func (m *MockCDP) Send(method string, params map[string]interface{}) (interface{}, error) {
 	m.ctrl.T.Helper()

--- a/components/feral-controld/status/device_status.go
+++ b/components/feral-controld/status/device_status.go
@@ -89,7 +89,8 @@ func (d deviceStatus) GetStatus(ctx context.Context) (*DeviceStatusResponse, err
 	var isMuted *bool
 	var displayURL *string
 
-	// Chrome UI document URL (same source as CDP target listing; does not require player JS).
+	// Chrome UI document URL. This is the same target listing the poller uses, but
+	// keeping it here preserves the response shape for direct CMD_DEVICE_STATUS calls.
 	g.Go(func() error {
 		if d.cdp == nil {
 			return nil

--- a/components/feral-controld/status/device_status.go
+++ b/components/feral-controld/status/device_status.go
@@ -69,9 +69,7 @@ type DeviceStatusResponse struct {
 	MACInfo             map[string]string `json:"macInfo,omitempty"`
 	Volume              *int              `json:"volume,omitempty"`
 	IsMuted             *bool             `json:"isMuted,omitempty"`
-	// DisplayURL is the Chrome top-frame URL for the sole "page" debug target (DevTools /json).
-	// Best-effort: omitted when CDP cannot resolve the URL.
-	DisplayURL *string `json:"displayURL,omitempty"`
+	DisplayURL          *string           `json:"displayURL,omitempty"` // Chrome UI URL from CDP; omitted if unavailable.
 }
 
 // GetStatus retrieves comprehensive device status information

--- a/components/feral-controld/status/device_status.go
+++ b/components/feral-controld/status/device_status.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/feral-file/ffos-user/components/feral-controld/cdp"
 	"github.com/feral-file/ffos-user/components/feral-controld/config"
 	constants "github.com/feral-file/ffos-user/components/feral-controld/constant"
 	"github.com/feral-file/ffos-user/components/feral-controld/wrapper"
@@ -34,6 +35,7 @@ type deviceStatus struct {
 	exec       wrapper.Exec
 	httpClient wrapper.HTTPClient
 	io         wrapper.IO
+	cdp        cdp.CDP
 	cache      *versionCache
 }
 
@@ -43,6 +45,7 @@ func NewDeviceStatus(
 	exec wrapper.Exec,
 	httpClient wrapper.HTTPClient,
 	io wrapper.IO,
+	cdpClient cdp.CDP,
 ) DeviceStatus {
 	return &deviceStatus{
 		json:       json,
@@ -50,6 +53,7 @@ func NewDeviceStatus(
 		exec:       exec,
 		httpClient: httpClient,
 		io:         io,
+		cdp:        cdpClient,
 		cache:      &versionCache{},
 	}
 }
@@ -65,6 +69,9 @@ type DeviceStatusResponse struct {
 	MACInfo             map[string]string `json:"macInfo,omitempty"`
 	Volume              *int              `json:"volume,omitempty"`
 	IsMuted             *bool             `json:"isMuted,omitempty"`
+	// DisplayURL is the Chrome top-frame URL for the sole "page" debug target (DevTools /json).
+	// Best-effort: omitted when CDP cannot resolve the URL.
+	DisplayURL *string `json:"displayURL,omitempty"`
 }
 
 // GetStatus retrieves comprehensive device status information
@@ -80,6 +87,21 @@ func (d deviceStatus) GetStatus(ctx context.Context) (*DeviceStatusResponse, err
 	var analyticsDisabled, betaFeaturesEnabled bool
 	var volume *int
 	var isMuted *bool
+	var displayURL *string
+
+	// Chrome UI document URL (same source as CDP target listing; does not require player JS).
+	g.Go(func() error {
+		if d.cdp == nil {
+			return nil
+		}
+		u, err := d.cdp.PageNavigationURL(ctx)
+		if err != nil {
+			// Non-fatal: device status remains useful without this field.
+			return nil
+		}
+		displayURL = &u
+		return nil
+	})
 
 	// Get screen rotation
 	g.Go(func() error {
@@ -246,6 +268,7 @@ func (d deviceStatus) GetStatus(ctx context.Context) (*DeviceStatusResponse, err
 	response.BetaFeaturesEnabled = betaFeaturesEnabled
 	response.Volume = volume
 	response.IsMuted = isMuted
+	response.DisplayURL = displayURL
 
 	// Get MAC info from config (fetched once at startup)
 	cfg := config.Get()

--- a/components/feral-controld/status/device_status_test.go
+++ b/components/feral-controld/status/device_status_test.go
@@ -1,0 +1,114 @@
+package status_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/feral-file/ffos-user/components/feral-controld/cdp"
+	constants "github.com/feral-file/ffos-user/components/feral-controld/constant"
+	"github.com/feral-file/ffos-user/components/feral-controld/mocks"
+	"github.com/feral-file/ffos-user/components/feral-controld/status"
+	"github.com/feral-file/ffos-user/components/feral-controld/wrapper"
+)
+
+// testFF1ConfigJSON is minimal valid ff1-config for GetStatus (no network latest-version fetch).
+const testFF1ConfigJSON = `{"version":"1.0.0","branch":"","endpoint":""}`
+
+func expectDeviceStatusOSMocks(t *testing.T, mockOS *mocks.MockOS) {
+	t.Helper()
+	mockOS.EXPECT().ReadFile(constants.SCREEN_ORIENTATION_FILE).Return(nil, os.ErrNotExist).Times(1)
+	mockOS.EXPECT().ReadFile(constants.FF1_CONFIG_FILE).Return([]byte(testFF1ConfigJSON), nil).Times(1)
+	mockOS.EXPECT().ReadFile("/home/feralfile/.state/analytics-toggle-off").Return(nil, os.ErrNotExist).Times(1)
+	mockOS.EXPECT().ReadFile("/home/feralfile/.state/beta-features-toggle-on").Return(nil, os.ErrNotExist).Times(1)
+	mockOS.EXPECT().IsNotExist(gomock.Any()).DoAndReturn(func(err error) bool { return os.IsNotExist(err) }).AnyTimes()
+}
+
+func expectDeviceStatusExecMocks(t *testing.T, mockExec *mocks.MockExec, nmcliCmd, pamCmd *mocks.MockExecCmd) {
+	t.Helper()
+	mockExec.EXPECT().
+		CommandContext(gomock.Any(), "nmcli", "-t", "-f", "NAME,DEVICE,STATE", "connection", "show", "--active").
+		Return(nmcliCmd).
+		Times(1)
+	nmcliCmd.EXPECT().Output().Return(nil, errors.New("nmcli unavailable")).Times(1)
+
+	mockExec.EXPECT().CommandContext(gomock.Any(), "pamixer", gomock.Any()).Return(pamCmd).Times(2)
+	pamCmd.EXPECT().Output().Return(nil, errors.New("pamixer unavailable")).Times(2)
+}
+
+func TestGetStatus_DisplayURL_FromCDP(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockOS := mocks.NewMockOS(ctrl)
+	mockExec := mocks.NewMockExec(ctrl)
+	mockHTTP := mocks.NewMockHTTPClient(ctrl)
+	mockIO := mocks.NewMockIO(ctrl)
+	mockCDP := mocks.NewMockCDP(ctrl)
+	nmcliCmd := mocks.NewMockExecCmd(ctrl)
+	pamCmd := mocks.NewMockExecCmd(ctrl)
+
+	expectDeviceStatusOSMocks(t, mockOS)
+	expectDeviceStatusExecMocks(t, mockExec, nmcliCmd, pamCmd)
+
+	wantURL := "file:///opt/feral/ui/launcher/index.html?step=qr"
+	mockCDP.EXPECT().PageNavigationURL(gomock.Any()).Return(wantURL, nil).Times(1)
+
+	ds := status.NewDeviceStatus(wrapper.NewJSON(), mockOS, mockExec, mockHTTP, mockIO, mockCDP)
+	resp, err := ds.GetStatus(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.DisplayURL)
+	assert.Equal(t, wantURL, *resp.DisplayURL)
+}
+
+func TestGetStatus_DisplayURL_OmittedOnCDPError(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockOS := mocks.NewMockOS(ctrl)
+	mockExec := mocks.NewMockExec(ctrl)
+	mockHTTP := mocks.NewMockHTTPClient(ctrl)
+	mockIO := mocks.NewMockIO(ctrl)
+	mockCDP := mocks.NewMockCDP(ctrl)
+	nmcliCmd := mocks.NewMockExecCmd(ctrl)
+	pamCmd := mocks.NewMockExecCmd(ctrl)
+
+	expectDeviceStatusOSMocks(t, mockOS)
+	expectDeviceStatusExecMocks(t, mockExec, nmcliCmd, pamCmd)
+
+	mockCDP.EXPECT().PageNavigationURL(gomock.Any()).Return("", errors.New("no debug targets")).Times(1)
+
+	ds := status.NewDeviceStatus(wrapper.NewJSON(), mockOS, mockExec, mockHTTP, mockIO, mockCDP)
+	resp, err := ds.GetStatus(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.DisplayURL)
+}
+
+func TestGetStatus_DisplayURL_OmittedWhenCDPNil(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockOS := mocks.NewMockOS(ctrl)
+	mockExec := mocks.NewMockExec(ctrl)
+	mockHTTP := mocks.NewMockHTTPClient(ctrl)
+	mockIO := mocks.NewMockIO(ctrl)
+	nmcliCmd := mocks.NewMockExecCmd(ctrl)
+	pamCmd := mocks.NewMockExecCmd(ctrl)
+
+	expectDeviceStatusOSMocks(t, mockOS)
+	expectDeviceStatusExecMocks(t, mockExec, nmcliCmd, pamCmd)
+
+	var nilCDP cdp.CDP
+	ds := status.NewDeviceStatus(wrapper.NewJSON(), mockOS, mockExec, mockHTTP, mockIO, nilCDP)
+	resp, err := ds.GetStatus(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.DisplayURL)
+}

--- a/components/feral-controld/status/status.go
+++ b/components/feral-controld/status/status.go
@@ -35,6 +35,7 @@ const (
 
 type PlayerStatus struct {
 	Command        string                      `json:"castCommand,omitempty"`
+	DisplayURL     *string                     `json:"displayURL,omitempty"`
 	PlaylistURL    *string                     `json:"playlistURL,omitempty"`
 	Playlist       *dp1.Playlist               `json:"playlist,omitempty"`
 	Index          *int                        `json:"index"`
@@ -365,6 +366,14 @@ func (s *poller) FetchPlayerStatus(ctx context.Context) (*PlayerStatus, error) {
 	if err := s.json.Unmarshal(jsonMessage, playerStatus); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal message: %w", err)
 	}
+
+	uiPageURL, err := s.cdp.PageNavigationURL(ctx)
+	if err != nil {
+		// UI URL enrichment is best effort; player status remains valid without it.
+		s.logger.Debug("Skipping UI page URL enrichment for player status", zap.Error(err))
+		return playerStatus, nil
+	}
+	playerStatus.DisplayURL = &uiPageURL
 
 	return playerStatus, nil
 }

--- a/components/feral-controld/status/status.go
+++ b/components/feral-controld/status/status.go
@@ -35,7 +35,6 @@ const (
 
 type PlayerStatus struct {
 	Command        string                      `json:"castCommand,omitempty"`
-	DisplayURL     *string                     `json:"displayURL,omitempty"`
 	PlaylistURL    *string                     `json:"playlistURL,omitempty"`
 	Playlist       *dp1.Playlist               `json:"playlist,omitempty"`
 	Index          *int                        `json:"index"`
@@ -366,14 +365,6 @@ func (s *poller) FetchPlayerStatus(ctx context.Context) (*PlayerStatus, error) {
 	if err := s.json.Unmarshal(jsonMessage, playerStatus); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal message: %w", err)
 	}
-
-	uiPageURL, err := s.cdp.PageNavigationURL(ctx)
-	if err != nil {
-		// UI URL enrichment is best effort; player status remains valid without it.
-		s.logger.Debug("Skipping UI page URL enrichment for player status", zap.Error(err))
-		return playerStatus, nil
-	}
-	playerStatus.DisplayURL = &uiPageURL
 
 	return playerStatus, nil
 }

--- a/components/feral-controld/status/status_test.go
+++ b/components/feral-controld/status/status_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/feral-file/ffos-user/components/feral-controld/ddc"
 	"github.com/feral-file/ffos-user/components/feral-controld/relayer"
+	"github.com/feral-file/ffos-user/components/feral-controld/wrapper"
 )
 
 type fakeRelayer struct {
@@ -238,4 +239,101 @@ func (b *blockingPanelDDC) CollectStatus(ctx context.Context) (*ddc.DdcPanelStat
 
 func (b *blockingPanelDDC) ApplyControl(context.Context, ddc.DdcPanelAction, json.RawMessage) error {
 	return nil
+}
+
+type fakeCDP struct {
+	noLogResult    interface{}
+	noLogErr       error
+	pageURL        string
+	pageURLErr     error
+	noLogSendCalls int
+	pageURLCalls   int
+}
+
+func (f *fakeCDP) Init(context.Context) error { return nil }
+
+func (f *fakeCDP) Send(string, map[string]interface{}) (interface{}, error) { return nil, nil }
+
+func (f *fakeCDP) NoLogSend(string, map[string]interface{}) (interface{}, error) {
+	f.noLogSendCalls++
+	return f.noLogResult, f.noLogErr
+}
+
+func (f *fakeCDP) PageNavigationURL(context.Context) (string, error) {
+	f.pageURLCalls++
+	return f.pageURL, f.pageURLErr
+}
+
+func (f *fakeCDP) Close() {}
+
+func (f *fakeCDP) Initialized() bool { return true }
+
+func TestFetchPlayerStatus_IncludesDisplayURL(t *testing.T) {
+	t.Parallel()
+
+	mockCDP := &fakeCDP{
+		noLogResult: map[string]interface{}{
+			"message": map[string]interface{}{
+				"castCommand": "displayPlaylist",
+				"ok":          true,
+			},
+		},
+		pageURL: "file:///opt/feral/ui/launcher/index.html?step=qr",
+	}
+	p := &poller{
+		cdp:    mockCDP,
+		json:   wrapper.NewJSON(),
+		logger: zap.NewNop(),
+	}
+
+	ctx := context.Background()
+
+	got, err := p.FetchPlayerStatus(ctx)
+	if err != nil {
+		t.Fatalf("FetchPlayerStatus() error = %v", err)
+	}
+	if got == nil || got.DisplayURL == nil {
+		t.Fatalf("FetchPlayerStatus() should include displayURL, got %+v", got)
+	}
+	if *got.DisplayURL != "file:///opt/feral/ui/launcher/index.html?step=qr" {
+		t.Fatalf("displayURL = %q, want %q", *got.DisplayURL, "file:///opt/feral/ui/launcher/index.html?step=qr")
+	}
+	if mockCDP.noLogSendCalls != 1 || mockCDP.pageURLCalls != 1 {
+		t.Fatalf("expected one NoLogSend and one PageNavigationURL call, got %d and %d", mockCDP.noLogSendCalls, mockCDP.pageURLCalls)
+	}
+}
+
+func TestFetchPlayerStatus_DisplayURLBestEffort(t *testing.T) {
+	t.Parallel()
+
+	mockCDP := &fakeCDP{
+		noLogResult: map[string]interface{}{
+			"message": map[string]interface{}{
+				"castCommand": "displayPlaylist",
+				"ok":          true,
+			},
+		},
+		pageURLErr: errors.New("debug targets unavailable"),
+	}
+	p := &poller{
+		cdp:    mockCDP,
+		json:   wrapper.NewJSON(),
+		logger: zap.NewNop(),
+	}
+
+	ctx := context.Background()
+
+	got, err := p.FetchPlayerStatus(ctx)
+	if err != nil {
+		t.Fatalf("FetchPlayerStatus() should keep status success when URL lookup fails, got err %v", err)
+	}
+	if got == nil {
+		t.Fatal("FetchPlayerStatus() returned nil status")
+	}
+	if got.DisplayURL != nil {
+		t.Fatalf("displayURL should be nil when lookup fails, got %q", *got.DisplayURL)
+	}
+	if mockCDP.noLogSendCalls != 1 || mockCDP.pageURLCalls != 1 {
+		t.Fatalf("expected one NoLogSend and one PageNavigationURL call, got %d and %d", mockCDP.noLogSendCalls, mockCDP.pageURLCalls)
+	}
 }

--- a/components/feral-controld/status/status_test.go
+++ b/components/feral-controld/status/status_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/feral-file/ffos-user/components/feral-controld/ddc"
 	"github.com/feral-file/ffos-user/components/feral-controld/relayer"
-	"github.com/feral-file/ffos-user/components/feral-controld/wrapper"
 )
 
 type fakeRelayer struct {
@@ -239,101 +238,4 @@ func (b *blockingPanelDDC) CollectStatus(ctx context.Context) (*ddc.DdcPanelStat
 
 func (b *blockingPanelDDC) ApplyControl(context.Context, ddc.DdcPanelAction, json.RawMessage) error {
 	return nil
-}
-
-type fakeCDP struct {
-	noLogResult    interface{}
-	noLogErr       error
-	pageURL        string
-	pageURLErr     error
-	noLogSendCalls int
-	pageURLCalls   int
-}
-
-func (f *fakeCDP) Init(context.Context) error { return nil }
-
-func (f *fakeCDP) Send(string, map[string]interface{}) (interface{}, error) { return nil, nil }
-
-func (f *fakeCDP) NoLogSend(string, map[string]interface{}) (interface{}, error) {
-	f.noLogSendCalls++
-	return f.noLogResult, f.noLogErr
-}
-
-func (f *fakeCDP) PageNavigationURL(context.Context) (string, error) {
-	f.pageURLCalls++
-	return f.pageURL, f.pageURLErr
-}
-
-func (f *fakeCDP) Close() {}
-
-func (f *fakeCDP) Initialized() bool { return true }
-
-func TestFetchPlayerStatus_IncludesDisplayURL(t *testing.T) {
-	t.Parallel()
-
-	mockCDP := &fakeCDP{
-		noLogResult: map[string]interface{}{
-			"message": map[string]interface{}{
-				"castCommand": "displayPlaylist",
-				"ok":          true,
-			},
-		},
-		pageURL: "file:///opt/feral/ui/launcher/index.html?step=qr",
-	}
-	p := &poller{
-		cdp:    mockCDP,
-		json:   wrapper.NewJSON(),
-		logger: zap.NewNop(),
-	}
-
-	ctx := context.Background()
-
-	got, err := p.FetchPlayerStatus(ctx)
-	if err != nil {
-		t.Fatalf("FetchPlayerStatus() error = %v", err)
-	}
-	if got == nil || got.DisplayURL == nil {
-		t.Fatalf("FetchPlayerStatus() should include displayURL, got %+v", got)
-	}
-	if *got.DisplayURL != "file:///opt/feral/ui/launcher/index.html?step=qr" {
-		t.Fatalf("displayURL = %q, want %q", *got.DisplayURL, "file:///opt/feral/ui/launcher/index.html?step=qr")
-	}
-	if mockCDP.noLogSendCalls != 1 || mockCDP.pageURLCalls != 1 {
-		t.Fatalf("expected one NoLogSend and one PageNavigationURL call, got %d and %d", mockCDP.noLogSendCalls, mockCDP.pageURLCalls)
-	}
-}
-
-func TestFetchPlayerStatus_DisplayURLBestEffort(t *testing.T) {
-	t.Parallel()
-
-	mockCDP := &fakeCDP{
-		noLogResult: map[string]interface{}{
-			"message": map[string]interface{}{
-				"castCommand": "displayPlaylist",
-				"ok":          true,
-			},
-		},
-		pageURLErr: errors.New("debug targets unavailable"),
-	}
-	p := &poller{
-		cdp:    mockCDP,
-		json:   wrapper.NewJSON(),
-		logger: zap.NewNop(),
-	}
-
-	ctx := context.Background()
-
-	got, err := p.FetchPlayerStatus(ctx)
-	if err != nil {
-		t.Fatalf("FetchPlayerStatus() should keep status success when URL lookup fails, got err %v", err)
-	}
-	if got == nil {
-		t.Fatal("FetchPlayerStatus() returned nil status")
-	}
-	if got.DisplayURL != nil {
-		t.Fatalf("displayURL should be nil when lookup fails, got %q", *got.DisplayURL)
-	}
-	if mockCDP.noLogSendCalls != 1 || mockCDP.pageURLCalls != 1 {
-		t.Fatalf("expected one NoLogSend and one PageNavigationURL call, got %d and %d", mockCDP.noLogSendCalls, mockCDP.pageURLCalls)
-	}
 }

--- a/components/feral-controld/status/status_test.go
+++ b/components/feral-controld/status/status_test.go
@@ -59,18 +59,31 @@ func (f *fakeRelayer) Close() {}
 type fakeWS struct {
 	sendAllCalls int
 	sendAllErr   error
+	lastPayload  any
 }
 
 func (f *fakeWS) NewConnection(http.ResponseWriter, *http.Request) (string, error) { return "", nil }
 
 func (f *fakeWS) Send(string, any) error { return nil }
 
-func (f *fakeWS) SendAll(any) error {
+func (f *fakeWS) SendAll(payload any) error {
 	f.sendAllCalls++
+	f.lastPayload = payload
 	return f.sendAllErr
 }
 
 func (f *fakeWS) Close() {}
+
+type fakeDeviceStatus struct {
+	status *DeviceStatusResponse
+	err    error
+	calls  int
+}
+
+func (f *fakeDeviceStatus) GetStatus(context.Context) (*DeviceStatusResponse, error) {
+	f.calls++
+	return f.status, f.err
+}
 
 func TestSendNotification_RelayerCatchesUpAfterReconnect(t *testing.T) {
 	fRelayer := &fakeRelayer{
@@ -131,6 +144,44 @@ func TestSendNotification_RetryRelayerWhenSendFails(t *testing.T) {
 	}
 	if fWS.sendAllCalls != 1 {
 		t.Fatalf("expected websocket dedupe to send once, got %d", fWS.sendAllCalls)
+	}
+}
+
+func TestPollDeviceStatus_SendsDeviceStatus(t *testing.T) {
+	fRelayer := &fakeRelayer{connectedResponses: []bool{true}}
+	fWS := &fakeWS{}
+	fDeviceStatus := &fakeDeviceStatus{
+		status: &DeviceStatusResponse{ScreenRotation: "landscape"},
+	}
+
+	p := &poller{
+		relayer:                 fRelayer,
+		ws:                      fWS,
+		deviceStatus:            fDeviceStatus,
+		logger:                  zap.NewNop(),
+		lastRelayerStatusHashes: make(map[relayer.NotificationType]string),
+		lastWSStatusHashes:      make(map[relayer.NotificationType]string),
+	}
+
+	p.pollDeviceStatus(context.Background())
+
+	if fWS.sendAllCalls != 1 {
+		t.Fatalf("expected one device status send, got %d", fWS.sendAllCalls)
+	}
+	if fDeviceStatus.calls != 1 {
+		t.Fatalf("expected one device status read, got %d", fDeviceStatus.calls)
+	}
+
+	payload, ok := fWS.lastPayload.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected payload to be a map, got %T", fWS.lastPayload)
+	}
+	message, ok := payload["message"].(*DeviceStatusResponse)
+	if !ok {
+		t.Fatalf("expected message to be *DeviceStatusResponse, got %T", payload["message"])
+	}
+	if message.ScreenRotation != "landscape" {
+		t.Fatalf("expected screenRotation to be preserved, got %+v", message.ScreenRotation)
 	}
 }
 

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -110,6 +110,11 @@ All messages are JSON. The message envelope is:
 
 **Command type constants** are defined in `components/feral-controld/commands/types.go`. New remote commands must be added there with a corresponding entry in `deviceCtlCommands` if they require executor handling.
 
+**Relayer outbound notifications (`feral-controld`):** The device periodically pushes JSON notifications over the relayer WebSocket (and local hub clients) with an envelope that includes `notification_type` and a structured `message`. At minimum:
+
+- `player_status` — playback/UI state from Chromium via CDP `checkStatus` (cast command, playlist, pause, etc.). This is not a substitute for hardware or OS-level facts.
+- `device_status` — device-oriented fields assembled by `status.DeviceStatus.GetStatus` (screen rotation, Wi‑Fi name, installed/latest version, volume, feature toggles, MAC info, and best-effort `displayURL`). The `displayURL` field is the top-level URL of the sole Chromium **page** debug target (DevTools `/json`), when exactly one such target exists; it is omitted when the URL cannot be resolved. Consumers that previously read a Chrome document URL from player payloads should use `device_status.message.displayURL` instead.
+
 ### Hub WebSocket protocol (port 1111)
 
 The Hub uses the same JSON command envelope as the relayer. The Hub does not carry `messageID == "system"` messages. A Hub client sends a command; `controld` routes it through the same `commandrouter` as relayer commands.


### PR DESCRIPTION
## Summary

Expose the Chromium top-level document URL for the single **page** debug target (DevTools `/json`) as an optional `displayURL` field on **device status** notifications and `getDeviceStatus` responses. Resolution is best-effort: the field is omitted when the URL cannot be determined (e.g. no page target, multiple page targets, or transport errors).

This keeps playback/UI state in **player status** (`checkStatus`) separate from environment/Chrome surface information on **device status**.

## Linked issue

- https://github.com/feral-file/feralfile-app/issues/2513

## Consumer change (breaking)

Clients that previously expected a Chrome document URL on **player** payloads must read `displayURL` from **device status** (`notification_type`: `device_status`) or the `getDeviceStatus` command response instead.

## Changes

- `cdp.PageNavigationURL`: HTTP GET to `${endpoint}/json`, filter `type == "page"`, require exactly one page target.
- `DeviceStatusResponse.displayURL` (JSON: `displayURL`); populated in `GetStatus` alongside existing device fields (parallel `errgroup` task).
- `main`: pass CDP client into `status.NewDeviceStatus(..., cdp)`.
- Documentation: `docs/api-design.md` (relayer notifications: player vs device, `displayURL` semantics); `components/feral-controld/AGENTS.md` (status package description).
- Tests: `cdp/page_navigation_url_test.go` (success, no page, multiple pages, context canceled, HTTP error, ReadAll error); `status/device_status_test.go` (`package status_test` to avoid import cycles, covers URL present, CDP error, nil CDP).

## Operational notes

- Device status polling (and thus relayer push of `device_status`) runs on the existing poller interval when the relayer is **connected**; there is no navigation event stream—URL updates follow the next successful `GetStatus` / poll. Direct `getDeviceStatus` always runs `GetStatus` when invoked.

## Verification

- `gofmt -s` on touched Go files
- `go test ./...` and `go vet ./...` in `components/feral-controld`
- `golangci-lint run --new-from-rev=HEAD~1 ./...` in `components/feral-controld` (when available locally)