### PR TITLE
chore(controld): artwork refresh cache invalidation

### DIFF
--- a/components/feral-controld/commandrouter/handler.go
+++ b/components/feral-controld/commandrouter/handler.go
@@ -129,6 +129,13 @@ func (h *handler) Process(ctx context.Context, command commands.Command) (interf
 
 		}
 
+		if commandType == commands.CMD_REFRESH_ARTWORK {
+			_, err = h.cdp.Send("Network.clearBrowserCache", map[string]interface{}{})
+			if err != nil {
+				h.logger.Warn("Failed to clear Chromium browser cache before artwork refresh", zap.Error(err))
+			}
+		}
+
 		// Forward to CDP (final, full data)
 		result, err = h.sendCDPRequest(command)
 		if err != nil {

--- a/components/feral-controld/commandrouter/handler_test.go
+++ b/components/feral-controld/commandrouter/handler_test.go
@@ -273,6 +273,35 @@ func TestCommandHandler_Process_DisplayPlaylist_WithPlaylistObject(t *testing.T)
 	assert.Equal(t, cdpResult, result)
 }
 
+func TestCommandHandler_Process_RefreshArtwork(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	command := commands.Command{
+		Type:      commands.CMD_REFRESH_ARTWORK,
+		Arguments: map[string]interface{}{},
+	}
+
+	ts.mockCDP.EXPECT().
+		Send("Network.clearBrowserCache", map[string]interface{}{}).
+		Return(nil, nil).
+		Times(1)
+
+	ts.mockCDP.EXPECT().
+		Send(cdp.METHOD_EVALUATE, gomock.Any()).
+		Return(playerOkResponse(), nil).
+		Times(1)
+
+	ts.mockStatusPoller.EXPECT().
+		ForceRefresh().
+		Times(1)
+
+	result, err := ts.handler.Process(ts.ctx, command)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
 func TestCommandHandler_Process_DisplayPlaylist_WithDynamicQueries(t *testing.T) {
 	ts := setup(t)
 	defer ts.teardown()

--- a/components/feral-controld/commands/types.go
+++ b/components/feral-controld/commands/types.go
@@ -67,6 +67,7 @@ const (
 	CMD_TOGGLE_MUTE              Type = "toggleMute"
 	CMD_SSH_ACCESS               Type = "sshAccess"
 	CMD_DISPLAY_DEFAULT_PLAYLIST Type = "displayDefaultPlaylist"
+	CMD_REFRESH_ARTWORK          Type = "refreshArtwork"
 	// CMD_DDC_PANEL_CONTROL drives the attached panel over DDC via ddcutil (brightness, contrast,
 	// speaker volume, mute, and power). One JSON command type; request body selects the operation.
 	CMD_DDC_PANEL_CONTROL Type = "ddcPanelControl"


### PR DESCRIPTION
Draft PR: FF1-side refresh flow for artwork cache invalidation.

Same changes as the ready-for-review branch; opened as draft for review workflow.

Refs: #148

Made with [Cursor](https://cursor.com)