### PR TITLE
docs: align README with CI verification

### DIFF
--- a/.github/workflows/lint-controld.yaml
+++ b/.github/workflows/lint-controld.yaml
@@ -6,12 +6,14 @@ on:
     paths:
       - 'components/feral-controld/**/*.go'
       - '.golangci.yml'
+      - 'Makefile'
       - 'components/feral-controld/go.mod'
       - 'components/feral-controld/go.sum'
   pull_request:
     paths:
       - 'components/feral-controld/**/*.go'
       - '.golangci.yml'
+      - 'Makefile'
       - 'components/feral-controld/go.mod'
       - 'components/feral-controld/go.sum'
 
@@ -26,9 +28,6 @@ jobs:
   lint:
     name: Lint feral-controld (Go)
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./components/feral-controld
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -40,22 +39,10 @@ jobs:
           cache: true
           cache-dependency-path: components/feral-controld/go.sum
 
-      - name: Install dependencies
-        run: go mod download
-
-      - name: Run go vet
-        run: go vet ./...
-
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v8
-        with:
-          version: v2.4.0
-          working-directory: ./components/feral-controld
-
-      - name: Run go fmt check
+      - name: Install golangci-lint
         run: |
-          if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then
-            echo "Code is not formatted. Please run 'gofmt -s -w .'"
-            gofmt -s -l .
-            exit 1
-          fi
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0
+
+      - name: Run local verification target
+        run: make verify-feral-controld-lint

--- a/.github/workflows/lint-setupd.yaml
+++ b/.github/workflows/lint-setupd.yaml
@@ -9,6 +9,7 @@ on:
       - 'components/feral-setupd/Cargo.lock'
       - 'components/feral-setupd/rustfmt.toml'
       - 'components/feral-setupd/clippy.toml'
+      - 'Makefile'
   pull_request:
     paths:
       - 'components/feral-setupd/src/**'
@@ -16,6 +17,7 @@ on:
       - 'components/feral-setupd/Cargo.lock'
       - 'components/feral-setupd/rustfmt.toml'
       - 'components/feral-setupd/clippy.toml'
+      - 'Makefile'
 
 permissions:
   contents: read
@@ -28,9 +30,6 @@ jobs:
   lint:
     name: Lint feral-setupd (Rust)
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./components/feral-setupd
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -58,11 +57,5 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      - name: Check formatting
-        run: cargo fmt -- --check
-
-      - name: Run clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
-
-      - name: Run cargo check
-        run: cargo check --all-targets --all-features --verbose
+      - name: Run local verification target
+        run: make verify-setupd-lint

--- a/.github/workflows/lint-sys-monitord.yaml
+++ b/.github/workflows/lint-sys-monitord.yaml
@@ -6,12 +6,14 @@ on:
     paths:
       - 'components/feral-sys-monitord/**/*.go'
       - '.golangci.yml'
+      - 'Makefile'
       - 'components/feral-sys-monitord/go.mod'
       - 'components/feral-sys-monitord/go.sum'
   pull_request:
     paths:
       - 'components/feral-sys-monitord/**/*.go'
       - '.golangci.yml'
+      - 'Makefile'
       - 'components/feral-sys-monitord/go.mod'
       - 'components/feral-sys-monitord/go.sum'
 
@@ -26,9 +28,6 @@ jobs:
   lint:
     name: Lint feral-sys-monitord (Go)
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./components/feral-sys-monitord
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -40,22 +39,10 @@ jobs:
           cache: true
           cache-dependency-path: components/feral-sys-monitord/go.sum
 
-      - name: Install dependencies
-        run: go mod download
-
-      - name: Run go vet
-        run: go vet ./...
-
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v8
-        with:
-          version: v2.4.0
-          working-directory: ./components/feral-sys-monitord
-
-      - name: Run go fmt check
+      - name: Install golangci-lint
         run: |
-          if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then
-            echo "Code is not formatted. Please run 'gofmt -s -w .'"
-            gofmt -s -l .
-            exit 1
-          fi
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0
+
+      - name: Run local verification target
+        run: make verify-feral-sys-monitord-lint

--- a/.github/workflows/lint-watchdog.yaml
+++ b/.github/workflows/lint-watchdog.yaml
@@ -6,12 +6,14 @@ on:
     paths:
       - 'components/feral-watchdog/**/*.go'
       - '.golangci.yml'
+      - 'Makefile'
       - 'components/feral-watchdog/go.mod'
       - 'components/feral-watchdog/go.sum'
   pull_request:
     paths:
       - 'components/feral-watchdog/**/*.go'
       - '.golangci.yml'
+      - 'Makefile'
       - 'components/feral-watchdog/go.mod'
       - 'components/feral-watchdog/go.sum'
 
@@ -26,9 +28,6 @@ jobs:
   lint:
     name: Lint feral-watchdog (Go)
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./components/feral-watchdog
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -40,22 +39,10 @@ jobs:
           cache: true
           cache-dependency-path: components/feral-watchdog/go.sum
 
-      - name: Install dependencies
-        run: go mod download
-
-      - name: Run go vet
-        run: go vet ./...
-
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v8
-        with:
-          version: v2.4.0
-          working-directory: ./components/feral-watchdog
-
-      - name: Run go fmt check
+      - name: Install golangci-lint
         run: |
-          if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then
-            echo "Code is not formatted. Please run 'gofmt -s -w .'"
-            gofmt -s -l .
-            exit 1
-          fi
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0
+
+      - name: Run local verification target
+        run: make verify-feral-watchdog-lint

--- a/.github/workflows/test-controld.yaml
+++ b/.github/workflows/test-controld.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'components/feral-controld/**/*.go'
       - '.golangci.yml'
+      - 'Makefile'
       - 'components/feral-controld/go.mod'
       - 'components/feral-controld/go.sum'
   workflow_call:
@@ -26,9 +27,6 @@ jobs:
   test:
     name: Test feral-controld (Go)
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./components/feral-controld
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -40,13 +38,12 @@ jobs:
           cache: true
           cache-dependency-path: components/feral-controld/go.sum
 
-      - name: Install dependencies
-        run: go mod download
+      - name: Run local verification target
+        run: make verify-feral-controld-test
 
-      - name: Run go vet
-        run: go vet ./...
-
-      - name: Run tests with coverage
+      - name: Generate coverage
+        if: ${{ inputs.upload-coverage == true }}
+        working-directory: ./components/feral-controld
         run: go test -v -coverprofile=coverage.out -covermode=atomic $(go list ./... | grep -vE "/mocks|/wrapper")
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/test-setupd.yaml
+++ b/.github/workflows/test-setupd.yaml
@@ -8,6 +8,8 @@ on:
       - 'components/feral-setupd/Cargo.lock'
       - 'components/feral-setupd/rustfmt.toml'
       - 'components/feral-setupd/clippy.toml'
+      - 'Makefile'
+      - 'scripts/test-serve-feral-player.sh'
       - 'users/feralfile/scripts/serve-feral-player.sh'
       - 'users/feralfile/systemd-services/feral-player.service'
       - 'users/feralfile/systemd-services/chromium-kiosk.service'
@@ -31,9 +33,6 @@ jobs:
   test:
     name: Test feral-setupd startup contract
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./components/feral-setupd
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -60,137 +59,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      - name: Run cargo check
-        run: cargo check --verbose
-
-      - name: Run feral-player static smoke test
-        run: |
-          set -euo pipefail
-
-          script_under_test="../../users/feralfile/scripts/serve-feral-player.sh"
-          unit_file="../../users/feralfile/systemd-services/feral-player.service"
-
-          fail() {
-            echo "test-serve-feral-player: $*" >&2
-            exit 1
-          }
-
-          assert_contains() {
-            local file="$1"
-            local needle="$2"
-            grep -Fq -- "$needle" "$file" || fail "expected '$needle' in $file"
-          }
-
-          assert_contains "$unit_file" "Type=notify"
-          assert_contains "$unit_file" "NotifyAccess=all"
-
-          tmp_dir="$(mktemp -d)"
-          trap 'rm -rf "$tmp_dir"' EXIT
-
-          missing_root="$tmp_dir/missing"
-          output_file="$tmp_dir/missing-tree.log"
-
-          if FF_PLAYER_STATIC_ROOT="$missing_root" \
-            bash "$script_under_test" >"$output_file" 2>&1; then
-            fail "expected missing bundle to fail"
-          fi
-
-          assert_contains "$output_file" "serve-feral-player: missing static tree"
-
-          root_dir="$tmp_dir/feral-player"
-          bin_dir="$tmp_dir/bin"
-          pid_file="$tmp_dir/darkhttpd.pid"
-          notify_file="$tmp_dir/ready.signal"
-          notify_args="$tmp_dir/notify.args"
-          output_file="$tmp_dir/ready.log"
-          port="18080"
-
-          mkdir -p "$root_dir" "$bin_dir"
-          cat >"$root_dir/index.html" <<'EOF'
-          <html><body>FF player static smoke test</body></html>
-          EOF
-
-          cat >"$bin_dir/darkhttpd" <<'EOF'
-          #!/usr/bin/env bash
-          set -euo pipefail
-
-          root="${1:?missing root}"
-          shift
-
-          port=""
-          addr="127.0.0.1"
-          while (($#)); do
-            case "$1" in
-              --port)
-                port="${2:?missing port}"
-                shift 2
-                ;;
-              --addr)
-                addr="${2:?missing addr}"
-                shift 2
-                ;;
-              *)
-                shift
-                ;;
-            esac
-          done
-
-          printf '%s\n' "$$" >"${FF_PLAYER_TEST_PID_FILE:?missing pid file}"
-
-          while [[ ! -f "${FF_PLAYER_TEST_NOTIFY_FILE:?missing notify file}" ]]; do
-            sleep 0.1
-          done
-          EOF
-
-          cat >"$bin_dir/curl" <<'EOF'
-          #!/usr/bin/env bash
-          set -euo pipefail
-
-          url=""
-          for arg in "$@"; do
-            case "$arg" in
-              http://*)
-                url="$arg"
-                ;;
-            esac
-          done
-
-          expected_url="http://127.0.0.1:${FF_PLAYER_TEST_PORT:?missing port}/"
-          if [[ "$url" == "$expected_url" && -f "${FF_PLAYER_TEST_ROOT:?missing root}/index.html" && -f "${FF_PLAYER_TEST_PID_FILE:?missing pid file}" ]]; then
-            exit 0
-          fi
-
-          exit 1
-          EOF
-
-          cat >"$bin_dir/systemd-notify" <<'EOF'
-          #!/usr/bin/env bash
-          set -euo pipefail
-
-          printf '%s\n' "$*" >"${FF_PLAYER_TEST_NOTIFY_ARGS:?missing notify args file}"
-          : >"${FF_PLAYER_TEST_NOTIFY_FILE:?missing notify file}"
-          EOF
-
-          chmod +x "$bin_dir/darkhttpd" "$bin_dir/curl" "$bin_dir/systemd-notify"
-
-          FF_PLAYER_STATIC_ROOT="$root_dir" \
-          FF_PLAYER_STATIC_PORT="$port" \
-          FF_PLAYER_READY_TIMEOUT_SECONDS=5 \
-          FF_PLAYER_TEST_ROOT="$root_dir" \
-          FF_PLAYER_TEST_PORT="$port" \
-          FF_PLAYER_TEST_PID_FILE="$pid_file" \
-          FF_PLAYER_TEST_NOTIFY_FILE="$notify_file" \
-          FF_PLAYER_TEST_NOTIFY_ARGS="$notify_args" \
-          PATH="$bin_dir:$PATH" \
-          bash "$script_under_test" >"$output_file" 2>&1
-
-          assert_contains "$notify_args" "--ready"
-          assert_contains "$notify_args" "feral-player static ready on http://127.0.0.1:${port}/"
-          [ -s "$pid_file" ] || fail "expected fake darkhttpd pid file to be written"
-
-          echo "test-serve-feral-player: OK"
+      - name: Run local verification target
+        run: make verify-setupd-test
 
       - name: Run tests with coverage
+        if: ${{ inputs.upload-coverage == true }}
+        working-directory: ./components/feral-setupd
         run: |
           # Pin tarpaulin: unversioned `cargo install` resolves to releases whose deps
           # can require a newer rustc than this job (e.g. cargo-platform 0.3.3 needs 1.91+).

--- a/.github/workflows/test-sys-monitord.yaml
+++ b/.github/workflows/test-sys-monitord.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'components/feral-sys-monitord/**/*.go'
       - '.golangci.yml'
+      - 'Makefile'
       - 'components/feral-sys-monitord/go.mod'
       - 'components/feral-sys-monitord/go.sum'
   workflow_call:
@@ -26,9 +27,6 @@ jobs:
   test:
     name: Test feral-sys-monitord (Go)
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./components/feral-sys-monitord
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -40,13 +38,12 @@ jobs:
           cache: true
           cache-dependency-path: components/feral-sys-monitord/go.sum
 
-      - name: Install dependencies
-        run: go mod download
+      - name: Run local verification target
+        run: make verify-feral-sys-monitord-test
 
-      - name: Run go vet
-        run: go vet ./...
-
-      - name: Run tests with coverage
+      - name: Generate coverage
+        if: ${{ inputs.upload-coverage == true }}
+        working-directory: ./components/feral-sys-monitord
         run: go test -v -coverprofile=coverage.out -covermode=atomic $(go list ./... | grep -vE "/mocks|/wrapper")
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/test-watchdog.yaml
+++ b/.github/workflows/test-watchdog.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'components/feral-watchdog/**/*.go'
       - '.golangci.yml'
+      - 'Makefile'
       - 'components/feral-watchdog/go.mod'
       - 'components/feral-watchdog/go.sum'
   workflow_call:
@@ -26,9 +27,6 @@ jobs:
   test:
     name: Test feral-watchdog (Go)
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./components/feral-watchdog
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -40,13 +38,12 @@ jobs:
           cache: true
           cache-dependency-path: components/feral-watchdog/go.sum
 
-      - name: Install dependencies
-        run: go mod download
+      - name: Run local verification target
+        run: make verify-feral-watchdog-test
 
-      - name: Run go vet
-        run: go vet ./...
-
-      - name: Run tests with coverage
+      - name: Generate coverage
+        if: ${{ inputs.upload-coverage == true }}
+        working-directory: ./components/feral-watchdog
         run: go test -v -coverprofile=coverage.out -covermode=atomic $(go list ./... | grep -vE "/mocks|/wrapper")
 
       - name: Upload coverage to Codecov

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,77 @@
+.PHONY: verify
+verify: verify-go verify-setupd
+
+.PHONY: verify-go
+verify-go: \
+	verify-feral-controld \
+	verify-feral-sys-monitord \
+	verify-feral-watchdog
+
+.PHONY: verify-feral-controld
+verify-feral-controld: verify-feral-controld-lint verify-feral-controld-test
+
+.PHONY: verify-feral-sys-monitord
+verify-feral-sys-monitord: verify-feral-sys-monitord-lint verify-feral-sys-monitord-test
+
+.PHONY: verify-feral-watchdog
+verify-feral-watchdog: verify-feral-watchdog-lint verify-feral-watchdog-test
+
+.PHONY: verify-feral-controld-lint
+verify-feral-controld-lint:
+	@$(MAKE) verify-go-component-lint GO_COMPONENT=feral-controld
+
+.PHONY: verify-feral-sys-monitord-lint
+verify-feral-sys-monitord-lint:
+	@$(MAKE) verify-go-component-lint GO_COMPONENT=feral-sys-monitord
+
+.PHONY: verify-feral-watchdog-lint
+verify-feral-watchdog-lint:
+	@$(MAKE) verify-go-component-lint GO_COMPONENT=feral-watchdog
+
+.PHONY: verify-feral-controld-test
+verify-feral-controld-test:
+	@$(MAKE) verify-go-component-test GO_COMPONENT=feral-controld
+
+.PHONY: verify-feral-sys-monitord-test
+verify-feral-sys-monitord-test:
+	@$(MAKE) verify-go-component-test GO_COMPONENT=feral-sys-monitord
+
+.PHONY: verify-feral-watchdog-test
+verify-feral-watchdog-test:
+	@$(MAKE) verify-go-component-test GO_COMPONENT=feral-watchdog
+
+.PHONY: verify-go-component-lint
+verify-go-component-lint:
+	@test -n "$(GO_COMPONENT)" || (echo "GO_COMPONENT is required" >&2; exit 2)
+	@cd components/$(GO_COMPONENT) && go mod download
+	@cd components/$(GO_COMPONENT) && go vet ./...
+	@cd components/$(GO_COMPONENT) && golangci-lint run ./...
+	@cd components/$(GO_COMPONENT) && \
+		unformatted="$$(gofmt -s -l .)"; \
+		if [ -n "$$unformatted" ]; then \
+			echo "Code is not formatted. Please run 'gofmt -s -w .'"; \
+			echo "$$unformatted"; \
+			exit 1; \
+		fi
+
+.PHONY: verify-go-component-test
+verify-go-component-test:
+	@test -n "$(GO_COMPONENT)" || (echo "GO_COMPONENT is required" >&2; exit 2)
+	@cd components/$(GO_COMPONENT) && go mod download
+	@cd components/$(GO_COMPONENT) && go vet ./...
+	@cd components/$(GO_COMPONENT) && go test -v $$(go list ./... | grep -vE "/mocks|/wrapper")
+
+.PHONY: verify-setupd
+verify-setupd: verify-setupd-lint verify-setupd-test
+
+.PHONY: verify-setupd-lint
+verify-setupd-lint:
+	@cd components/feral-setupd && cargo fmt -- --check
+	@cd components/feral-setupd && cargo clippy --all-targets --all-features -- -D warnings
+	@cd components/feral-setupd && cargo check --all-targets --all-features --verbose
+
+.PHONY: verify-setupd-test
+verify-setupd-test:
+	@cd components/feral-setupd && cargo check --verbose
+	@./scripts/test-serve-feral-player.sh
+	@cd components/feral-setupd && cargo test --all-targets --all-features --verbose

--- a/README.md
+++ b/README.md
@@ -198,11 +198,43 @@ ffos-user/develop → ffos build → R2/{develop}/
 - Prefix with component name for clarity
 - Example: `feral-controld: add heartbeat functionality`
 
-## Setup Instructions
+## Verification
 
-### No GitHub Actions Required
+This repository has active GitHub Actions for component lint and test coverage. Build orchestration for full FFOS images still lives in the FFOS repository, but component source and user-data contracts are verified here.
 
-This repository is purely for source code and data. All build logic is handled by the FFOS repository.
+Run the repo-wide local verification path from the repository root:
+
+```bash
+make verify
+```
+
+`make verify` is non-mutating for repository files and runs the same component checks that CI calls:
+
+- Go components: `go mod download`, `go vet ./...`, `golangci-lint run ./...`, `gofmt -s -l .`, and `go test -v` for `feral-controld`, `feral-sys-monitord`, and `feral-watchdog`.
+- Rust component: `cargo fmt -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo check`, and `cargo test` for `feral-setupd`.
+- Startup contract smoke test: `scripts/test-serve-feral-player.sh` validates the `serve-feral-player.sh` static bundle failure path and systemd notify readiness contract with temporary fakes.
+
+Local prerequisites are Go 1.23.5 or compatible, `golangci-lint` v2.4.0, Rust 1.88.0 with `rustfmt` and `clippy`, and the system libraries needed by `feral-setupd` (`libdbus-1-dev` and `pkg-config` on Ubuntu).
+
+GitHub Actions are split by component and purpose:
+
+- `lint-controld.yaml`, `lint-sys-monitord.yaml`, and `lint-watchdog.yaml` run the matching Go lint targets.
+- `lint-setupd.yaml` runs the Rust lint target.
+- `test-controld.yaml`, `test-sys-monitord.yaml`, `test-watchdog.yaml`, and `test-setupd.yaml` run the matching test targets.
+- `testing.yaml` reuses the component test workflows on pushes to `main` and `develop` and enables Codecov upload.
+
+CI intentionally has one parity exception: push coverage jobs generate coverage artifacts for Codecov after the shared `make verify-*` test target passes. That coverage step is CI-only and is not part of the non-mutating local verification path.
+
+Focused local targets are available when working on one component:
+
+```bash
+make verify-feral-controld
+make verify-feral-sys-monitord
+make verify-feral-watchdog
+make verify-setupd
+```
+
+Each target prints deterministic command output suitable for local review or agent evaluation; the smoke test also emits `test-serve-feral-player: OK` when the service-state contract passes.
 
 ### Sync components to a device (dev)
 

--- a/scripts/test-serve-feral-player.sh
+++ b/scripts/test-serve-feral-player.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+script_under_test="$repo_root/users/feralfile/scripts/serve-feral-player.sh"
+unit_file="$repo_root/users/feralfile/systemd-services/feral-player.service"
+
+fail() {
+  echo "test-serve-feral-player: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  grep -Fq -- "$needle" "$file" || fail "expected '$needle' in $file"
+}
+
+assert_contains "$unit_file" "Type=notify"
+assert_contains "$unit_file" "NotifyAccess=all"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+missing_root="$tmp_dir/missing"
+output_file="$tmp_dir/missing-tree.log"
+
+if FF_PLAYER_STATIC_ROOT="$missing_root" \
+  bash "$script_under_test" >"$output_file" 2>&1; then
+  fail "expected missing bundle to fail"
+fi
+
+assert_contains "$output_file" "serve-feral-player: missing static tree"
+
+root_dir="$tmp_dir/feral-player"
+bin_dir="$tmp_dir/bin"
+pid_file="$tmp_dir/darkhttpd.pid"
+notify_file="$tmp_dir/ready.signal"
+notify_args="$tmp_dir/notify.args"
+output_file="$tmp_dir/ready.log"
+port="18080"
+
+mkdir -p "$root_dir" "$bin_dir"
+cat >"$root_dir/index.html" <<'EOF'
+<html><body>FF player static smoke test</body></html>
+EOF
+
+cat >"$bin_dir/darkhttpd" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="${1:?missing root}"
+shift
+
+port=""
+addr="127.0.0.1"
+while (($#)); do
+  case "$1" in
+    --port)
+      port="${2:?missing port}"
+      shift 2
+      ;;
+    --addr)
+      addr="${2:?missing addr}"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+printf '%s\n' "$$" >"${FF_PLAYER_TEST_PID_FILE:?missing pid file}"
+
+while [[ ! -f "${FF_PLAYER_TEST_NOTIFY_FILE:?missing notify file}" ]]; do
+  sleep 0.1
+done
+EOF
+
+cat >"$bin_dir/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url=""
+for arg in "$@"; do
+  case "$arg" in
+    http://*)
+      url="$arg"
+      ;;
+  esac
+done
+
+expected_url="http://127.0.0.1:${FF_PLAYER_TEST_PORT:?missing port}/"
+if [[ "$url" == "$expected_url" && -f "${FF_PLAYER_TEST_ROOT:?missing root}/index.html" && -f "${FF_PLAYER_TEST_PID_FILE:?missing pid file}" ]]; then
+  exit 0
+fi
+
+exit 1
+EOF
+
+cat >"$bin_dir/systemd-notify" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >"${FF_PLAYER_TEST_NOTIFY_ARGS:?missing notify args file}"
+: >"${FF_PLAYER_TEST_NOTIFY_FILE:?missing notify file}"
+EOF
+
+chmod +x "$bin_dir/darkhttpd" "$bin_dir/curl" "$bin_dir/systemd-notify"
+
+FF_PLAYER_STATIC_ROOT="$root_dir" \
+FF_PLAYER_STATIC_PORT="$port" \
+FF_PLAYER_READY_TIMEOUT_SECONDS=5 \
+FF_PLAYER_TEST_ROOT="$root_dir" \
+FF_PLAYER_TEST_PORT="$port" \
+FF_PLAYER_TEST_PID_FILE="$pid_file" \
+FF_PLAYER_TEST_NOTIFY_FILE="$notify_file" \
+FF_PLAYER_TEST_NOTIFY_ARGS="$notify_args" \
+PATH="$bin_dir:$PATH" \
+bash "$script_under_test" >"$output_file" 2>&1
+
+assert_contains "$notify_args" "--ready"
+assert_contains "$notify_args" "feral-player static ready on http://127.0.0.1:${port}/"
+[ -s "$pid_file" ] || fail "expected fake darkhttpd pid file to be written"
+
+echo "test-serve-feral-player: OK"


### PR DESCRIPTION
Fixes #162

## Problem
The README advertised GitHub Actions status and CI behavior, then later claimed `No GitHub Actions Required`. The repo also lacked one root local verification command that matched the active component lint/test workflows.

## Why It Matters
Agents and maintainers need one dependable, non-mutating verification path before shipping changes. Contradictory docs make it unclear whether Actions are authoritative, and duplicated workflow commands drift from local checks over time.

## Acceptance Checks
- README documents the active component lint/test workflows and removes the contradictory `No GitHub Actions Required` claim.
- `make verify` provides a repo-wide local verification path with focused component targets.
- Existing Actions call the shared Makefile targets, with Codecov coverage generation documented as the CI-only parity exception.

## Validation Run
- `PATH="/tmp/ffos-user-verify-bin:$PATH" make verify-go` passed after installing `golangci-lint` v2.4.0 into `/tmp/ffos-user-verify-bin`.
- `./scripts/test-serve-feral-player.sh` passed.
- `make verify-setupd` blocked locally: `cargo`/Rust toolchain is not installed, and `pkg-config --exists dbus-1` reports `dbus-1-missing`.
- `git diff --check` passed.
- `bash -n scripts/test-serve-feral-player.sh` passed.
- Workflow YAML parsed with Ruby `YAML.load_file` for all `.github/workflows/*.{yml,yaml}` files.
- `make -n verify` passed.
