### PR TITLE
FF1: scheduled sleep and wake in feral-controld

### DIFF
--- a/components/feral-controld/commands/types.go
+++ b/components/feral-controld/commands/types.go
@@ -38,6 +38,9 @@ var deviceCtlCommands = map[Type]bool{
 	CMD_SSH_ACCESS:                 true,
 	CMD_DDC_PANEL_CONTROL:          true,
 	CMD_DDC_PANEL_STATUS:           true,
+	CMD_SET_SLEEP_SCHEDULE:         true,
+	CMD_SLEEP_NOW:                  true,
+	CMD_WAKE_NOW:                   true,
 }
 
 type Command struct {
@@ -76,6 +79,10 @@ const (
 	CMD_SSH_ACCESS                 Type = "sshAccess"
 	CMD_DISPLAY_DEFAULT_PLAYLIST   Type = "displayDefaultPlaylist"
 	CMD_REFRESH_ARTWORK            Type = "refreshArtwork"
+	CMD_SET_SLEEP_SCHEDULE         Type = "setSleepSchedule"
+	CMD_SLEEP_NOW                  Type = "sleepNow"
+	CMD_WAKE_NOW                   Type = "wakeNow"
+	CMD_SET_SLEEP_MODE             Type = "setSleepMode"
 	// CMD_DDC_PANEL_CONTROL drives the attached panel over DDC via ddcutil (brightness, contrast,
 	// speaker volume, mute, and power). One JSON command type; request body selects the operation.
 	CMD_DDC_PANEL_CONTROL Type = "ddcPanelControl"

--- a/components/feral-controld/constant/constant.go
+++ b/components/feral-controld/constant/constant.go
@@ -6,6 +6,7 @@ const (
 
 	SCREEN_ORIENTATION_FILE = "/home/feralfile/.state/screen-orientation"
 	STATE_FILE              = "/home/feralfile/.state/controld.state"
+	SLEEP_SCHEDULE_FILE     = "/home/feralfile/.state/sleep-schedule.json"
 	CONFIG_FILE             = "/home/feralfile/.config/controld.json"
 
 	SSH_AUTHORIZED_KEYS_FILE = "/home/feralfile/.ssh/authorized_keys"

--- a/components/feral-controld/devicectl/executor.go
+++ b/components/feral-controld/devicectl/executor.go
@@ -82,6 +82,10 @@ type executor struct {
 	clock wrapper.Clock
 
 	panelDDC ddc.PanelDDC
+
+	sleepScheduleWakeCh chan struct{}
+	sleepScheduleMu     sync.Mutex
+	sleepScheduleRun    bool
 }
 
 func New(
@@ -180,6 +184,12 @@ func (e *executor) Execute(ctx context.Context, cmd commands.Command) (interface
 		result, err = e.ddcPanelControl(ctx, bytes)
 	case commands.CMD_DDC_PANEL_STATUS:
 		result, err = e.ddcPanelStatus(ctx, bytes)
+	case commands.CMD_SET_SLEEP_SCHEDULE:
+		result, err = e.setSleepSchedule(ctx, bytes)
+	case commands.CMD_SLEEP_NOW:
+		result, err = e.sleepNow(ctx)
+	case commands.CMD_WAKE_NOW:
+		result, err = e.wakeNow(ctx)
 	default:
 		return nil, fmt.Errorf("invalid command: %s", cmd)
 	}

--- a/components/feral-controld/devicectl/sleep_schedule.go
+++ b/components/feral-controld/devicectl/sleep_schedule.go
@@ -221,14 +221,14 @@ func (e *executor) applySleepTransition(ctx context.Context, state sleepschedule
 		return err
 	}
 
-	if e.panelDDC != nil {
-		if err := e.applyFfpPowerState(ctx, state); err != nil {
-			e.logger.Warn("Failed to align FFP power with sleep state",
-				zap.Error(err),
-				zap.String("state", string(state)),
-				zap.String("reason", reason))
-		}
-	}
+	// if e.panelDDC != nil {
+	// 	if err := e.applyFfpPowerState(ctx, state); err != nil {
+	// 		e.logger.Warn("Failed to align FFP power with sleep state",
+	// 			zap.Error(err),
+	// 			zap.String("state", string(state)),
+	// 			zap.String("reason", reason))
+	// 	}
+	// }
 
 	if e.statusPoller != nil {
 		e.statusPoller.ForceRefresh()

--- a/components/feral-controld/devicectl/sleep_schedule.go
+++ b/components/feral-controld/devicectl/sleep_schedule.go
@@ -137,7 +137,7 @@ func (e *executor) setSleepSchedule(ctx context.Context, args []byte) (interface
 		return nil, err
 	}
 	if record == nil {
-		record = &sleepschedule.Record{}
+		record = sleepschedule.DefaultRecord()
 	}
 
 	record.Enabled = cmd.Enabled

--- a/components/feral-controld/devicectl/sleep_schedule.go
+++ b/components/feral-controld/devicectl/sleep_schedule.go
@@ -1,0 +1,277 @@
+package devicectl
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/feral-file/ffos-user/components/feral-controld/cdp"
+	"github.com/feral-file/ffos-user/components/feral-controld/commands"
+	"github.com/feral-file/ffos-user/components/feral-controld/ddc"
+	"github.com/feral-file/ffos-user/components/feral-controld/sleepschedule"
+)
+
+type sleepScheduleCommand struct {
+	Enabled   bool   `json:"enabled"`
+	SleepTime string `json:"sleepTime"`
+	WakeTime  string `json:"wakeTime"`
+}
+
+func StartSleepScheduleLoop(ctx context.Context, exec Executor, logger *zap.Logger) {
+	runner, ok := exec.(interface{ startSleepScheduleLoop(context.Context) })
+	if !ok {
+		logger.Warn("Executor does not support sleep schedule loop")
+		return
+	}
+	runner.startSleepScheduleLoop(ctx)
+}
+
+func (e *executor) startSleepScheduleLoop(ctx context.Context) {
+	e.sleepScheduleMu.Lock()
+	defer e.sleepScheduleMu.Unlock()
+
+	if e.sleepScheduleRun {
+		return
+	}
+
+	e.sleepScheduleRun = true
+	e.sleepScheduleWakeCh = make(chan struct{}, 1)
+
+	go e.runSleepScheduleLoop(ctx)
+}
+
+func (e *executor) runSleepScheduleLoop(ctx context.Context) {
+	for {
+		record, err := sleepschedule.Load(e.os, e.json)
+		if err != nil {
+			e.logger.Error("Failed to load sleep schedule", zap.Error(err))
+			if !e.waitForSleepScheduleSignal(ctx, 30*time.Second) {
+				return
+			}
+			continue
+		}
+
+		now := e.clock.Now()
+		normalized, changed := sleepschedule.Normalize(record, now)
+		if changed {
+			if err := sleepschedule.Save(e.os, e.json, normalized); err != nil {
+				e.logger.Error("Failed to persist normalized sleep schedule", zap.Error(err))
+			}
+		}
+
+		status, _ := sleepschedule.EffectiveStatus(now, normalized)
+		if err := e.applySleepTransition(ctx, status.CurrentState, "schedule-loop"); err != nil {
+			e.logger.Error("Failed to apply sleep schedule transition",
+				zap.Error(err),
+				zap.String("state", string(status.CurrentState)))
+		}
+
+		if status.NextTransitionAt == nil {
+			if !e.waitForSleepScheduleSignal(ctx, 0) {
+				return
+			}
+			continue
+		}
+
+		waitFor := time.Until(*status.NextTransitionAt)
+		if waitFor < 0 {
+			waitFor = 0
+		}
+		if !e.waitForSleepScheduleSignal(ctx, waitFor) {
+			return
+		}
+	}
+}
+
+func (e *executor) waitForSleepScheduleSignal(ctx context.Context, waitFor time.Duration) bool {
+	if e.sleepScheduleWakeCh == nil {
+		return false
+	}
+
+	if waitFor == 0 {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-e.sleepScheduleWakeCh:
+			return true
+		}
+	}
+
+	timer := time.NewTimer(waitFor)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-e.sleepScheduleWakeCh:
+		return true
+	case <-timer.C:
+		return true
+	}
+}
+
+func (e *executor) wakeSleepScheduleLoop() {
+	e.sleepScheduleMu.Lock()
+	defer e.sleepScheduleMu.Unlock()
+
+	if e.sleepScheduleWakeCh == nil {
+		return
+	}
+
+	select {
+	case e.sleepScheduleWakeCh <- struct{}{}:
+	default:
+	}
+}
+
+func (e *executor) setSleepSchedule(ctx context.Context, args []byte) (interface{}, error) {
+	var cmd sleepScheduleCommand
+	if err := e.json.Unmarshal(args, &cmd); err != nil {
+		return nil, fmt.Errorf("invalid arguments: %w", err)
+	}
+
+	record, err := sleepschedule.Load(e.os, e.json)
+	if err != nil {
+		return nil, err
+	}
+	if record == nil {
+		record = &sleepschedule.Record{}
+	}
+
+	record.Enabled = cmd.Enabled
+	if cmd.SleepTime != "" {
+		record.SleepTime = cmd.SleepTime
+	}
+	if cmd.WakeTime != "" {
+		record.WakeTime = cmd.WakeTime
+	}
+
+	if !record.Enabled {
+		record.OverrideState = nil
+		record.OverrideUntil = nil
+	}
+
+	if err := sleepschedule.Save(e.os, e.json, record); err != nil {
+		return nil, err
+	}
+
+	now := e.clock.Now()
+	status, _ := sleepschedule.EffectiveStatus(now, record)
+	if err := e.applySleepTransition(ctx, status.CurrentState, "schedule-update"); err != nil {
+		return nil, err
+	}
+
+	e.wakeSleepScheduleLoop()
+	return map[string]any{
+		"ok":            true,
+		"sleepSchedule": status,
+	}, nil
+}
+
+func (e *executor) sleepNow(ctx context.Context) (interface{}, error) {
+	return e.applyManualSleepOverride(ctx, sleepschedule.StateSleeping)
+}
+
+func (e *executor) wakeNow(ctx context.Context) (interface{}, error) {
+	return e.applyManualSleepOverride(ctx, sleepschedule.StateAwake)
+}
+
+func (e *executor) applyManualSleepOverride(ctx context.Context, state sleepschedule.State) (interface{}, error) {
+	record, err := sleepschedule.Load(e.os, e.json)
+	if err != nil {
+		return nil, err
+	}
+
+	now := e.clock.Now()
+	var updated *sleepschedule.Record
+	switch state {
+	case sleepschedule.StateSleeping:
+		updated, err = sleepschedule.ManualSleep(record, now)
+	case sleepschedule.StateAwake:
+		updated, err = sleepschedule.ManualWake(record, now)
+	default:
+		err = fmt.Errorf("unsupported manual sleep override state %q", state)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if err := sleepschedule.Save(e.os, e.json, updated); err != nil {
+		return nil, err
+	}
+
+	status, _ := sleepschedule.EffectiveStatus(now, updated)
+	if err := e.applySleepTransition(ctx, state, "manual-override"); err != nil {
+		return nil, err
+	}
+
+	e.wakeSleepScheduleLoop()
+	return map[string]any{
+		"ok":            true,
+		"sleepSchedule": status,
+	}, nil
+}
+
+func (e *executor) applySleepTransition(ctx context.Context, state sleepschedule.State, reason string) error {
+	// Keep FF1 sleep mode and FFP panel power changes in one transition helper so
+	// schedule ticks and manual overrides cannot drift into separate control paths.
+	if err := e.applyPlayerSleepMode(ctx, state == sleepschedule.StateSleeping); err != nil {
+		return err
+	}
+
+	if e.panelDDC != nil {
+		if err := e.applyFfpPowerState(ctx, state); err != nil {
+			e.logger.Warn("Failed to align FFP power with sleep state",
+				zap.Error(err),
+				zap.String("state", string(state)),
+				zap.String("reason", reason))
+		}
+	}
+
+	if e.statusPoller != nil {
+		e.statusPoller.ForceRefresh()
+	}
+
+	return nil
+}
+
+func (e *executor) applyPlayerSleepMode(ctx context.Context, sleepMode bool) error {
+	if e.cdp == nil {
+		return fmt.Errorf("cdp client is not configured")
+	}
+
+	command := commands.Command{
+		Type: commands.CMD_SET_SLEEP_MODE,
+		Arguments: map[string]any{
+			"sleepMode": sleepMode,
+		},
+	}
+	payload, err := command.JSON()
+	if err != nil {
+		return fmt.Errorf("marshal setSleepMode payload: %w", err)
+	}
+
+	_, err = e.cdp.Send(cdp.METHOD_EVALUATE, map[string]any{
+		"expression": fmt.Sprintf("window.handleCDPRequest(%s)", string(payload)),
+	})
+	if err != nil {
+		return fmt.Errorf("send setSleepMode command to player: %w", err)
+	}
+	return nil
+}
+
+func (e *executor) applyFfpPowerState(ctx context.Context, state sleepschedule.State) error {
+	var powerState string
+	switch state {
+	case sleepschedule.StateSleeping:
+		powerState = string(ddc.DdcPowerStandby)
+	case sleepschedule.StateAwake:
+		powerState = string(ddc.DdcPowerOn)
+	default:
+		return fmt.Errorf("unsupported sleep state %q", state)
+	}
+
+	return e.panelDDC.ApplyControl(ctx, ddc.DdcPanelActionPower, []byte(fmt.Sprintf("%q", powerState)))
+}

--- a/components/feral-controld/devicectl/sleep_schedule.go
+++ b/components/feral-controld/devicectl/sleep_schedule.go
@@ -61,7 +61,7 @@ func (e *executor) runSleepScheduleLoop(ctx context.Context) {
 			}
 		}
 
-		status, _ := sleepschedule.EffectiveStatus(now, normalized)
+		status, _ := sleepschedule.EffectiveStatus(now, normalized, sleepschedule.LoadSystemTimezone(e.os))
 		if err := e.applySleepTransition(ctx, status.CurrentState, "schedule-loop"); err != nil {
 			e.logger.Error("Failed to apply sleep schedule transition",
 				zap.Error(err),
@@ -158,7 +158,7 @@ func (e *executor) setSleepSchedule(ctx context.Context, args []byte) (interface
 	}
 
 	now := e.clock.Now()
-	status, _ := sleepschedule.EffectiveStatus(now, record)
+	status, _ := sleepschedule.EffectiveStatus(now, record, sleepschedule.LoadSystemTimezone(e.os))
 	if err := e.applySleepTransition(ctx, status.CurrentState, "schedule-update"); err != nil {
 		return nil, err
 	}
@@ -188,9 +188,9 @@ func (e *executor) applyManualSleepOverride(ctx context.Context, state sleepsche
 	var updated *sleepschedule.Record
 	switch state {
 	case sleepschedule.StateSleeping:
-		updated, err = sleepschedule.ManualSleep(record, now)
+		updated, err = sleepschedule.ManualSleep(record, now, sleepschedule.LoadSystemTimezone(e.os))
 	case sleepschedule.StateAwake:
-		updated, err = sleepschedule.ManualWake(record, now)
+		updated, err = sleepschedule.ManualWake(record, now, sleepschedule.LoadSystemTimezone(e.os))
 	default:
 		err = fmt.Errorf("unsupported manual sleep override state %q", state)
 	}
@@ -202,7 +202,7 @@ func (e *executor) applyManualSleepOverride(ctx context.Context, state sleepsche
 		return nil, err
 	}
 
-	status, _ := sleepschedule.EffectiveStatus(now, updated)
+	status, _ := sleepschedule.EffectiveStatus(now, updated, sleepschedule.LoadSystemTimezone(e.os))
 	if err := e.applySleepTransition(ctx, state, "manual-override"); err != nil {
 		return nil, err
 	}

--- a/components/feral-controld/main.go
+++ b/components/feral-controld/main.go
@@ -253,6 +253,8 @@ func (app *app) run(ctx context.Context, conf *config.Config) error {
 	go app.StatusPoller.Start(ctx)
 	defer app.StatusPoller.Stop()
 
+	devicectl.StartSleepScheduleLoop(ctx, app.Executor, app.Logger)
+
 	// send ready notification to systemd
 	sent, err := app.Daemon.SdNotify(false, go_daemon.SdNotifyReady)
 	if err != nil {

--- a/components/feral-controld/sleepschedule/schedule.go
+++ b/components/feral-controld/sleepschedule/schedule.go
@@ -17,12 +17,6 @@ const (
 	StateSleeping State = "sleeping"
 )
 
-// Record holds the persisted sleep schedule configuration.
-// SleepTime and WakeTime are wall-clock strings in "HH:MM" format and are
-// always interpreted as UTC. The daemon pins time.Now() to UTC so that
-// schedule behaviour is independent of the system timezone configured on
-// the device. Callers (e.g. the Flutter app) must send and display these
-// values in UTC, converting to/from local time on the client side.
 type Record struct {
 	Enabled       bool       `json:"enabled"`
 	SleepTime     string     `json:"sleepTime,omitempty"`

--- a/components/feral-controld/sleepschedule/schedule.go
+++ b/components/feral-controld/sleepschedule/schedule.go
@@ -15,6 +15,12 @@ type State string
 const (
 	StateAwake    State = "awake"
 	StateSleeping State = "sleeping"
+
+	// DefaultSleepTime and DefaultWakeTime pre-fill the record when
+	// sleep-schedule.json is missing or empty; EffectiveStatus ignores the
+	// window until enabled is true. HH:MM uses the caller's time.Location().
+	DefaultSleepTime = "22:00"
+	DefaultWakeTime  = "07:30"
 )
 
 type Record struct {
@@ -67,7 +73,11 @@ func (c ClockTime) OnDay(t time.Time) time.Time {
 }
 
 func DefaultRecord() *Record {
-	return &Record{}
+	return &Record{
+		Enabled:   false,
+		SleepTime: DefaultSleepTime,
+		WakeTime:  DefaultWakeTime,
+	}
 }
 
 func Validate(record *Record) error {

--- a/components/feral-controld/sleepschedule/schedule.go
+++ b/components/feral-controld/sleepschedule/schedule.go
@@ -2,6 +2,7 @@ package sleepschedule
 
 import (
 	"fmt"
+	stdsys "os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -69,20 +70,38 @@ func (c ClockTime) Format() string {
 	return fmt.Sprintf("%02d:%02d", c.Hour, c.Minute)
 }
 
-// LoadSystemTimezone reads the IANA timezone name from /etc/timezone and
-// returns the corresponding Location. This bypasses time.Local, which Go
-// caches once at process start: if feral-controld starts before the device
-// timezone is configured (e.g. during initial setup), time.Local stays UTC
-// for the entire process lifetime even after /etc/localtime is later set.
-// Falls back to time.Local when /etc/timezone is absent or unreadable.
+// LoadSystemTimezone returns the device's current local timezone, bypassing
+// Go's process-level time.Local cache. time.Local is read once at process
+// start; if feral-controld starts before the timezone is configured, it stays
+// UTC for the lifetime of that process even after /etc/localtime is updated.
+//
+// Resolution order:
+//  1. /etc/timezone — plain IANA name, present on Debian/Ubuntu.
+//  2. /etc/localtime symlink — present on all Linux distros; target path
+//     encodes the IANA name as /usr/share/zoneinfo/<name>.
+//  3. time.Local — last resort if neither file is readable.
 func LoadSystemTimezone(os wrapper.OS) *time.Location {
-	data, err := os.ReadFile("/etc/timezone")
-	if err == nil {
-		name := strings.TrimSpace(string(data))
-		if loc, err := time.LoadLocation(name); err == nil {
-			return loc
+	// /etc/timezone (Debian/Ubuntu style — plain text IANA name)
+	if data, err := os.ReadFile("/etc/timezone"); err == nil {
+		if name := strings.TrimSpace(string(data)); name != "" {
+			if loc, err := time.LoadLocation(name); err == nil {
+				return loc
+			}
 		}
 	}
+
+	// /etc/localtime is a symlink → /usr/share/zoneinfo/<name>.
+	// Reading the symlink target is always fresh: it reflects whatever
+	// timedatectl / setup wrote, regardless of when this process started.
+	if target, err := stdsys.Readlink("/etc/localtime"); err == nil {
+		const zonePrefix = "/usr/share/zoneinfo/"
+		if strings.HasPrefix(target, zonePrefix) {
+			if loc, err := time.LoadLocation(target[len(zonePrefix):]); err == nil {
+				return loc
+			}
+		}
+	}
+
 	return time.Local
 }
 

--- a/components/feral-controld/sleepschedule/schedule.go
+++ b/components/feral-controld/sleepschedule/schedule.go
@@ -18,7 +18,8 @@ const (
 
 	// DefaultSleepTime and DefaultWakeTime pre-fill the record when
 	// sleep-schedule.json is missing or empty; EffectiveStatus ignores the
-	// window until enabled is true. HH:MM uses the caller's time.Location().
+	// window until enabled is true. HH:MM is anchored to the timezone
+	// returned by LoadSystemTimezone, not the Go process-level time.Local.
 	DefaultSleepTime = "22:00"
 	DefaultWakeTime  = "07:30"
 )
@@ -68,8 +69,29 @@ func (c ClockTime) Format() string {
 	return fmt.Sprintf("%02d:%02d", c.Hour, c.Minute)
 }
 
-func (c ClockTime) OnDay(t time.Time) time.Time {
-	return time.Date(t.Year(), t.Month(), t.Day(), c.Hour, c.Minute, 0, 0, t.Location())
+// LoadSystemTimezone reads the IANA timezone name from /etc/timezone and
+// returns the corresponding Location. This bypasses time.Local, which Go
+// caches once at process start: if feral-controld starts before the device
+// timezone is configured (e.g. during initial setup), time.Local stays UTC
+// for the entire process lifetime even after /etc/localtime is later set.
+// Falls back to time.Local when /etc/timezone is absent or unreadable.
+func LoadSystemTimezone(os wrapper.OS) *time.Location {
+	data, err := os.ReadFile("/etc/timezone")
+	if err == nil {
+		name := strings.TrimSpace(string(data))
+		if loc, err := time.LoadLocation(name); err == nil {
+			return loc
+		}
+	}
+	return time.Local
+}
+
+// OnDay anchors the clock time to the calendar date of t, interpreted in loc.
+// loc is separate from t so a UTC clock can still express "07:00 in the
+// device's local timezone" — both concerns stay explicit at the call site.
+func (c ClockTime) OnDay(t time.Time, loc *time.Location) time.Time {
+	tLoc := t.In(loc)
+	return time.Date(tLoc.Year(), tLoc.Month(), tLoc.Day(), c.Hour, c.Minute, 0, 0, loc)
 }
 
 func DefaultRecord() *Record {
@@ -149,7 +171,11 @@ func Save(os wrapper.OS, json wrapper.JSON, record *Record) error {
 	return nil
 }
 
-func EffectiveStatus(now time.Time, record *Record) (*Status, bool) {
+// EffectiveStatus derives the current sleep state from record at now.
+// loc must be the device's local timezone (from LoadSystemTimezone); it is
+// used to anchor HH:MM wall-clock times to concrete instants. Keeping loc
+// separate from now allows a UTC clock to coexist with a local schedule.
+func EffectiveStatus(now time.Time, record *Record, loc *time.Location) (*Status, bool) {
 	record, changed := Normalize(record, now)
 	if record == nil {
 		record = DefaultRecord()
@@ -183,13 +209,13 @@ func EffectiveStatus(now time.Time, record *Record) (*Status, bool) {
 		return status, changed
 	}
 
-	if isSleepingAt(now, sleepTime, wakeTime) {
+	if isSleepingAt(now, sleepTime, wakeTime, loc) {
 		status.CurrentState = StateSleeping
-		status.NextTransitionAt = timePtr(nextOccurrence(now, wakeTime))
+		status.NextTransitionAt = timePtr(nextOccurrence(now, wakeTime, loc))
 		return status, changed
 	}
 
-	status.NextTransitionAt = timePtr(nextOccurrence(now, sleepTime))
+	status.NextTransitionAt = timePtr(nextOccurrence(now, sleepTime, loc))
 	return status, changed
 }
 
@@ -207,15 +233,15 @@ func Normalize(record *Record, now time.Time) (*Record, bool) {
 	return &normalized, true
 }
 
-func ManualSleep(record *Record, now time.Time) (*Record, error) {
-	return applyOverride(record, now, StateSleeping)
+func ManualSleep(record *Record, now time.Time, loc *time.Location) (*Record, error) {
+	return applyOverride(record, now, StateSleeping, loc)
 }
 
-func ManualWake(record *Record, now time.Time) (*Record, error) {
-	return applyOverride(record, now, StateAwake)
+func ManualWake(record *Record, now time.Time, loc *time.Location) (*Record, error) {
+	return applyOverride(record, now, StateAwake, loc)
 }
 
-func applyOverride(record *Record, now time.Time, state State) (*Record, error) {
+func applyOverride(record *Record, now time.Time, state State, loc *time.Location) (*Record, error) {
 	record, _ = Normalize(record, now)
 	if record == nil {
 		record = DefaultRecord()
@@ -237,9 +263,9 @@ func applyOverride(record *Record, now time.Time, state State) (*Record, error) 
 
 		switch state {
 		case StateSleeping:
-			updated.OverrideUntil = timePtr(nextOccurrence(now, wakeTime))
+			updated.OverrideUntil = timePtr(nextOccurrence(now, wakeTime, loc))
 		case StateAwake:
-			updated.OverrideUntil = timePtr(nextOccurrence(now, sleepTime))
+			updated.OverrideUntil = timePtr(nextOccurrence(now, sleepTime, loc))
 		default:
 			return nil, fmt.Errorf("unknown override state %q", state)
 		}
@@ -248,17 +274,17 @@ func applyOverride(record *Record, now time.Time, state State) (*Record, error) 
 	return &updated, nil
 }
 
-func nextOccurrence(now time.Time, clockTime ClockTime) time.Time {
-	candidate := clockTime.OnDay(now)
+func nextOccurrence(now time.Time, clockTime ClockTime, loc *time.Location) time.Time {
+	candidate := clockTime.OnDay(now, loc)
 	if !candidate.After(now) {
 		return candidate.Add(24 * time.Hour)
 	}
 	return candidate
 }
 
-func isSleepingAt(now time.Time, sleepTime, wakeTime ClockTime) bool {
-	sleepToday := sleepTime.OnDay(now)
-	wakeToday := wakeTime.OnDay(now)
+func isSleepingAt(now time.Time, sleepTime, wakeTime ClockTime, loc *time.Location) bool {
+	sleepToday := sleepTime.OnDay(now, loc)
+	wakeToday := wakeTime.OnDay(now, loc)
 
 	if sleepToday.Before(wakeToday) {
 		return !now.Before(sleepToday) && now.Before(wakeToday)

--- a/components/feral-controld/sleepschedule/schedule.go
+++ b/components/feral-controld/sleepschedule/schedule.go
@@ -1,0 +1,266 @@
+package sleepschedule
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	constants "github.com/feral-file/ffos-user/components/feral-controld/constant"
+	"github.com/feral-file/ffos-user/components/feral-controld/wrapper"
+)
+
+type State string
+
+const (
+	StateAwake    State = "awake"
+	StateSleeping State = "sleeping"
+)
+
+type Record struct {
+	Enabled       bool       `json:"enabled"`
+	SleepTime     string     `json:"sleepTime,omitempty"`
+	WakeTime      string     `json:"wakeTime,omitempty"`
+	OverrideState *State     `json:"overrideState,omitempty"`
+	OverrideUntil *time.Time `json:"overrideUntil,omitempty"`
+}
+
+type Status struct {
+	Enabled          bool       `json:"enabled"`
+	SleepTime        string     `json:"sleepTime,omitempty"`
+	WakeTime         string     `json:"wakeTime,omitempty"`
+	CurrentState     State      `json:"currentState"`
+	OverrideState    *State     `json:"overrideState,omitempty"`
+	OverrideUntil    *time.Time `json:"overrideUntil,omitempty"`
+	NextTransitionAt *time.Time `json:"nextTransitionAt,omitempty"`
+}
+
+type ClockTime struct {
+	Hour   int
+	Minute int
+}
+
+func ParseClockTime(raw string) (ClockTime, error) {
+	trimmed := strings.TrimSpace(raw)
+	parts := strings.Split(trimmed, ":")
+	if len(parts) != 2 {
+		return ClockTime{}, fmt.Errorf("invalid time %q: want HH:MM", raw)
+	}
+
+	var hour, minute int
+	if _, err := fmt.Sscanf(trimmed, "%d:%d", &hour, &minute); err != nil {
+		return ClockTime{}, fmt.Errorf("invalid time %q: %w", raw, err)
+	}
+	if hour < 0 || hour > 23 || minute < 0 || minute > 59 {
+		return ClockTime{}, fmt.Errorf("invalid time %q: hour must be 0-23 and minute 0-59", raw)
+	}
+
+	return ClockTime{Hour: hour, Minute: minute}, nil
+}
+
+func (c ClockTime) Format() string {
+	return fmt.Sprintf("%02d:%02d", c.Hour, c.Minute)
+}
+
+func (c ClockTime) OnDay(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), c.Hour, c.Minute, 0, 0, t.Location())
+}
+
+func DefaultRecord() *Record {
+	return &Record{}
+}
+
+func Validate(record *Record) error {
+	if record == nil {
+		return fmt.Errorf("sleep schedule is required")
+	}
+	if !record.Enabled {
+		return nil
+	}
+
+	sleepTime, err := ParseClockTime(record.SleepTime)
+	if err != nil {
+		return err
+	}
+	wakeTime, err := ParseClockTime(record.WakeTime)
+	if err != nil {
+		return err
+	}
+	if sleepTime == wakeTime {
+		return fmt.Errorf("sleepTime and wakeTime must be different")
+	}
+	return nil
+}
+
+func Load(os wrapper.OS, json wrapper.JSON) (*Record, error) {
+	data, err := os.ReadFile(constants.SLEEP_SCHEDULE_FILE)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return DefaultRecord(), nil
+		}
+		return nil, fmt.Errorf("read sleep schedule: %w", err)
+	}
+	if len(data) == 0 {
+		return DefaultRecord(), nil
+	}
+
+	var record Record
+	if err := json.Unmarshal(data, &record); err != nil {
+		return nil, fmt.Errorf("parse sleep schedule: %w", err)
+	}
+	return &record, nil
+}
+
+func Save(os wrapper.OS, json wrapper.JSON, record *Record) error {
+	if record == nil {
+		record = DefaultRecord()
+	}
+	if err := Validate(record); err != nil {
+		return err
+	}
+
+	stateDir := filepath.Dir(constants.SLEEP_SCHEDULE_FILE)
+	if err := os.MkdirAll(stateDir, 0o750); err != nil {
+		return fmt.Errorf("create sleep schedule dir: %w", err)
+	}
+
+	data, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("marshal sleep schedule: %w", err)
+	}
+
+	tmpPath := constants.SLEEP_SCHEDULE_FILE + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o600); err != nil {
+		return fmt.Errorf("write sleep schedule tmp: %w", err)
+	}
+	if err := os.Rename(tmpPath, constants.SLEEP_SCHEDULE_FILE); err != nil {
+		return fmt.Errorf("rename sleep schedule tmp: %w", err)
+	}
+	return nil
+}
+
+func EffectiveStatus(now time.Time, record *Record) (*Status, bool) {
+	record, changed := Normalize(record, now)
+	if record == nil {
+		record = DefaultRecord()
+	}
+
+	status := &Status{
+		Enabled:       record.Enabled,
+		SleepTime:     record.SleepTime,
+		WakeTime:      record.WakeTime,
+		OverrideState: record.OverrideState,
+		OverrideUntil: record.OverrideUntil,
+		CurrentState:  StateAwake,
+	}
+
+	if record.OverrideState != nil {
+		status.CurrentState = *record.OverrideState
+		status.NextTransitionAt = record.OverrideUntil
+		return status, changed
+	}
+
+	if !record.Enabled || record.SleepTime == "" || record.WakeTime == "" {
+		return status, changed
+	}
+
+	sleepTime, err := ParseClockTime(record.SleepTime)
+	if err != nil {
+		return status, changed
+	}
+	wakeTime, err := ParseClockTime(record.WakeTime)
+	if err != nil {
+		return status, changed
+	}
+
+	if isSleepingAt(now, sleepTime, wakeTime) {
+		status.CurrentState = StateSleeping
+		status.NextTransitionAt = timePtr(nextOccurrence(now, wakeTime))
+		return status, changed
+	}
+
+	status.NextTransitionAt = timePtr(nextOccurrence(now, sleepTime))
+	return status, changed
+}
+
+func Normalize(record *Record, now time.Time) (*Record, bool) {
+	if record == nil {
+		return DefaultRecord(), false
+	}
+	if record.OverrideUntil == nil || record.OverrideUntil.After(now) {
+		return record, false
+	}
+
+	normalized := *record
+	normalized.OverrideState = nil
+	normalized.OverrideUntil = nil
+	return &normalized, true
+}
+
+func ManualSleep(record *Record, now time.Time) (*Record, error) {
+	return applyOverride(record, now, StateSleeping)
+}
+
+func ManualWake(record *Record, now time.Time) (*Record, error) {
+	return applyOverride(record, now, StateAwake)
+}
+
+func applyOverride(record *Record, now time.Time, state State) (*Record, error) {
+	record, _ = Normalize(record, now)
+	if record == nil {
+		record = DefaultRecord()
+	}
+
+	updated := *record
+	updated.OverrideState = state.Ptr()
+	updated.OverrideUntil = nil
+
+	if record.Enabled {
+		sleepTime, err := ParseClockTime(record.SleepTime)
+		if err != nil {
+			return nil, err
+		}
+		wakeTime, err := ParseClockTime(record.WakeTime)
+		if err != nil {
+			return nil, err
+		}
+
+		switch state {
+		case StateSleeping:
+			updated.OverrideUntil = timePtr(nextOccurrence(now, wakeTime))
+		case StateAwake:
+			updated.OverrideUntil = timePtr(nextOccurrence(now, sleepTime))
+		default:
+			return nil, fmt.Errorf("unknown override state %q", state)
+		}
+	}
+
+	return &updated, nil
+}
+
+func nextOccurrence(now time.Time, clockTime ClockTime) time.Time {
+	candidate := clockTime.OnDay(now)
+	if !candidate.After(now) {
+		return candidate.Add(24 * time.Hour)
+	}
+	return candidate
+}
+
+func isSleepingAt(now time.Time, sleepTime, wakeTime ClockTime) bool {
+	sleepToday := sleepTime.OnDay(now)
+	wakeToday := wakeTime.OnDay(now)
+
+	if sleepToday.Before(wakeToday) {
+		return !now.Before(sleepToday) && now.Before(wakeToday)
+	}
+
+	return !now.Before(sleepToday) || now.Before(wakeToday)
+}
+
+func timePtr(t time.Time) *time.Time {
+	return &t
+}
+
+func (s State) Ptr() *State {
+	return &s
+}

--- a/components/feral-controld/sleepschedule/schedule.go
+++ b/components/feral-controld/sleepschedule/schedule.go
@@ -17,6 +17,12 @@ const (
 	StateSleeping State = "sleeping"
 )
 
+// Record holds the persisted sleep schedule configuration.
+// SleepTime and WakeTime are wall-clock strings in "HH:MM" format and are
+// always interpreted as UTC. The daemon pins time.Now() to UTC so that
+// schedule behaviour is independent of the system timezone configured on
+// the device. Callers (e.g. the Flutter app) must send and display these
+// values in UTC, converting to/from local time on the client side.
 type Record struct {
 	Enabled       bool       `json:"enabled"`
 	SleepTime     string     `json:"sleepTime,omitempty"`

--- a/components/feral-controld/sleepschedule/schedule_test.go
+++ b/components/feral-controld/sleepschedule/schedule_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestEffectiveStatus_DaytimeWindow(t *testing.T) {
-	now := time.Date(2026, 5, 5, 14, 30, 0, 0, time.UTC)
+	now := time.Date(2026, 5, 5, 14, 30, 0, 0, time.Local)
 	status, changed := EffectiveStatus(now, &Record{
 		Enabled:   true,
 		SleepTime: "22:00",
@@ -25,7 +25,7 @@ func TestEffectiveStatus_DaytimeWindow(t *testing.T) {
 }
 
 func TestEffectiveStatus_OvernightSleepingWindow(t *testing.T) {
-	now := time.Date(2026, 5, 5, 23, 15, 0, 0, time.UTC)
+	now := time.Date(2026, 5, 5, 23, 15, 0, 0, time.Local)
 	status, changed := EffectiveStatus(now, &Record{
 		Enabled:   true,
 		SleepTime: "22:00",
@@ -41,7 +41,7 @@ func TestEffectiveStatus_OvernightSleepingWindow(t *testing.T) {
 }
 
 func TestNormalize_ExpiredOverride(t *testing.T) {
-	now := time.Date(2026, 5, 5, 8, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 5, 5, 8, 0, 0, 0, time.Local)
 	expired := now.Add(-time.Minute)
 	record, changed := Normalize(&Record{
 		Enabled:       true,
@@ -58,7 +58,7 @@ func TestNormalize_ExpiredOverride(t *testing.T) {
 }
 
 func TestManualSleep_UsesNextWakeBoundary(t *testing.T) {
-	now := time.Date(2026, 5, 5, 14, 30, 0, 0, time.UTC)
+	now := time.Date(2026, 5, 5, 14, 30, 0, 0, time.Local)
 	record, err := ManualSleep(&Record{
 		Enabled:   true,
 		SleepTime: "22:00",
@@ -75,7 +75,7 @@ func TestManualSleep_UsesNextWakeBoundary(t *testing.T) {
 }
 
 func TestManualWake_UsesNextSleepBoundary(t *testing.T) {
-	now := time.Date(2026, 5, 5, 23, 30, 0, 0, time.UTC)
+	now := time.Date(2026, 5, 5, 23, 30, 0, 0, time.Local)
 	record, err := ManualWake(&Record{
 		Enabled:   true,
 		SleepTime: "22:00",

--- a/components/feral-controld/sleepschedule/schedule_test.go
+++ b/components/feral-controld/sleepschedule/schedule_test.go
@@ -14,7 +14,7 @@ func TestEffectiveStatus_DefaultRecord_DisabledNoTransitions(t *testing.T) {
 		time.Date(2026, 5, 5, 23, 0, 0, 0, time.UTC),
 	} {
 		t.Run(now.Format(time.RFC3339), func(t *testing.T) {
-			status, changed := EffectiveStatus(now, DefaultRecord())
+			status, changed := EffectiveStatus(now, DefaultRecord(), time.UTC)
 			require.NotNil(t, status)
 			assert.False(t, changed)
 			assert.False(t, status.Enabled)
@@ -27,12 +27,12 @@ func TestEffectiveStatus_DefaultRecord_DisabledNoTransitions(t *testing.T) {
 }
 
 func TestEffectiveStatus_DaytimeWindow(t *testing.T) {
-	now := time.Date(2026, 5, 5, 14, 30, 0, 0, time.Local)
+	now := time.Date(2026, 5, 5, 14, 30, 0, 0, time.UTC)
 	status, changed := EffectiveStatus(now, &Record{
 		Enabled:   true,
 		SleepTime: "22:00",
 		WakeTime:  "07:00",
-	})
+	}, time.UTC)
 
 	require.NotNil(t, status)
 	assert.False(t, changed)
@@ -43,12 +43,12 @@ func TestEffectiveStatus_DaytimeWindow(t *testing.T) {
 }
 
 func TestEffectiveStatus_OvernightSleepingWindow(t *testing.T) {
-	now := time.Date(2026, 5, 5, 23, 15, 0, 0, time.Local)
+	now := time.Date(2026, 5, 5, 23, 15, 0, 0, time.UTC)
 	status, changed := EffectiveStatus(now, &Record{
 		Enabled:   true,
 		SleepTime: "22:00",
 		WakeTime:  "07:00",
-	})
+	}, time.UTC)
 
 	require.NotNil(t, status)
 	assert.False(t, changed)
@@ -59,7 +59,7 @@ func TestEffectiveStatus_OvernightSleepingWindow(t *testing.T) {
 }
 
 func TestNormalize_ExpiredOverride(t *testing.T) {
-	now := time.Date(2026, 5, 5, 8, 0, 0, 0, time.Local)
+	now := time.Date(2026, 5, 5, 8, 0, 0, 0, time.UTC)
 	expired := now.Add(-time.Minute)
 	record, changed := Normalize(&Record{
 		Enabled:       true,
@@ -76,12 +76,12 @@ func TestNormalize_ExpiredOverride(t *testing.T) {
 }
 
 func TestManualSleep_UsesNextWakeBoundary(t *testing.T) {
-	now := time.Date(2026, 5, 5, 14, 30, 0, 0, time.Local)
+	now := time.Date(2026, 5, 5, 14, 30, 0, 0, time.UTC)
 	record, err := ManualSleep(&Record{
 		Enabled:   true,
 		SleepTime: "22:00",
 		WakeTime:  "07:00",
-	}, now)
+	}, now, time.UTC)
 
 	require.NoError(t, err)
 	require.NotNil(t, record.OverrideState)
@@ -93,12 +93,12 @@ func TestManualSleep_UsesNextWakeBoundary(t *testing.T) {
 }
 
 func TestManualWake_UsesNextSleepBoundary(t *testing.T) {
-	now := time.Date(2026, 5, 5, 23, 30, 0, 0, time.Local)
+	now := time.Date(2026, 5, 5, 23, 30, 0, 0, time.UTC)
 	record, err := ManualWake(&Record{
 		Enabled:   true,
 		SleepTime: "22:00",
 		WakeTime:  "07:00",
-	}, now)
+	}, now, time.UTC)
 
 	require.NoError(t, err)
 	require.NotNil(t, record.OverrideState)

--- a/components/feral-controld/sleepschedule/schedule_test.go
+++ b/components/feral-controld/sleepschedule/schedule_test.go
@@ -1,0 +1,92 @@
+package sleepschedule
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEffectiveStatus_DaytimeWindow(t *testing.T) {
+	now := time.Date(2026, 5, 5, 14, 30, 0, 0, time.Local)
+	status, changed := EffectiveStatus(now, &Record{
+		Enabled:   true,
+		SleepTime: "22:00",
+		WakeTime:  "07:00",
+	})
+
+	require.NotNil(t, status)
+	assert.False(t, changed)
+	assert.Equal(t, StateAwake, status.CurrentState)
+	require.NotNil(t, status.NextTransitionAt)
+	assert.Equal(t, 22, status.NextTransitionAt.Hour())
+	assert.Equal(t, 0, status.NextTransitionAt.Minute())
+}
+
+func TestEffectiveStatus_OvernightSleepingWindow(t *testing.T) {
+	now := time.Date(2026, 5, 5, 23, 15, 0, 0, time.Local)
+	status, changed := EffectiveStatus(now, &Record{
+		Enabled:   true,
+		SleepTime: "22:00",
+		WakeTime:  "07:00",
+	})
+
+	require.NotNil(t, status)
+	assert.False(t, changed)
+	assert.Equal(t, StateSleeping, status.CurrentState)
+	require.NotNil(t, status.NextTransitionAt)
+	assert.Equal(t, 7, status.NextTransitionAt.Hour())
+	assert.Equal(t, 0, status.NextTransitionAt.Minute())
+}
+
+func TestNormalize_ExpiredOverride(t *testing.T) {
+	now := time.Date(2026, 5, 5, 8, 0, 0, 0, time.Local)
+	expired := now.Add(-time.Minute)
+	record, changed := Normalize(&Record{
+		Enabled:       true,
+		SleepTime:     "22:00",
+		WakeTime:      "07:00",
+		OverrideState: StateSleeping.Ptr(),
+		OverrideUntil: &expired,
+	}, now)
+
+	require.NotNil(t, record)
+	assert.True(t, changed)
+	assert.Nil(t, record.OverrideState)
+	assert.Nil(t, record.OverrideUntil)
+}
+
+func TestManualSleep_UsesNextWakeBoundary(t *testing.T) {
+	now := time.Date(2026, 5, 5, 14, 30, 0, 0, time.Local)
+	record, err := ManualSleep(&Record{
+		Enabled:   true,
+		SleepTime: "22:00",
+		WakeTime:  "07:00",
+	}, now)
+
+	require.NoError(t, err)
+	require.NotNil(t, record.OverrideState)
+	assert.Equal(t, StateSleeping, *record.OverrideState)
+	require.NotNil(t, record.OverrideUntil)
+	assert.Equal(t, 7, record.OverrideUntil.Hour())
+	assert.Equal(t, 0, record.OverrideUntil.Minute())
+	assert.True(t, record.OverrideUntil.After(now))
+}
+
+func TestManualWake_UsesNextSleepBoundary(t *testing.T) {
+	now := time.Date(2026, 5, 5, 23, 30, 0, 0, time.Local)
+	record, err := ManualWake(&Record{
+		Enabled:   true,
+		SleepTime: "22:00",
+		WakeTime:  "07:00",
+	}, now)
+
+	require.NoError(t, err)
+	require.NotNil(t, record.OverrideState)
+	assert.Equal(t, StateAwake, *record.OverrideState)
+	require.NotNil(t, record.OverrideUntil)
+	assert.Equal(t, 22, record.OverrideUntil.Hour())
+	assert.Equal(t, 0, record.OverrideUntil.Minute())
+	assert.True(t, record.OverrideUntil.After(now))
+}

--- a/components/feral-controld/sleepschedule/schedule_test.go
+++ b/components/feral-controld/sleepschedule/schedule_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestEffectiveStatus_DaytimeWindow(t *testing.T) {
-	now := time.Date(2026, 5, 5, 14, 30, 0, 0, time.Local)
+	now := time.Date(2026, 5, 5, 14, 30, 0, 0, time.UTC)
 	status, changed := EffectiveStatus(now, &Record{
 		Enabled:   true,
 		SleepTime: "22:00",
@@ -25,7 +25,7 @@ func TestEffectiveStatus_DaytimeWindow(t *testing.T) {
 }
 
 func TestEffectiveStatus_OvernightSleepingWindow(t *testing.T) {
-	now := time.Date(2026, 5, 5, 23, 15, 0, 0, time.Local)
+	now := time.Date(2026, 5, 5, 23, 15, 0, 0, time.UTC)
 	status, changed := EffectiveStatus(now, &Record{
 		Enabled:   true,
 		SleepTime: "22:00",
@@ -41,7 +41,7 @@ func TestEffectiveStatus_OvernightSleepingWindow(t *testing.T) {
 }
 
 func TestNormalize_ExpiredOverride(t *testing.T) {
-	now := time.Date(2026, 5, 5, 8, 0, 0, 0, time.Local)
+	now := time.Date(2026, 5, 5, 8, 0, 0, 0, time.UTC)
 	expired := now.Add(-time.Minute)
 	record, changed := Normalize(&Record{
 		Enabled:       true,
@@ -58,7 +58,7 @@ func TestNormalize_ExpiredOverride(t *testing.T) {
 }
 
 func TestManualSleep_UsesNextWakeBoundary(t *testing.T) {
-	now := time.Date(2026, 5, 5, 14, 30, 0, 0, time.Local)
+	now := time.Date(2026, 5, 5, 14, 30, 0, 0, time.UTC)
 	record, err := ManualSleep(&Record{
 		Enabled:   true,
 		SleepTime: "22:00",
@@ -75,7 +75,7 @@ func TestManualSleep_UsesNextWakeBoundary(t *testing.T) {
 }
 
 func TestManualWake_UsesNextSleepBoundary(t *testing.T) {
-	now := time.Date(2026, 5, 5, 23, 30, 0, 0, time.Local)
+	now := time.Date(2026, 5, 5, 23, 30, 0, 0, time.UTC)
 	record, err := ManualWake(&Record{
 		Enabled:   true,
 		SleepTime: "22:00",

--- a/components/feral-controld/sleepschedule/schedule_test.go
+++ b/components/feral-controld/sleepschedule/schedule_test.go
@@ -8,6 +8,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestEffectiveStatus_DefaultRecord_DisabledNoTransitions(t *testing.T) {
+	for _, now := range []time.Time{
+		time.Date(2026, 5, 5, 14, 30, 0, 0, time.UTC),
+		time.Date(2026, 5, 5, 23, 0, 0, 0, time.UTC),
+	} {
+		t.Run(now.Format(time.RFC3339), func(t *testing.T) {
+			status, changed := EffectiveStatus(now, DefaultRecord())
+			require.NotNil(t, status)
+			assert.False(t, changed)
+			assert.False(t, status.Enabled)
+			assert.Equal(t, DefaultSleepTime, status.SleepTime)
+			assert.Equal(t, DefaultWakeTime, status.WakeTime)
+			assert.Equal(t, StateAwake, status.CurrentState)
+			assert.Nil(t, status.NextTransitionAt)
+		})
+	}
+}
+
 func TestEffectiveStatus_DaytimeWindow(t *testing.T) {
 	now := time.Date(2026, 5, 5, 14, 30, 0, 0, time.Local)
 	status, changed := EffectiveStatus(now, &Record{

--- a/components/feral-controld/status/device_status.go
+++ b/components/feral-controld/status/device_status.go
@@ -190,7 +190,7 @@ func (d deviceStatus) GetStatus(ctx context.Context) (*DeviceStatusResponse, err
 			}
 			return nil
 		}
-		sleepScheduleStatus, _ = sleepschedule.EffectiveStatus(time.Now(), record)
+		sleepScheduleStatus, _ = sleepschedule.EffectiveStatus(time.Now(), record, sleepschedule.LoadSystemTimezone(d.os))
 		return nil
 	})
 

--- a/components/feral-controld/status/device_status.go
+++ b/components/feral-controld/status/device_status.go
@@ -12,6 +12,7 @@ import (
 	"github.com/feral-file/ffos-user/components/feral-controld/cdp"
 	"github.com/feral-file/ffos-user/components/feral-controld/config"
 	constants "github.com/feral-file/ffos-user/components/feral-controld/constant"
+	"github.com/feral-file/ffos-user/components/feral-controld/sleepschedule"
 	"github.com/feral-file/ffos-user/components/feral-controld/wrapper"
 
 	"golang.org/x/sync/errgroup"
@@ -60,16 +61,17 @@ func NewDeviceStatus(
 
 // DeviceStatusResponse represents the structure of device status information
 type DeviceStatusResponse struct {
-	ScreenRotation      string            `json:"screenRotation,omitempty"`
-	ConnectedWifi       string            `json:"connectedWifi,omitempty"`
-	InstalledVersion    string            `json:"installedVersion,omitempty"`
-	LatestVersion       string            `json:"latestVersion,omitempty"`
-	AnalyticsDisabled   bool              `json:"analyticsDisabled,omitempty"`
-	BetaFeaturesEnabled bool              `json:"betaFeaturesEnabled,omitempty"`
-	MACInfo             map[string]string `json:"macInfo,omitempty"`
-	Volume              *int              `json:"volume,omitempty"`
-	IsMuted             *bool             `json:"isMuted,omitempty"`
-	DisplayURL          *string           `json:"displayURL,omitempty"` // Chrome UI URL from CDP; omitted if unavailable.
+	ScreenRotation      string                `json:"screenRotation,omitempty"`
+	ConnectedWifi       string                `json:"connectedWifi,omitempty"`
+	InstalledVersion    string                `json:"installedVersion,omitempty"`
+	LatestVersion       string                `json:"latestVersion,omitempty"`
+	AnalyticsDisabled   bool                  `json:"analyticsDisabled,omitempty"`
+	BetaFeaturesEnabled bool                  `json:"betaFeaturesEnabled,omitempty"`
+	MACInfo             map[string]string     `json:"macInfo,omitempty"`
+	Volume              *int                  `json:"volume,omitempty"`
+	IsMuted             *bool                 `json:"isMuted,omitempty"`
+	DisplayURL          *string               `json:"displayURL,omitempty"` // Chrome UI URL from CDP; omitted if unavailable.
+	SleepSchedule       *sleepschedule.Status `json:"sleepSchedule,omitempty"`
 }
 
 // GetStatus retrieves comprehensive device status information
@@ -86,6 +88,7 @@ func (d deviceStatus) GetStatus(ctx context.Context) (*DeviceStatusResponse, err
 	var volume *int
 	var isMuted *bool
 	var displayURL *string
+	var sleepScheduleStatus *sleepschedule.Status
 
 	// Chrome UI document URL. This is the same target listing the poller uses, but
 	// keeping it here preserves the response shape for direct CMD_DEVICE_STATUS calls.
@@ -179,6 +182,18 @@ func (d deviceStatus) GetStatus(ctx context.Context) (*DeviceStatusResponse, err
 		return nil
 	})
 
+	g.Go(func() error {
+		record, err := sleepschedule.Load(d.os, d.json)
+		if err != nil {
+			if d.os.IsNotExist(err) {
+				return nil
+			}
+			return nil
+		}
+		sleepScheduleStatus, _ = sleepschedule.EffectiveStatus(time.Now(), record)
+		return nil
+	})
+
 	// Get analytics toggle (disabled when file exists)
 	g.Go(func() error {
 		const analyticsTogglePath = "/home/feralfile/.state/analytics-toggle-off"
@@ -268,6 +283,7 @@ func (d deviceStatus) GetStatus(ctx context.Context) (*DeviceStatusResponse, err
 	response.Volume = volume
 	response.IsMuted = isMuted
 	response.DisplayURL = displayURL
+	response.SleepSchedule = sleepScheduleStatus
 
 	// Get MAC info from config (fetched once at startup)
 	cfg := config.Get()

--- a/components/feral-controld/status/device_status_test.go
+++ b/components/feral-controld/status/device_status_test.go
@@ -24,6 +24,7 @@ func expectDeviceStatusOSMocks(t *testing.T, mockOS *mocks.MockOS) {
 	t.Helper()
 	mockOS.EXPECT().ReadFile(constants.SCREEN_ORIENTATION_FILE).Return(nil, os.ErrNotExist).Times(1)
 	mockOS.EXPECT().ReadFile(constants.FF1_CONFIG_FILE).Return([]byte(testFF1ConfigJSON), nil).Times(1)
+	mockOS.EXPECT().ReadFile(constants.SLEEP_SCHEDULE_FILE).Return(nil, os.ErrNotExist).Times(1)
 	mockOS.EXPECT().ReadFile("/home/feralfile/.state/analytics-toggle-off").Return(nil, os.ErrNotExist).Times(1)
 	mockOS.EXPECT().ReadFile("/home/feralfile/.state/beta-features-toggle-on").Return(nil, os.ErrNotExist).Times(1)
 	mockOS.EXPECT().IsNotExist(gomock.Any()).DoAndReturn(func(err error) bool { return os.IsNotExist(err) }).AnyTimes()

--- a/components/feral-controld/wrapper/clock.go
+++ b/components/feral-controld/wrapper/clock.go
@@ -22,10 +22,7 @@ func NewClock() Clock {
 }
 
 func (t *clock) Now() time.Time {
-	// Always return UTC so sleep schedule clock-times (HH:MM strings) are
-	// interpreted consistently regardless of the system timezone configured
-	// on the device. Callers must treat sleepTime/wakeTime as UTC values.
-	return time.Now().UTC()
+	return time.Now()
 }
 
 func (t *clock) Sleep(d time.Duration) {

--- a/components/feral-controld/wrapper/clock.go
+++ b/components/feral-controld/wrapper/clock.go
@@ -22,7 +22,10 @@ func NewClock() Clock {
 }
 
 func (t *clock) Now() time.Time {
-	return time.Now()
+	// Always return UTC so sleep schedule clock-times (HH:MM strings) are
+	// interpreted consistently regardless of the system timezone configured
+	// on the device. Callers must treat sleepTime/wakeTime as UTC values.
+	return time.Now().UTC()
 }
 
 func (t *clock) Sleep(d time.Duration) {


### PR DESCRIPTION
## Summary
Implements FF1 scheduled sleep/wake orchestration in `feral-controld`: persisted schedule state, tick loop, device-control commands, and status exposure so the player sleep mode (and related status) stay aligned with the schedule.

Tracks: https://github.com/feral-file/feral-file/issues/3415

## Changes (high level)
- New `sleepschedule` package: wall-clock schedule logic, persistence, tests.
- `devicectl`: sleep schedule executor wiring, transitions, manual override path.
- `commands` / `constant`: command surface for schedule control.
- `status`: device status fields/tests updated for schedule visibility.

## Reviewer note
`applySleepTransition` currently has **FFP panel DDC power** (`applyFfpPowerState`) **commented out** in `devicectl/sleep_schedule.go`. Confirm whether that should ship as-is for #3415 or be restored before merge.

Made with [Cursor](https://cursor.com)