### PR TITLE
[codex] Harden transient device-service outages

### DIFF
--- a/components/feral-controld/relayer/relayer.go
+++ b/components/feral-controld/relayer/relayer.go
@@ -380,9 +380,21 @@ func (r *relayer) background(ctx context.Context) {
 				r.Unlock()
 				_, msg, err := conn.ReadMessage()
 				if err != nil {
-					r.logger.Error("Failed to read message. Will attempt to reconnect shortly", zap.Error(err))
+					if r.shouldStop(ctx) {
+						r.logger.Info("Relayer read loop stopped after connection shutdown", zap.Error(err))
+						return
+					}
+
+					r.logger.Warn("Relayer read failed; reconnecting",
+						zap.Error(err),
+						zap.Bool("abnormal_closure", isAbnormalClosure(err)),
+					)
 					err := r.reconnect(ctx)
 					if err != nil {
+						if r.shouldStop(ctx) {
+							r.logger.Info("Skipping relayer reconnect failure during shutdown", zap.Error(err))
+							return
+						}
 						// Stop the program and let the systemd restart it
 						r.logger.Error("Failed to reconnect to Relayer, the controld will be restarted by systemd shortly", zap.Error(err))
 						r.os.Exit(1)
@@ -509,6 +521,28 @@ func (r *relayer) Close() {
 	}
 
 	r.closeConn()
+}
+
+// shouldStop is checked after blocking socket calls return so shutdown-driven
+// close errors do not get mistaken for remote disconnects that need reconnecting.
+func (r *relayer) shouldStop(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return true
+	default:
+	}
+
+	select {
+	case <-r.done:
+		return true
+	default:
+		return false
+	}
+}
+
+func isAbnormalClosure(err error) bool {
+	var closeErr *websocket.CloseError
+	return errors.As(err, &closeErr) && closeErr.Code == websocket.CloseAbnormalClosure
 }
 
 func (r *relayer) closeConn() {

--- a/components/feral-controld/relayer/relayer_test.go
+++ b/components/feral-controld/relayer/relayer_test.go
@@ -1325,6 +1325,83 @@ func TestClient_ReceiveMessage_Error(t *testing.T) {
 	assert.False(t, ts.client.IsConnected(), "expected client to be disconnected after close")
 }
 
+func TestClient_ReadMessage_ErrorAfterClose_DoesNotReconnect(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	setupMockTicker(ts)
+
+	ts.mockClock.EXPECT().
+		Now().
+		Return(time.Time{}).
+		AnyTimes()
+
+	ts.mockDialer.EXPECT().
+		DialContext(ts.ctx, gomock.Any(), nil).
+		Return(ts.mockConn, &http.Response{StatusCode: http.StatusOK}, nil).
+		Times(1)
+
+	ts.mockConn.EXPECT().
+		SetPongHandler(gomock.Any()).
+		Times(1)
+
+	ts.mockConn.EXPECT().
+		WriteMessage(websocket.PingMessage, gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	ts.mockConn.EXPECT().
+		SetReadDeadline(gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	readStarted := make(chan struct{})
+	releaseRead := make(chan struct{})
+	readReturned := make(chan struct{})
+	ts.mockConn.EXPECT().
+		ReadMessage().
+		DoAndReturn(func() (int, []byte, error) {
+			close(readStarted)
+			<-releaseRead
+			defer close(readReturned)
+			return 0, nil, &websocket.CloseError{Code: websocket.CloseAbnormalClosure, Text: "unexpected EOF"}
+		}).
+		Times(1)
+
+	ts.mockConn.EXPECT().
+		WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""), gomock.Any()).
+		Return(nil).
+		Times(1)
+
+	releaseOnce := sync.Once{}
+	ts.mockConn.EXPECT().
+		Close().
+		DoAndReturn(func() error {
+			releaseOnce.Do(func() { close(releaseRead) })
+			return nil
+		}).
+		Times(1)
+
+	err := ts.client.Connect(ts.ctx)
+	assert.NoError(t, err, "expected no error, got %v", err)
+
+	select {
+	case <-readStarted:
+	case <-time.After(1 * time.Second):
+		t.Fatal("ReadMessage should have started")
+	}
+
+	ts.client.Close()
+
+	select {
+	case <-readReturned:
+	case <-time.After(1 * time.Second):
+		t.Fatal("read loop should return after close")
+	}
+
+	assert.False(t, ts.client.IsConnected(), "expected client to remain disconnected after close")
+}
+
 func TestClient_Ping_Success(t *testing.T) {
 	ts := setup(t)
 	defer ts.teardown()

--- a/components/feral-sys-monitord/metric/metric.go
+++ b/components/feral-sys-monitord/metric/metric.go
@@ -46,6 +46,8 @@ func init() {
 	metricsRegistry.MustRegister(CPUTemperatureCelsius, CPUUptimeSeconds)
 }
 
+var errBestEffortMetricUnavailable = errors.New("best-effort metric unavailable")
+
 func MetricsGatherer() prometheus.Gatherer {
 	return metricsRegistry
 }
@@ -167,6 +169,9 @@ func (p *SysResMonitor) tick(ctx context.Context, interval time.Duration, fns ..
 		for _, fn := range fns {
 			err := fn(ctx)
 			if err != nil {
+				if errors.Is(err, errBestEffortMetricUnavailable) {
+					continue
+				}
 				p.logger.Error("Failed to monitor system resources", zap.Error(err))
 				continue
 			}
@@ -651,8 +656,8 @@ func (p *SysResMonitor) monitorScreen(ctx context.Context) error {
 	cmd.Stderr = &stderr
 	output, err := cmd.Output()
 	if err != nil {
-		p.logger.Error("Failed to get screen metrics", zap.String("stderr", stderr.String()), zap.Error(err))
-		return err
+		p.logger.Warn("Screen metrics unavailable", zap.String("stderr", strings.TrimSpace(stderr.String())), zap.Error(err))
+		return fmt.Errorf("%w: screen metrics", errBestEffortMetricUnavailable)
 	}
 
 	lines := strings.Split(string(output), "\n")

--- a/components/feral-sys-monitord/metric/metric_test.go
+++ b/components/feral-sys-monitord/metric/metric_test.go
@@ -1,0 +1,48 @@
+package metric
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestTickSuppressesBestEffortMetricErrors(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	core, logs := observer.New(zapcore.DebugLevel)
+	monitor := NewSysResMonitor(ctx, zap.New(core))
+
+	monitor.tick(ctx, time.Hour, func(context.Context) error {
+		return errBestEffortMetricUnavailable
+	})
+
+	if logs.FilterMessage("Failed to monitor system resources").Len() != 0 {
+		t.Fatal("best-effort metric errors should not be promoted to generic error logs")
+	}
+}
+
+func TestTickLogsUnexpectedMetricErrors(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	core, logs := observer.New(zapcore.DebugLevel)
+	monitor := NewSysResMonitor(ctx, zap.New(core))
+
+	monitor.tick(ctx, time.Hour, func(context.Context) error {
+		return errors.New("unexpected metric failure")
+	})
+
+	entry := logs.FilterMessage("Failed to monitor system resources")
+	if entry.Len() != 1 {
+		t.Fatalf("unexpected metric errors should be logged once, got %d", entry.Len())
+	}
+	if entry.All()[0].Level != zapcore.ErrorLevel {
+		t.Fatalf("unexpected metric error should remain error-level, got %s", entry.All()[0].Level)
+	}
+}

--- a/components/feral-watchdog/README.md
+++ b/components/feral-watchdog/README.md
@@ -9,6 +9,9 @@ The CDP Monitor is responsible for monitoring the health of the Chromium browser
 ### Monitoring Logic
 
 - Checks Chromium health via CDP every 5 seconds
+- Treats Chromium/CDP as a recoverable runtime dependency during startup,
+  kiosk restart, OTA, and crash recovery; the watchdog stays alive and retries
+  CDP access instead of exiting on a single refused connection
 - If health check fails or returns non-200, checks time since last successful response
 - If no successful response for over 20 seconds, restarts `chromium-kiosk.service`
 - If 3 restarts occur within 5 minutes, triggers a system reboot

--- a/components/feral-watchdog/chromium.go
+++ b/components/feral-watchdog/chromium.go
@@ -39,9 +39,13 @@ func NewChromiumMonitor(cdpEndpoint string, logger *zap.Logger, commandHandler *
 		client: &http.Client{
 			Timeout: CHROMIUM_REQUEST_TIMEOUT,
 		},
-		logger:             logger,
-		restartHistory:     make([]time.Time, 0, CHROMIUM_RESTART_HISTORY_SIZE),
-		lastSuccessfulResp: time.Time{},
+		logger:         logger,
+		restartHistory: make([]time.Time, 0, CHROMIUM_RESTART_HISTORY_SIZE),
+		// Chromium can be legitimately unavailable while kiosk startup or
+		// restart is in progress. Starting the grace window at monitor creation
+		// prevents a single early refused connection from becoming an immediate
+		// restart/reboot decision.
+		lastSuccessfulResp: time.Now(),
 		commandHandler:     commandHandler,
 	}
 }

--- a/components/feral-watchdog/chromium_test.go
+++ b/components/feral-watchdog/chromium_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestChromiumMonitorFirstFailureUsesStartupGrace(t *testing.T) {
+	countFile := installCountingSystemctl(t)
+	endpoint := closedLocalHTTPEndpoint(t)
+	monitor := NewChromiumMonitor(endpoint, zap.NewNop(), NewCommandHandler(zap.NewNop(), nil))
+
+	if err := monitor.check(context.Background()); err == nil {
+		t.Fatal("expected health check to fail against closed endpoint")
+	}
+
+	// #nosec G304 -- countFile is created by this test inside t.TempDir.
+	countBytes, err := os.ReadFile(countFile)
+	if err != nil {
+		t.Fatalf("failed to read restart count: %v", err)
+	}
+	if got := strings.TrimSpace(string(countBytes)); got != "0" {
+		t.Fatalf("expected no immediate kiosk restart during startup grace, got restart count %s", got)
+	}
+}
+
+func closedLocalHTTPEndpoint(t *testing.T) string {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to allocate local port: %v", err)
+	}
+	addr := listener.Addr().String()
+	if err := listener.Close(); err != nil {
+		t.Fatalf("failed to close local port: %v", err)
+	}
+	return "http://" + addr
+}
+
+func installCountingSystemctl(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	countFile := filepath.Join(dir, "restart-count")
+	if err := os.WriteFile(countFile, []byte("0\n"), 0o600); err != nil {
+		t.Fatalf("failed to create restart count file: %v", err)
+	}
+
+	systemctlPath := filepath.Join(dir, "systemctl")
+	systemctlScript := `#!/bin/sh
+count_file="` + countFile + `"
+if [ "$1" = "--user" ] && [ "$2" = "restart" ] && [ "$3" = "chromium-kiosk.service" ]; then
+  count="$(cat "$count_file")"
+  count=$((count + 1))
+  printf "%s\n" "$count" > "$count_file"
+  exit 0
+fi
+exit 0
+`
+	// #nosec G306 -- test helper script must be executable.
+	if err := os.WriteFile(systemctlPath, []byte(systemctlScript), 0o755); err != nil {
+		t.Fatalf("failed to create fake systemctl: %v", err)
+	}
+
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return countFile
+}

--- a/components/feral-watchdog/main.go
+++ b/components/feral-watchdog/main.go
@@ -113,12 +113,12 @@ func main() {
 	// Initialize system command executor
 	commandHandler := NewCommandHandler(log, vmagentClient)
 
-	// Initialize CDP client
+	// Initialize CDP client. Chromium owns the CDP socket lifecycle and can be
+	// temporarily absent during boot, OTA, kiosk restarts, or crash recovery. The
+	// watchdog must keep its own recovery monitors alive in those states instead
+	// of letting systemd restart this process and amplify Sentry noise.
 	cdpClient := cdp.NewDefault(&cdp.Config{Endpoint: config.CDPConfig.Endpoint}, log)
-	err = cdpClient.Init(ctx)
-	if err != nil {
-		log.Fatal("CDP init failed", zap.Error(err))
-	}
+	initCDPBestEffort(ctx, cdpClient, log)
 	defer cdpClient.Close()
 
 	// Initialize resource monitors
@@ -185,4 +185,12 @@ func main() {
 	}
 
 	log.Info("feral-watchdog daemon shutdown complete")
+}
+
+func initCDPBestEffort(ctx context.Context, cdpClient cdp.ClientInterface, log *zap.Logger) bool {
+	if err := cdpClient.Init(ctx); err != nil {
+		log.Warn("CDP init unavailable; watchdog will retry on demand", zap.Error(err))
+		return false
+	}
+	return true
 }

--- a/components/feral-watchdog/main_test.go
+++ b/components/feral-watchdog/main_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestInitCDPBestEffortDoesNotTreatTemporaryCDPFailureAsFatal(t *testing.T) {
+	client := &fakeCDPClient{initErr: errors.New("connection refused")}
+
+	if initCDPBestEffort(context.Background(), client, zap.NewNop()) {
+		t.Fatal("expected CDP init to be reported as unavailable")
+	}
+
+	if client.initCalls != 1 {
+		t.Fatalf("expected one init attempt, got %d", client.initCalls)
+	}
+}
+
+func TestInitCDPBestEffortReportsSuccessfulInit(t *testing.T) {
+	client := &fakeCDPClient{}
+
+	if !initCDPBestEffort(context.Background(), client, zap.NewNop()) {
+		t.Fatal("expected CDP init to be reported as available")
+	}
+
+	if client.initCalls != 1 {
+		t.Fatalf("expected one init attempt, got %d", client.initCalls)
+	}
+}
+
+type fakeCDPClient struct {
+	initErr   error
+	initCalls int
+}
+
+func (f *fakeCDPClient) Init(context.Context) error {
+	f.initCalls++
+	return f.initErr
+}
+
+func (f *fakeCDPClient) Send(string, map[string]interface{}) (interface{}, error) {
+	return nil, nil
+}
+
+func (f *fakeCDPClient) Close() {}

--- a/components/feral-watchdog/packages/cdp/cdp.go
+++ b/components/feral-watchdog/packages/cdp/cdp.go
@@ -292,6 +292,10 @@ func (c *Client) IsReconnectionError(err error) bool {
 		return false
 	}
 
+	if errors.Is(err, ErrCDPConnectionNotInitialized) {
+		return true
+	}
+
 	// Check for websocket close errors
 	var closeErr *websocket.CloseError
 	if errors.As(err, &closeErr) {
@@ -326,12 +330,12 @@ func (c *Client) IsReconnectionError(err error) bool {
 }
 
 func (c *Client) Reconnect(ctx context.Context) error {
-	if c.isReconnecting {
-		return nil
-	}
-
 	c.logger.Info("Reconnecting to CDP")
 	c.mu.Lock()
+	if c.isReconnecting {
+		c.mu.Unlock()
+		return nil
+	}
 	c.isReconnecting = true
 	defer func() {
 		c.isReconnecting = false
@@ -361,6 +365,36 @@ func (c *Client) Reconnect(ctx context.Context) error {
 	return c.initLocked(ctx)
 }
 
+func (c *Client) sendWithReconnect(ctx context.Context, method string, params map[string]interface{}) (interface{}, error) {
+	// Startup and renderer recovery can leave CDP temporarily unavailable. CDP
+	// actions are therefore best-effort reconnect points instead of reasons for
+	// the watchdog process to exit.
+	if !c.Initialized() {
+		if err := c.Reconnect(ctx); err != nil {
+			return nil, fmt.Errorf("failed to reconnect: %w", err)
+		}
+	}
+
+	result, err := c.Send(method, params)
+	if err == nil {
+		return result, nil
+	}
+
+	if !c.IsReconnectionError(err) {
+		return nil, err
+	}
+
+	if reconnErr := c.Reconnect(ctx); reconnErr != nil {
+		return nil, fmt.Errorf("failed to reconnect: %w", reconnErr)
+	}
+
+	result, err = c.Send(method, params)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 // sendWatchdogEvent sends a watchdog event to the website via CDP
 func (c *Client) sendWatchdogEvent(ctx context.Context, eventType string) error {
 	expression := fmt.Sprintf("window.handleWatchdogEvent(%q)", eventType)
@@ -369,20 +403,8 @@ func (c *Client) sendWatchdogEvent(ctx context.Context, eventType string) error 
 		"expression": expression,
 	}
 
-	_, err := c.Send(METHOD_EVALUATE, params)
-	if err != nil {
-		if c.IsReconnectionError(err) {
-			if reconnErr := c.Reconnect(ctx); reconnErr != nil {
-				return fmt.Errorf("failed to reconnect: %w", reconnErr)
-			}
-			// Retry after reconnect
-			_, err = c.Send(METHOD_EVALUATE, params)
-			if err != nil {
-				return fmt.Errorf("failed to send watchdog event: %w", err)
-			}
-		} else {
-			return fmt.Errorf("failed to send watchdog event: %w", err)
-		}
+	if _, err := c.sendWithReconnect(ctx, METHOD_EVALUATE, params); err != nil {
+		return fmt.Errorf("failed to send watchdog event: %w", err)
 	}
 
 	return nil
@@ -414,20 +436,8 @@ func (c *Client) Navigate(ctx context.Context, url string) error {
 	params := map[string]interface{}{
 		"url": url,
 	}
-	_, err := c.Send(METHOD_NAVIGATE, params)
-	if err != nil {
-		if c.IsReconnectionError(err) {
-			if reconnErr := c.Reconnect(ctx); reconnErr != nil {
-				return fmt.Errorf("failed to reconnect: %w", reconnErr)
-			}
-			// Retry navigation after reconnect
-			_, err = c.Send(METHOD_NAVIGATE, params)
-			if err != nil {
-				return fmt.Errorf("failed to navigate to %s: %w", url, err)
-			}
-		} else {
-			return fmt.Errorf("failed to navigate to %s: %w", url, err)
-		}
+	if _, err := c.sendWithReconnect(ctx, METHOD_NAVIGATE, params); err != nil {
+		return fmt.Errorf("failed to navigate to %s: %w", url, err)
 	}
 	return nil
 }

--- a/components/feral-watchdog/packages/cdp/cdp_test.go
+++ b/components/feral-watchdog/packages/cdp/cdp_test.go
@@ -1,0 +1,131 @@
+package cdp
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"go.uber.org/zap"
+
+	"github.com/feral-file/ffos-user/components/feral-watchdog/packages/wrapper"
+)
+
+func TestSendServiceFailedEventReconnectsWhenStartupInitWasSkipped(t *testing.T) {
+	conn := &fakeWebSocketConn{
+		readMessage: []byte(`{"id":1,"result":{"result":{"type":""}}}`),
+	}
+	dialer := &fakeWebSocketDialer{conn: conn}
+	httpClient := &fakeHTTPClient{
+		body: `[{"type":"page","webSocketDebuggerUrl":"ws://debugger.test/page"}]`,
+	}
+
+	client := NewClient(
+		&Config{Endpoint: "http://127.0.0.1:9222"},
+		zap.NewNop(),
+		dialer,
+		wrapper.NewIO(),
+		wrapper.NewJSON(),
+		httpClient,
+	)
+	t.Cleanup(client.Close)
+
+	if err := client.SendServiceFailedEvent(context.Background()); err != nil {
+		t.Fatalf("SendServiceFailedEvent returned error: %v", err)
+	}
+
+	if httpClient.gotURL != "http://127.0.0.1:9222/json" {
+		t.Fatalf("unexpected CDP target URL: got=%q", httpClient.gotURL)
+	}
+	if dialer.gotURL != "ws://debugger.test/page" {
+		t.Fatalf("unexpected websocket URL: got=%q", dialer.gotURL)
+	}
+
+	writes := conn.Writes()
+	if len(writes) != 1 {
+		t.Fatalf("expected one CDP write, got %d", len(writes))
+	}
+	if !strings.Contains(writes[0], `"method":"Runtime.evaluate"`) {
+		t.Fatalf("expected Runtime.evaluate request, got %s", writes[0])
+	}
+	if !strings.Contains(writes[0], `window.handleWatchdogEvent(\"ServiceFailed\")`) {
+		t.Fatalf("expected service failed watchdog event, got %s", writes[0])
+	}
+}
+
+type fakeHTTPClient struct {
+	body   string
+	err    error
+	gotURL string
+}
+
+func (f *fakeHTTPClient) Get(url string) (*http.Response, error) {
+	f.gotURL = url
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(f.body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+type fakeWebSocketDialer struct {
+	conn   wrapper.WebSocketConnInterface
+	err    error
+	gotURL string
+}
+
+func (f *fakeWebSocketDialer) DialContext(_ context.Context, stringURL string, requestHeader http.Header) (wrapper.WebSocketConnInterface, *http.Response, error) {
+	f.gotURL = stringURL
+	if f.err != nil {
+		return nil, nil, f.err
+	}
+	return f.conn, &http.Response{StatusCode: http.StatusSwitchingProtocols, Header: requestHeader}, nil
+}
+
+type fakeWebSocketConn struct {
+	mu          sync.Mutex
+	writes      []string
+	readMessage []byte
+	readErr     error
+	closeErr    error
+}
+
+func (f *fakeWebSocketConn) WriteJSON(interface{}) error { return nil }
+
+func (f *fakeWebSocketConn) ReadMessage() (int, []byte, error) {
+	if f.readErr != nil {
+		return websocket.TextMessage, nil, f.readErr
+	}
+	return websocket.TextMessage, f.readMessage, nil
+}
+
+func (f *fakeWebSocketConn) WriteMessage(_ int, data []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.writes = append(f.writes, string(data))
+	return nil
+}
+
+func (f *fakeWebSocketConn) WriteControl(int, []byte, time.Time) error { return nil }
+
+func (f *fakeWebSocketConn) SetPongHandler(func(string) error) {}
+
+func (f *fakeWebSocketConn) SetReadDeadline(time.Time) error { return nil }
+
+func (f *fakeWebSocketConn) Close() error { return f.closeErr }
+
+func (f *fakeWebSocketConn) Writes() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	writes := make([]string, len(f.writes))
+	copy(writes, f.writes)
+	return writes
+}


### PR DESCRIPTION
## Summary
- Treat watchdog CDP startup initialization as best-effort instead of fatal when Chromium is temporarily unavailable.
- Lazily reconnect CDP before browser-facing watchdog events and navigation after skipped startup init or connection loss.
- Add Chromium startup grace so the first refused health poll does not immediately restart kiosk.
- Treat relayer read errors after local shutdown as expected close fallout, while preserving reconnect behavior for live remote disconnects.
- Suppress best-effort sys-monitord metric collection failures from noisy error logging when a metric source is unavailable.

## Root cause
`feral-watchdog` initialized CDP during process startup with `log.Fatal` on `/json` target discovery failure. During normal FF1 startup, kiosk restarts, OTA, or crash recovery, Chromium can legitimately refuse `127.0.0.1:9222`, causing systemd restart loops and repeated Sentry events instead of a recoverable retry path.

A relayer `ReadMessage` can also return WebSocket close `1006 unexpected EOF` after local shutdown closes the socket. That should not be mistaken for a remote disconnect that needs reconnecting.

Fixes #190.

## Validation
- `go test ./...` in `components/feral-watchdog`
- `go vet ./...` in `components/feral-watchdog`
- `golangci-lint run --new-from-rev=HEAD~1 ./...` in `components/feral-watchdog`
- `go test ./relayer -run 'TestClient_ReadMessage_(Error|ErrorAfterClose)|TestClient_ReadMessage_PermanentError' -count=1` in `components/feral-controld`
- `go test ./...` in `components/feral-controld`
- `go vet ./...` in `components/feral-controld`
- `golangci-lint run --new-from-rev=HEAD~1 ./...` in `components/feral-controld`
- `go test ./...` in `components/feral-sys-monitord`
- `go vet ./...` in `components/feral-sys-monitord`
- `golangci-lint run --new-from-rev=HEAD~1 ./...` in `components/feral-sys-monitord`
- `git diff --check`
- Reviewer loop: `Verdict: accept`

## Not tested
- Physical FF1 Chromium kill/delayed-start smoke test.
- Live relayer disconnect against production relayer endpoint.