### PR TITLE
[codex] Prevent Chromium page zoom from zoomGesture

### DIFF
--- a/components/feral-controld/cdp/cdp.go
+++ b/components/feral-controld/cdp/cdp.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -22,6 +23,19 @@ var (
 	ErrNoPageTargetFound           = errors.New("no page target found in Chromium instance")
 	ErrMultiplePageTargetsFound    = errors.New("multiple page targets found in Chromium instance")
 )
+
+type RemoteError struct {
+	Method      string
+	Description string
+	Unsupported bool
+}
+
+func (e *RemoteError) Error() string {
+	if e.Method == "" {
+		return fmt.Sprintf("CDP error: %s", e.Description)
+	}
+	return fmt.Sprintf("CDP error: %s: %s", e.Method, e.Description)
+}
 
 const (
 	// CDP Methods
@@ -322,7 +336,12 @@ func (c *cdp) send(method string, params map[string]interface{}) (interface{}, e
 		zap.String("response", string(response)))
 
 	var resp struct {
-		ID     int `json:"id"`
+		ID    int `json:"id"`
+		Error *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+			Data    any    `json:"data"`
+		} `json:"error"`
 		Result struct {
 			Result struct {
 				Type        string      `json:"type"`
@@ -337,13 +356,32 @@ func (c *cdp) send(method string, params map[string]interface{}) (interface{}, e
 		return nil, fmt.Errorf("failed to parse CDP response: %w", err)
 	}
 
+	if resp.Error != nil {
+		return nil, &RemoteError{
+			Method:      method,
+			Description: resp.Error.Message,
+			Unsupported: isUnsupportedRemoteMethodError(method, resp.Error.Code),
+		}
+	}
+
 	result := resp.Result.Result
 
 	// Check for uncaught errors
 	if result.Type == TYPE_OBJECT &&
 		result.Subtype != nil &&
 		*result.Subtype == SUBTYPE_ERROR {
-		return nil, fmt.Errorf("CDP error: %v", *result.Description)
+		description := "remote error"
+		switch {
+		case result.Description != nil && strings.TrimSpace(*result.Description) != "":
+			description = *result.Description
+		case result.ClassName != nil && strings.TrimSpace(*result.ClassName) != "":
+			description = *result.ClassName
+		}
+		return nil, &RemoteError{
+			Method:      method,
+			Description: description,
+			Unsupported: false,
+		}
 	}
 
 	// Check for response type mismatch
@@ -361,6 +399,10 @@ func (c *cdp) send(method string, params map[string]interface{}) (interface{}, e
 	default:
 		return nil, fmt.Errorf("CDP response type mismatch: %s", result.Type)
 	}
+}
+
+func isUnsupportedRemoteMethodError(method string, code int) bool {
+	return method == "Input.synthesizePinchGesture" && code == -32601
 }
 
 // Close closes the CDP connection

--- a/components/feral-controld/cdp/cdp_test.go
+++ b/components/feral-controld/cdp/cdp_test.go
@@ -787,7 +787,12 @@ func TestClient_Send_Success(t *testing.T) {
 		Unmarshal([]byte(cdpResponse), gomock.Any()).
 		DoAndReturn(func(data []byte, v interface{}) error {
 			resp := v.(*struct {
-				ID     int `json:"id"`
+				ID    int `json:"id"`
+				Error *struct {
+					Code    int         `json:"code"`
+					Message string      `json:"message"`
+					Data    interface{} `json:"data"`
+				} `json:"error"`
 				Result struct {
 					Result struct {
 						Type        string      `json:"type"`
@@ -1220,7 +1225,12 @@ func TestClient_Send_Error(t *testing.T) {
 					Unmarshal(gomock.Any(), gomock.Any()).
 					DoAndReturn(func(data []byte, v interface{}) error {
 						resp := v.(*struct {
-							ID     int `json:"id"`
+							ID    int `json:"id"`
+							Error *struct {
+								Code    int         `json:"code"`
+								Message string      `json:"message"`
+								Data    interface{} `json:"data"`
+							} `json:"error"`
 							Result struct {
 								Result struct {
 									Type        string      `json:"type"`
@@ -1241,7 +1251,210 @@ func TestClient_Send_Error(t *testing.T) {
 					}).
 					Times(1)
 			},
-			wantErr: "CDP error: Test error",
+			wantErr: "CDP error: Runtime.evaluate: Test error",
+		},
+		{
+			name: "CDP error object without description",
+			setupFunc: func(ts *testSetup) {
+				// Initialize the client first
+				responseBody := "fake response body"
+				mockResponse := &http.Response{
+					StatusCode: 200,
+					Body:       io.NopCloser(strings.NewReader(responseBody)),
+				}
+
+				// Expect HTTP GET to return response body
+				ts.mockHTTP.EXPECT().
+					Do(gomock.Any()).
+					Return(mockResponse, nil).
+					Times(1)
+
+				// Expect io.ReadAll to return response body
+				ts.mockIO.EXPECT().
+					ReadAll(gomock.Any()).
+					Return([]byte(responseBody), nil).
+					Times(1)
+
+				// Expect json.Unmarshal to unmarshal response body
+				ts.mockJSON.EXPECT().
+					Unmarshal(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(data []byte, v interface{}) error {
+						targets := v.(*[]struct {
+							Type                 string `json:"type"`
+							Title                string `json:"title"`
+							WebSocketDebuggerURL string `json:"webSocketDebuggerUrl"`
+						})
+						*targets = []struct {
+							Type                 string `json:"type"`
+							Title                string `json:"title"`
+							WebSocketDebuggerURL string `json:"webSocketDebuggerUrl"`
+						}{
+							{
+								Type:                 "page",
+								Title:                "Test Page",
+								WebSocketDebuggerURL: "ws://localhost:9222/devtools/page/123",
+							},
+						}
+						return nil
+					}).
+					Times(1)
+
+				// Expect dialer to dial and return connection
+				ts.mockDialer.EXPECT().
+					DialContext(ts.ctx, gomock.Any(), nil).
+					Return(ts.mockConn, nil, nil).
+					Times(1)
+
+				// Initialize
+				err := ts.client.Init(ts.ctx)
+				assert.NoError(t, err)
+				assert.True(t, ts.client.Initialized())
+
+				// Expect JSON marshal to succeed
+				ts.mockJSON.EXPECT().
+					Marshal(gomock.Any()).
+					Return([]byte(`{"test":"data"}`), nil).
+					Times(1)
+
+				// Expect WriteMessage to succeed
+				ts.mockConn.EXPECT().
+					WriteMessage(websocket.TextMessage, gomock.Any()).
+					Return(nil).
+					Times(1)
+
+				// Expect ReadMessage to succeed
+				ts.mockConn.EXPECT().
+					ReadMessage().
+					Return(websocket.TextMessage, []byte{}, nil).
+					Times(1)
+
+				// Expect JSON unmarshal to succeed and return error response with no description
+				ts.mockJSON.EXPECT().
+					Unmarshal(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(data []byte, v interface{}) error {
+						resp := v.(*struct {
+							ID    int `json:"id"`
+							Error *struct {
+								Code    int         `json:"code"`
+								Message string      `json:"message"`
+								Data    interface{} `json:"data"`
+							} `json:"error"`
+							Result struct {
+								Result struct {
+									Type        string      `json:"type"`
+									Subtype     *string     `json:"subtype"`
+									ClassName   *string     `json:"className"`
+									Description *string     `json:"description"`
+									Value       interface{} `json:"value"`
+								} `json:"result"`
+							} `json:"result"`
+						})
+						resp.ID = 1
+						resp.Result.Result.Type = cdp.TYPE_OBJECT
+						subtype := cdp.SUBTYPE_ERROR
+						resp.Result.Result.Subtype = &subtype
+						className := "TypeError"
+						resp.Result.Result.ClassName = &className
+						resp.Result.Result.Description = nil
+						return nil
+					}).
+					Times(1)
+			},
+			wantErr: "CDP error: Runtime.evaluate: TypeError",
+		},
+		{
+			name: "CDP top-level error envelope",
+			setupFunc: func(ts *testSetup) {
+				responseBody := "fake response body"
+				mockResponse := &http.Response{
+					StatusCode: 200,
+					Body:       io.NopCloser(strings.NewReader(responseBody)),
+				}
+
+				ts.mockHTTP.EXPECT().
+					Do(gomock.Any()).
+					Return(mockResponse, nil).
+					Times(1)
+
+				ts.mockIO.EXPECT().
+					ReadAll(gomock.Any()).
+					Return([]byte(responseBody), nil).
+					Times(1)
+
+				ts.mockJSON.EXPECT().
+					Unmarshal(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(data []byte, v interface{}) error {
+						targets := v.(*[]struct {
+							Type                 string `json:"type"`
+							Title                string `json:"title"`
+							WebSocketDebuggerURL string `json:"webSocketDebuggerUrl"`
+						})
+						*targets = []struct {
+							Type                 string `json:"type"`
+							Title                string `json:"title"`
+							WebSocketDebuggerURL string `json:"webSocketDebuggerUrl"`
+						}{
+							{Type: "page", Title: "Test Page", WebSocketDebuggerURL: "ws://localhost:9222/devtools/page/123"},
+						}
+						return nil
+					}).
+					Times(1)
+
+				ts.mockDialer.EXPECT().
+					DialContext(ts.ctx, gomock.Any(), nil).
+					Return(ts.mockConn, nil, nil).
+					Times(1)
+
+				err := ts.client.Init(ts.ctx)
+				assert.NoError(t, err)
+				assert.True(t, ts.client.Initialized())
+
+				ts.mockJSON.EXPECT().
+					Marshal(gomock.Any()).
+					Return([]byte(`{"id":1,"method":"Runtime.evaluate","params":{"expression":"test"}}`), nil).
+					Times(1)
+				ts.mockConn.EXPECT().
+					WriteMessage(websocket.TextMessage, gomock.Any()).
+					Return(nil).
+					Times(1)
+				ts.mockConn.EXPECT().
+					ReadMessage().
+					Return(websocket.TextMessage, []byte(`{"id":1,"error":{"code":-32601,"message":"Method not found"}}`), nil).
+					Times(1)
+				ts.mockJSON.EXPECT().
+					Unmarshal([]byte(`{"id":1,"error":{"code":-32601,"message":"Method not found"}}`), gomock.Any()).
+					DoAndReturn(func(data []byte, v interface{}) error {
+						resp := v.(*struct {
+							ID    int `json:"id"`
+							Error *struct {
+								Code    int         `json:"code"`
+								Message string      `json:"message"`
+								Data    interface{} `json:"data"`
+							} `json:"error"`
+							Result struct {
+								Result struct {
+									Type        string      `json:"type"`
+									Subtype     *string     `json:"subtype"`
+									ClassName   *string     `json:"className"`
+									Description *string     `json:"description"`
+									Value       interface{} `json:"value"`
+								} `json:"result"`
+							} `json:"result"`
+						})
+						resp.ID = 1
+						resp.Error = &struct {
+							Code    int         `json:"code"`
+							Message string      `json:"message"`
+							Data    interface{} `json:"data"`
+						}{
+							Code:    -32601,
+							Message: "Method not found",
+						}
+						return nil
+					}).
+					Times(1)
+			},
+			wantErr: "CDP error: Runtime.evaluate: Method not found",
 		},
 		{
 			name: "CDP invalid string response",
@@ -1324,7 +1537,12 @@ func TestClient_Send_Error(t *testing.T) {
 					Unmarshal(gomock.Any(), gomock.Any()).
 					DoAndReturn(func(data []byte, v interface{}) error {
 						resp := v.(*struct {
-							ID     int `json:"id"`
+							ID    int `json:"id"`
+							Error *struct {
+								Code    int         `json:"code"`
+								Message string      `json:"message"`
+								Data    interface{} `json:"data"`
+							} `json:"error"`
 							Result struct {
 								Result struct {
 									Type        string      `json:"type"`
@@ -1432,7 +1650,12 @@ func TestClient_Send_Error(t *testing.T) {
 					Unmarshal(gomock.Any(), gomock.Any()).
 					DoAndReturn(func(data []byte, v interface{}) error {
 						resp := v.(*struct {
-							ID     int `json:"id"`
+							ID    int `json:"id"`
+							Error *struct {
+								Code    int         `json:"code"`
+								Message string      `json:"message"`
+								Data    interface{} `json:"data"`
+							} `json:"error"`
 							Result struct {
 								Result struct {
 									Type        string      `json:"type"`
@@ -1484,6 +1707,212 @@ func TestClient_Send_Error(t *testing.T) {
 			ts.client.Close()
 		})
 	}
+}
+
+func TestClient_Send_PinchingUnsupportedTopLevelError(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	responseBody := "fake response body"
+	mockResponse := &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(responseBody)),
+	}
+
+	ts.mockHTTP.EXPECT().
+		Do(gomock.Any()).
+		Return(mockResponse, nil).
+		Times(1)
+
+	ts.mockIO.EXPECT().
+		ReadAll(gomock.Any()).
+		Return([]byte(responseBody), nil).
+		Times(1)
+
+	ts.mockJSON.EXPECT().
+		Unmarshal(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(data []byte, v interface{}) error {
+			targets := v.(*[]struct {
+				Type                 string `json:"type"`
+				Title                string `json:"title"`
+				WebSocketDebuggerURL string `json:"webSocketDebuggerUrl"`
+			})
+			*targets = []struct {
+				Type                 string `json:"type"`
+				Title                string `json:"title"`
+				WebSocketDebuggerURL string `json:"webSocketDebuggerUrl"`
+			}{
+				{Type: "page", Title: "Test Page", WebSocketDebuggerURL: "ws://localhost:9222/devtools/page/123"},
+			}
+			return nil
+		}).
+		Times(1)
+
+	ts.mockDialer.EXPECT().
+		DialContext(ts.ctx, gomock.Any(), nil).
+		Return(ts.mockConn, nil, nil).
+		Times(1)
+
+	err := ts.client.Init(ts.ctx)
+	assert.NoError(t, err)
+	assert.True(t, ts.client.Initialized())
+
+	ts.mockJSON.EXPECT().
+		Marshal(gomock.Any()).
+		Return([]byte(`{"id":1,"method":"Input.synthesizePinchGesture","params":{"x":1,"y":2}}`), nil).
+		Times(1)
+	ts.mockConn.EXPECT().
+		WriteMessage(websocket.TextMessage, gomock.Any()).
+		Return(nil).
+		Times(1)
+	ts.mockConn.EXPECT().
+		ReadMessage().
+		Return(websocket.TextMessage, []byte(`{"id":1,"error":{"code":-32601,"message":"método no encontrado"}}`), nil).
+		Times(1)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(`{"id":1,"error":{"code":-32601,"message":"método no encontrado"}}`), gomock.Any()).
+		DoAndReturn(func(data []byte, v interface{}) error {
+			resp := v.(*struct {
+				ID    int `json:"id"`
+				Error *struct {
+					Code    int         `json:"code"`
+					Message string      `json:"message"`
+					Data    interface{} `json:"data"`
+				} `json:"error"`
+				Result struct {
+					Result struct {
+						Type        string      `json:"type"`
+						Subtype     *string     `json:"subtype"`
+						ClassName   *string     `json:"className"`
+						Description *string     `json:"description"`
+						Value       interface{} `json:"value"`
+					} `json:"result"`
+				} `json:"result"`
+			})
+			resp.ID = 1
+			resp.Error = &struct {
+				Code    int         `json:"code"`
+				Message string      `json:"message"`
+				Data    interface{} `json:"data"`
+			}{
+				Code:    -32601,
+				Message: "método no encontrado",
+			}
+			return nil
+		}).
+		Times(1)
+
+	result, err := ts.client.Send("Input.synthesizePinchGesture", map[string]interface{}{"x": 1, "y": 2})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+
+	var remoteErr *cdp.RemoteError
+	assert.ErrorAs(t, err, &remoteErr)
+	assert.True(t, remoteErr.Unsupported)
+	assert.Equal(t, "Input.synthesizePinchGesture", remoteErr.Method)
+}
+
+func TestClient_Send_PinchingUnsupportedTopLevelErrorFromProtocolEnvelope(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	responseBody := "fake response body"
+	mockResponse := &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(responseBody)),
+	}
+
+	ts.mockHTTP.EXPECT().
+		Do(gomock.Any()).
+		Return(mockResponse, nil).
+		Times(1)
+
+	ts.mockIO.EXPECT().
+		ReadAll(gomock.Any()).
+		Return([]byte(responseBody), nil).
+		Times(1)
+
+	ts.mockJSON.EXPECT().
+		Unmarshal(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(data []byte, v interface{}) error {
+			targets := v.(*[]struct {
+				Type                 string `json:"type"`
+				Title                string `json:"title"`
+				WebSocketDebuggerURL string `json:"webSocketDebuggerUrl"`
+			})
+			*targets = []struct {
+				Type                 string `json:"type"`
+				Title                string `json:"title"`
+				WebSocketDebuggerURL string `json:"webSocketDebuggerUrl"`
+			}{
+				{Type: "page", Title: "Test Page", WebSocketDebuggerURL: "ws://localhost:9222/devtools/page/123"},
+			}
+			return nil
+		}).
+		Times(1)
+
+	ts.mockDialer.EXPECT().
+		DialContext(ts.ctx, gomock.Any(), nil).
+		Return(ts.mockConn, nil, nil).
+		Times(1)
+
+	err := ts.client.Init(ts.ctx)
+	assert.NoError(t, err)
+	assert.True(t, ts.client.Initialized())
+
+	ts.mockJSON.EXPECT().
+		Marshal(gomock.Any()).
+		Return([]byte(`{"id":1,"method":"Input.synthesizePinchGesture","params":{"x":1,"y":2}}`), nil).
+		Times(1)
+	ts.mockConn.EXPECT().
+		WriteMessage(websocket.TextMessage, gomock.Any()).
+		Return(nil).
+		Times(1)
+	ts.mockConn.EXPECT().
+		ReadMessage().
+		Return(websocket.TextMessage, []byte(`{"id":1,"error":{"code":-32601,"message":"method not found"}}`), nil).
+		Times(1)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(`{"id":1,"error":{"code":-32601,"message":"method not found"}}`), gomock.Any()).
+		DoAndReturn(func(data []byte, v interface{}) error {
+			resp := v.(*struct {
+				ID    int `json:"id"`
+				Error *struct {
+					Code    int         `json:"code"`
+					Message string      `json:"message"`
+					Data    interface{} `json:"data"`
+				} `json:"error"`
+				Result struct {
+					Result struct {
+						Type        string      `json:"type"`
+						Subtype     *string     `json:"subtype"`
+						ClassName   *string     `json:"className"`
+						Description *string     `json:"description"`
+						Value       interface{} `json:"value"`
+					} `json:"result"`
+				} `json:"result"`
+			})
+			resp.ID = 1
+			resp.Error = &struct {
+				Code    int         `json:"code"`
+				Message string      `json:"message"`
+				Data    interface{} `json:"data"`
+			}{
+				Code:    -32601,
+				Message: "method not found",
+			}
+			return nil
+		}).
+		Times(1)
+
+	result, err := ts.client.Send("Input.synthesizePinchGesture", map[string]interface{}{"x": 1, "y": 2})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+
+	var remoteErr *cdp.RemoteError
+	assert.ErrorAs(t, err, &remoteErr)
+	assert.True(t, remoteErr.Unsupported)
+	assert.Equal(t, "Input.synthesizePinchGesture", remoteErr.Method)
 }
 
 func TestClient_Send_Async(t *testing.T) {
@@ -1610,7 +2039,12 @@ func TestClient_Send_Async(t *testing.T) {
 
 			// Check if this is a CDP response structure (the first unmarshal call)
 			if _, ok := v.(*struct {
-				ID     int `json:"id"`
+				ID    int `json:"id"`
+				Error *struct {
+					Code    int         `json:"code"`
+					Message string      `json:"message"`
+					Data    interface{} `json:"data"`
+				} `json:"error"`
 				Result struct {
 					Result struct {
 						Type        string      `json:"type"`
@@ -1628,7 +2062,12 @@ func TestClient_Send_Async(t *testing.T) {
 				if _, err := fmt.Sscanf(string(data), `{"id":%d,`, &rawResp.ID); err == nil {
 					// This is the CDP response unmarshal
 					resp := v.(*struct {
-						ID     int `json:"id"`
+						ID    int `json:"id"`
+						Error *struct {
+							Code    int         `json:"code"`
+							Message string      `json:"message"`
+							Data    interface{} `json:"data"`
+						} `json:"error"`
 						Result struct {
 							Result struct {
 								Type        string      `json:"type"`

--- a/components/feral-controld/commandrouter/handler_test.go
+++ b/components/feral-controld/commandrouter/handler_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/feral-file/ffos-user/components/feral-controld/cdp"
 	"github.com/feral-file/ffos-user/components/feral-controld/commandrouter"
 	"github.com/feral-file/ffos-user/components/feral-controld/commands"
+	"github.com/feral-file/ffos-user/components/feral-controld/devicectl"
 	"github.com/feral-file/ffos-user/components/feral-controld/dp1"
 	"github.com/feral-file/ffos-user/components/feral-controld/mocks"
 	"github.com/feral-file/ffos-user/components/feral-controld/status"
@@ -172,6 +173,41 @@ func TestCommandHandler_Process_ControldCommand_Error(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, execError, err)
 	assert.Nil(t, result)
+}
+
+func TestCommandHandler_Process_NewGestureCommandsRouteToExecutor(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	cases := []struct {
+		name string
+		cmd  commands.Type
+	}{
+		{name: "doubleTapGesture", cmd: commands.CMD_MOUSE_DOUBLE_TAP_EVENT},
+		{name: "longPressGesture", cmd: commands.CMD_MOUSE_LONG_PRESS_EVENT},
+		{name: "clickAndDragGesture", cmd: commands.CMD_MOUSE_CLICK_AND_DRAG_EVENT},
+		{name: "zoomGesture", cmd: commands.CMD_ZOOM_GESTURE},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts.mockExecutor.EXPECT().
+				Execute(ts.ctx, commands.Command{
+					Type:      tc.cmd,
+					Arguments: map[string]interface{}{},
+				}).
+				Return(devicectl.CmdOK, nil).
+				Times(1)
+
+			result, err := ts.handler.Process(ts.ctx, commands.Command{
+				Type:      tc.cmd,
+				Arguments: map[string]interface{}{},
+			})
+
+			assert.NoError(t, err)
+			assert.Equal(t, devicectl.CmdOK, result)
+		})
+	}
 }
 
 func TestCommandHandler_Process_DisplayPlaylist_WithURL(t *testing.T) {

--- a/components/feral-controld/commands/types.go
+++ b/components/feral-controld/commands/types.go
@@ -14,29 +14,33 @@ func (c Type) String() string {
 
 // Device control commands
 var deviceCtlCommands = map[Type]bool{
-	CMD_CONNECT:              true,
-	CMD_SHOW_PAIRING_QR_CODE: true,
-	CMD_PROFILE:              true,
-	CMD_KEYBOARD_EVENT:       true,
-	CMD_MOUSE_DRAG_EVENT:     true,
-	CMD_MOUSE_TAP_EVENT:      true,
-	CMD_SCREEN_ROTATION:      true,
-	CMD_SHUTDOWN:             true,
-	CMD_REBOOT:               true,
-	CMD_ANALYTICS_TOGGLE:     true,
-	CMD_BETA_FEATURES_TOGGLE: true,
-	CMD_DEVICE_STATUS:        true,
-	CMD_UPDATE_TO_LATEST:     true,
-	CMD_FACTORY_RESET:        true,
-	CMD_UPLOAD_LOGS:          true,
-	CMD_SET_VOLUME:           true,
-	CMD_TOGGLE_MUTE:          true,
-	CMD_SSH_ACCESS:           true,
-	CMD_DDC_PANEL_CONTROL:    true,
-	CMD_DDC_PANEL_STATUS:     true,
-	CMD_SET_SLEEP_SCHEDULE:   true,
-	CMD_SLEEP_NOW:            true,
-	CMD_WAKE_NOW:             true,
+	CMD_CONNECT:                    true,
+	CMD_SHOW_PAIRING_QR_CODE:       true,
+	CMD_PROFILE:                    true,
+	CMD_KEYBOARD_EVENT:             true,
+	CMD_MOUSE_DRAG_EVENT:           true,
+	CMD_MOUSE_TAP_EVENT:            true,
+	CMD_MOUSE_DOUBLE_TAP_EVENT:     true,
+	CMD_MOUSE_LONG_PRESS_EVENT:     true,
+	CMD_MOUSE_CLICK_AND_DRAG_EVENT: true,
+	CMD_ZOOM_GESTURE:               true,
+	CMD_SCREEN_ROTATION:            true,
+	CMD_SHUTDOWN:                   true,
+	CMD_REBOOT:                     true,
+	CMD_ANALYTICS_TOGGLE:           true,
+	CMD_BETA_FEATURES_TOGGLE:       true,
+	CMD_DEVICE_STATUS:              true,
+	CMD_UPDATE_TO_LATEST:           true,
+	CMD_FACTORY_RESET:              true,
+	CMD_UPLOAD_LOGS:                true,
+	CMD_SET_VOLUME:                 true,
+	CMD_TOGGLE_MUTE:                true,
+	CMD_SSH_ACCESS:                 true,
+	CMD_DDC_PANEL_CONTROL:          true,
+	CMD_DDC_PANEL_STATUS:           true,
+	CMD_SET_SLEEP_SCHEDULE:         true,
+	CMD_SLEEP_NOW:                  true,
+	CMD_WAKE_NOW:                   true,
 }
 
 type Command struct {
@@ -49,32 +53,36 @@ func (c Command) JSON() ([]byte, error) {
 }
 
 const (
-	CMD_CONNECT                  Type = "connect"
-	CMD_SHOW_PAIRING_QR_CODE     Type = "showPairingQRCode"
-	CMD_PROFILE                  Type = "deviceMetrics"
-	CMD_KEYBOARD_EVENT           Type = "sendKeyboardEvent"
-	CMD_MOUSE_DRAG_EVENT         Type = "dragGesture"
-	CMD_MOUSE_TAP_EVENT          Type = "tapGesture"
-	CMD_SYS_METRICS              Type = "deviceMetrics"
-	CMD_SCREEN_ROTATION          Type = "rotate"
-	CMD_SHUTDOWN                 Type = "shutdown"
-	CMD_REBOOT                   Type = "reboot"
-	CMD_ANALYTICS_TOGGLE         Type = "analyticsToggle"
-	CMD_BETA_FEATURES_TOGGLE     Type = "betaFeaturesToggle"
-	CMD_DEVICE_STATUS            Type = "getDeviceStatus"
-	CMD_UPDATE_TO_LATEST         Type = "updateToLatestVersion"
-	CMD_DISPLAY_PLAYLIST         Type = "displayPlaylist"
-	CMD_FACTORY_RESET            Type = "factoryReset"
-	CMD_UPLOAD_LOGS              Type = "uploadLogs"
-	CMD_SET_VOLUME               Type = "setVolume"
-	CMD_TOGGLE_MUTE              Type = "toggleMute"
-	CMD_SSH_ACCESS               Type = "sshAccess"
-	CMD_DISPLAY_DEFAULT_PLAYLIST Type = "displayDefaultPlaylist"
-	CMD_REFRESH_ARTWORK          Type = "refreshArtwork"
-	CMD_SET_SLEEP_SCHEDULE       Type = "setSleepSchedule"
-	CMD_SLEEP_NOW                Type = "sleepNow"
-	CMD_WAKE_NOW                 Type = "wakeNow"
-	CMD_SET_SLEEP_MODE           Type = "setSleepMode"
+	CMD_CONNECT                    Type = "connect"
+	CMD_SHOW_PAIRING_QR_CODE       Type = "showPairingQRCode"
+	CMD_PROFILE                    Type = "deviceMetrics"
+	CMD_KEYBOARD_EVENT             Type = "sendKeyboardEvent"
+	CMD_MOUSE_DRAG_EVENT           Type = "dragGesture"
+	CMD_MOUSE_TAP_EVENT            Type = "tapGesture"
+	CMD_MOUSE_DOUBLE_TAP_EVENT     Type = "doubleTapGesture"
+	CMD_MOUSE_LONG_PRESS_EVENT     Type = "longPressGesture"
+	CMD_MOUSE_CLICK_AND_DRAG_EVENT Type = "clickAndDragGesture"
+	CMD_ZOOM_GESTURE               Type = "zoomGesture"
+	CMD_SYS_METRICS                Type = "deviceMetrics"
+	CMD_SCREEN_ROTATION            Type = "rotate"
+	CMD_SHUTDOWN                   Type = "shutdown"
+	CMD_REBOOT                     Type = "reboot"
+	CMD_ANALYTICS_TOGGLE           Type = "analyticsToggle"
+	CMD_BETA_FEATURES_TOGGLE       Type = "betaFeaturesToggle"
+	CMD_DEVICE_STATUS              Type = "getDeviceStatus"
+	CMD_UPDATE_TO_LATEST           Type = "updateToLatestVersion"
+	CMD_DISPLAY_PLAYLIST           Type = "displayPlaylist"
+	CMD_FACTORY_RESET              Type = "factoryReset"
+	CMD_UPLOAD_LOGS                Type = "uploadLogs"
+	CMD_SET_VOLUME                 Type = "setVolume"
+	CMD_TOGGLE_MUTE                Type = "toggleMute"
+	CMD_SSH_ACCESS                 Type = "sshAccess"
+	CMD_DISPLAY_DEFAULT_PLAYLIST   Type = "displayDefaultPlaylist"
+	CMD_REFRESH_ARTWORK            Type = "refreshArtwork"
+	CMD_SET_SLEEP_SCHEDULE         Type = "setSleepSchedule"
+	CMD_SLEEP_NOW                  Type = "sleepNow"
+	CMD_WAKE_NOW                   Type = "wakeNow"
+	CMD_SET_SLEEP_MODE             Type = "setSleepMode"
 	// CMD_DDC_PANEL_CONTROL drives the attached panel over DDC via ddcutil (brightness, contrast,
 	// speaker volume, mute, and power). One JSON command type; request body selects the operation.
 	CMD_DDC_PANEL_CONTROL Type = "ddcPanelControl"

--- a/components/feral-controld/devicectl/executor.go
+++ b/components/feral-controld/devicectl/executor.go
@@ -1046,12 +1046,30 @@ func (e *executor) sendZoomPinchGesture(scaleFactor float64) error {
 		"y":                 e.cursorPositionY,
 		"scaleFactor":       scaleFactor,
 		"relativeSpeed":     800,
-		"gestureSourceType": "default",
+		"gestureSourceType": "touch",
 	}
 
 	_, err := e.cdp.Send("Input.synthesizePinchGesture", params)
 	if err != nil {
 		return fmt.Errorf("synthesize pinch gesture: %w", err)
+	}
+
+	if err := e.resetPageScale(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *executor) resetPageScale() error {
+	// Some artwork documents do not consume a synthetic pinch, allowing Chromium
+	// to apply page-scale zoom. Keep browser scale fixed so later gestures do not
+	// operate on a stuck zoomed page.
+	_, err := e.cdp.Send("Emulation.setPageScaleFactor", map[string]interface{}{
+		"pageScaleFactor": 1,
+	})
+	if err != nil {
+		return fmt.Errorf("reset page scale: %w", err)
 	}
 
 	return nil
@@ -1075,7 +1093,7 @@ func (e *executor) sendZoomWheelGesture(scaleFactor float64) error {
 		"deltaY":    deltaY,
 		"button":    "none",
 		"buttons":   0,
-		"modifiers": 2,
+		"modifiers": 0,
 	}
 
 	_, err := e.cdp.Send("Input.dispatchMouseEvent", params)

--- a/components/feral-controld/devicectl/executor.go
+++ b/components/feral-controld/devicectl/executor.go
@@ -2,7 +2,9 @@ package devicectl
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -152,7 +154,15 @@ func (e *executor) Execute(ctx context.Context, cmd commands.Command) (interface
 	case commands.CMD_MOUSE_DRAG_EVENT:
 		result, err = e.handleMouseMoveEvent(bytes)
 	case commands.CMD_MOUSE_TAP_EVENT:
-		result, err = e.handleMouseTapEvent()
+		result, err = e.handleMouseTapEvent(bytes)
+	case commands.CMD_MOUSE_DOUBLE_TAP_EVENT:
+		result, err = e.handleMouseDoubleTapEvent(bytes)
+	case commands.CMD_MOUSE_LONG_PRESS_EVENT:
+		result, err = e.handleMouseLongPressEvent(ctx, bytes)
+	case commands.CMD_MOUSE_CLICK_AND_DRAG_EVENT:
+		result, err = e.handleMouseClickAndDragEvent(bytes)
+	case commands.CMD_ZOOM_GESTURE:
+		result, err = e.handleZoomGestureEvent(bytes)
 	case commands.CMD_PROFILE:
 		result, err = e.getSysMetrics()
 	case commands.CMD_SCREEN_ROTATION:
@@ -562,6 +572,38 @@ func printableASCIIKeyEvent(keyCode int) (key string, code string, text string) 
 	}
 }
 
+type mouseButtonWire string
+
+const (
+	mouseButtonLeft   mouseButtonWire = "left"
+	mouseButtonRight  mouseButtonWire = "right"
+	mouseButtonMiddle mouseButtonWire = "middle"
+)
+
+func (e *executor) parseMouseButton(args []byte) (button string, buttons int, err error) {
+	var cmdArgs struct {
+		Button string `json:"button"`
+	}
+	if err := e.json.Unmarshal(args, &cmdArgs); err != nil {
+		return "", 0, fmt.Errorf("invalid arguments: %w", err)
+	}
+
+	wire := mouseButtonWire(cmdArgs.Button)
+	if wire == "" {
+		wire = mouseButtonLeft
+	}
+	switch wire {
+	case mouseButtonLeft:
+		return "left", 1, nil
+	case mouseButtonRight:
+		return "right", 2, nil
+	case mouseButtonMiddle:
+		return "middle", 4, nil
+	default:
+		return "", 0, fmt.Errorf("invalid arguments: unknown mouse button: %s", cmdArgs.Button)
+	}
+}
+
 func (e *executor) initializeScreenDimensions() {
 	if e.screenInitialized {
 		return
@@ -607,7 +649,10 @@ func (e *executor) initializeScreenDimensions() {
 		zap.Float64("cursorY", e.cursorPositionY))
 }
 
-func (e *executor) handleMouseMoveEvent(args []byte) (interface{}, error) {
+func (e *executor) handleMouseMoveEventWithButtons(
+	args []byte,
+	pressedButtons int,
+) (interface{}, error) {
 	// Initialize screen dimensions if not done already
 	e.initializeScreenDimensions()
 
@@ -698,40 +743,215 @@ func (e *executor) handleMouseMoveEvent(args []byte) (interface{}, error) {
 	}
 
 	// 2. Send the final mouse event to actually move the cursor
-	if len(absolutePositions) > 0 {
-		// Get the last position for the final mouseMoved event
-		moveParams := map[string]interface{}{
-			"type":       "mouseMoved",
-			"x":          e.cursorPositionX,
-			"y":          e.cursorPositionY,
-			"button":     "none",
-			"buttons":    0,
-			"clickCount": 0,
-		}
-
-		_, err = e.cdp.Send("Input.dispatchMouseEvent", moveParams)
-		if err != nil {
-			e.logger.Error("Failed to move mouse via CDP", zap.Error(err))
-			return nil, fmt.Errorf("failed to move mouse: %w", err)
-		}
-
-		e.logger.Info("Mouse moved to final position",
-			zap.Float64("x", e.cursorPositionX),
-			zap.Float64("y", e.cursorPositionY))
+	moveParams := map[string]interface{}{
+		"type":       "mouseMoved",
+		"x":          e.cursorPositionX,
+		"y":          e.cursorPositionY,
+		"button":     "none",
+		"buttons":    pressedButtons,
+		"clickCount": 0,
 	}
+
+	_, err = e.cdp.Send("Input.dispatchMouseEvent", moveParams)
+	if err != nil {
+		e.logger.Error("Failed to move mouse via CDP", zap.Error(err))
+		return nil, fmt.Errorf("failed to move mouse: %w", err)
+	}
+
+	e.logger.Info("Mouse moved to final position",
+		zap.Float64("x", e.cursorPositionX),
+		zap.Float64("y", e.cursorPositionY))
 
 	return CmdOK, nil
 }
 
-func (e *executor) handleMouseTapEvent() (interface{}, error) {
+func (e *executor) handleMouseMoveEvent(args []byte) (interface{}, error) {
+	return e.handleMouseMoveEventWithButtons(args, 0)
+}
+
+func (e *executor) handleMouseTapEvent(args []byte) (interface{}, error) {
 	// Initialize screen dimensions if not done already
 	e.initializeScreenDimensions()
+
+	button, pressedButtons, err := e.parseMouseButton(args)
+	if err != nil {
+		return nil, err
+	}
 
 	e.logger.Info("Mouse tap event at current position",
 		zap.Float64("x", e.cursorPositionX),
 		zap.Float64("y", e.cursorPositionY))
 
-	// 1. Press mouse button at current position
+	if err := e.dispatchMouseClick(button, pressedButtons, 1); err != nil {
+		return nil, err
+	}
+
+	return CmdOK, nil
+}
+
+func (e *executor) dispatchMouseClick(button string, pressedButtons int, clickCount int) (err error) {
+	downParams := map[string]interface{}{
+		"type":       "mousePressed",
+		"x":          e.cursorPositionX,
+		"y":          e.cursorPositionY,
+		"button":     button,
+		"buttons":    pressedButtons,
+		"clickCount": clickCount,
+	}
+	upParams := map[string]interface{}{
+		"type":       "mouseReleased",
+		"x":          e.cursorPositionX,
+		"y":          e.cursorPositionY,
+		"button":     button,
+		"buttons":    0,
+		"clickCount": clickCount,
+	}
+
+	pressed := false
+	defer func() {
+		if !pressed {
+			return
+		}
+		_, releaseErr := e.cdp.Send("Input.dispatchMouseEvent", upParams)
+		if releaseErr != nil {
+			e.logger.Error("Failed to release mouse button via CDP during cleanup", zap.Error(releaseErr))
+		}
+	}()
+
+	_, err = e.cdp.Send("Input.dispatchMouseEvent", downParams)
+	if err != nil {
+		e.logger.Error("Failed to press mouse button via CDP", zap.Error(err))
+		return fmt.Errorf("failed to press mouse button: %w", err)
+	}
+	pressed = true
+
+	_, err = e.cdp.Send("Input.dispatchMouseEvent", upParams)
+	if err != nil {
+		e.logger.Error("Failed to release mouse button via CDP", zap.Error(err))
+		return fmt.Errorf("failed to release mouse button: %w", err)
+	}
+	pressed = false
+
+	return nil
+}
+
+func (e *executor) handleMouseDoubleTapEvent(args []byte) (interface{}, error) {
+	e.initializeScreenDimensions()
+
+	button, pressedButtons, err := e.parseMouseButton(args)
+	if err != nil {
+		return nil, err
+	}
+
+	e.logger.Info("Mouse double tap event at current position",
+		zap.Float64("x", e.cursorPositionX),
+		zap.Float64("y", e.cursorPositionY))
+
+	// Chromium's dblclick handling is sequence-sensitive: a single press/release
+	// pair with clickCount=2 can still collapse to a plain click on targets that
+	// inspect the full click sequence. Emit two clicks so the second one carries
+	// the double-click count expected by dblclick/double-tap handlers.
+	for clickCount := 1; clickCount <= 2; clickCount++ {
+		if err := e.dispatchMouseClick(button, pressedButtons, clickCount); err != nil {
+			return nil, err
+		}
+	}
+
+	return CmdOK, nil
+}
+
+func (e *executor) handleMouseLongPressEvent(ctx context.Context, args []byte) (result interface{}, err error) {
+	e.initializeScreenDimensions()
+
+	button, pressedButtons, err := e.parseMouseButton(args)
+	if err != nil {
+		return nil, err
+	}
+
+	e.logger.Info("Mouse long press event at current position",
+		zap.Float64("x", e.cursorPositionX),
+		zap.Float64("y", e.cursorPositionY))
+
+	downParams := map[string]interface{}{
+		"type":       "mousePressed",
+		"x":          e.cursorPositionX,
+		"y":          e.cursorPositionY,
+		"button":     button,
+		"buttons":    pressedButtons,
+		"clickCount": 1,
+	}
+	upParams := map[string]interface{}{
+		"type":       "mouseReleased",
+		"x":          e.cursorPositionX,
+		"y":          e.cursorPositionY,
+		"button":     button,
+		"buttons":    0,
+		"clickCount": 1,
+	}
+
+	pressed := false
+	defer func() {
+		if !pressed {
+			return
+		}
+		_, releaseErr := e.cdp.Send("Input.dispatchMouseEvent", upParams)
+		pressed = false
+		if releaseErr != nil {
+			e.logger.Error("Failed to release mouse button via CDP during cleanup", zap.Error(releaseErr))
+			// Join with any return err (e.g. ctx cancel during hold vs CDP stuck-button cleanup failure).
+			cleanupErr := fmt.Errorf("failed to release mouse button during cleanup: %w", releaseErr)
+			if err != nil {
+				err = errors.Join(err, cleanupErr)
+				return
+			}
+			err = cleanupErr
+		}
+	}()
+
+	_, err = e.cdp.Send("Input.dispatchMouseEvent", downParams)
+	if err != nil {
+		e.logger.Error("Failed to press mouse button via CDP", zap.Error(err))
+		return nil, fmt.Errorf("failed to press mouse button: %w", err)
+	}
+	pressed = true
+
+	// Hold duration must respect ctx so teardown can unwind without waiting the full second
+	// while the button is still logically down in Chromium.
+	if err = e.clock.SleepContext(ctx, 1*time.Second); err != nil {
+		return nil, err
+	}
+
+	_, err = e.cdp.Send("Input.dispatchMouseEvent", upParams)
+	if err != nil {
+		e.logger.Error("Failed to release mouse button via CDP", zap.Error(err))
+		return nil, fmt.Errorf("failed to release mouse button: %w", err)
+	}
+	pressed = false
+
+	return CmdOK, nil
+}
+
+func (e *executor) handleMouseClickAndDragEvent(args []byte) (result interface{}, err error) {
+	e.initializeScreenDimensions()
+
+	// Parse cursor offsets to decide whether we should press/move/release.
+	var cursorArgs struct {
+		CursorOffsets []struct {
+			DX float64 `json:"dx"`
+			DY float64 `json:"dy"`
+		} `json:"cursorOffsets"`
+	}
+	if err := e.json.Unmarshal(args, &cursorArgs); err != nil {
+		return nil, fmt.Errorf("invalid arguments: %w", err)
+	}
+	if len(cursorArgs.CursorOffsets) == 0 {
+		return CmdOK, nil
+	}
+
+	e.logger.Info("Mouse click-and-drag event at current position",
+		zap.Float64("x", e.cursorPositionX),
+		zap.Float64("y", e.cursorPositionY))
+
 	downParams := map[string]interface{}{
 		"type":       "mousePressed",
 		"x":          e.cursorPositionX,
@@ -740,30 +960,152 @@ func (e *executor) handleMouseTapEvent() (interface{}, error) {
 		"buttons":    1,
 		"clickCount": 1,
 	}
-
-	_, err := e.cdp.Send("Input.dispatchMouseEvent", downParams)
+	_, err = e.cdp.Send("Input.dispatchMouseEvent", downParams)
 	if err != nil {
 		e.logger.Error("Failed to press mouse button via CDP", zap.Error(err))
 		return nil, fmt.Errorf("failed to press mouse button: %w", err)
 	}
+	// Each click-and-drag batch is press + move + release. If the move step fails, we still
+	// must release the button; otherwise the page can keep a stuck mouse-down in Chromium
+	// until a later event clears it. Failed cleanup releases are always surfaced: alone when
+	// the move succeeded, or joined with the move error so a stuck-button cleanup failure is
+	// not dropped when the move path already failed.
+	defer func() {
+		up := map[string]interface{}{
+			"type":       "mouseReleased",
+			"x":          e.cursorPositionX,
+			"y":          e.cursorPositionY,
+			"button":     "left",
+			"buttons":    0,
+			"clickCount": 1,
+		}
+		if _, relErr := e.cdp.Send("Input.dispatchMouseEvent", up); relErr != nil {
+			e.logger.Error("click-and-drag: best-effort release after batch failed", zap.Error(relErr))
+			releaseErr := fmt.Errorf("failed to release mouse button during cleanup: %w", relErr)
+			if err == nil {
+				err = releaseErr
+			} else {
+				err = errors.Join(err, releaseErr)
+			}
+			result = nil
+		}
+	}()
 
-	// 2. Release mouse button
-	upParams := map[string]interface{}{
-		"type":       "mouseReleased",
-		"x":          e.cursorPositionX,
-		"y":          e.cursorPositionY,
-		"button":     "left",
-		"buttons":    0,
-		"clickCount": 1,
-	}
-
-	_, err = e.cdp.Send("Input.dispatchMouseEvent", upParams)
+	_, err = e.handleMouseMoveEventWithButtons(args, 1)
 	if err != nil {
-		e.logger.Error("Failed to release mouse button via CDP", zap.Error(err))
-		return nil, fmt.Errorf("failed to release mouse button: %w", err)
+		return nil, err
 	}
 
 	return CmdOK, nil
+}
+
+// handleZoomGestureEvent synthesizes pinch gestures at the CDP boundary. We
+// keep this in controld so the player UI does not need to understand a separate
+// gesture command.
+func (e *executor) handleZoomGestureEvent(args []byte) (interface{}, error) {
+	e.initializeScreenDimensions()
+
+	var in struct {
+		MessageID  string    `json:"messageID"`
+		ScaleSteps []float64 `json:"scaleSteps"`
+	}
+	if err := e.json.Unmarshal(args, &in); err != nil {
+		return nil, fmt.Errorf("invalid arguments: %w", err)
+	}
+	if len(in.ScaleSteps) == 0 {
+		return CmdOK, nil
+	}
+
+	for _, step := range in.ScaleSteps {
+		if step <= 0 {
+			return nil, fmt.Errorf("invalid arguments: scaleSteps must be positive: %v", step)
+		}
+	}
+
+	for _, step := range in.ScaleSteps {
+		if err := e.sendZoomPinchGesture(step); err != nil {
+			if !isUnsupportedPinchGestureError(err) {
+				e.logger.Error("Failed to synthesize pinch gesture", zap.Error(err))
+				return nil, fmt.Errorf("failed to process zoom gesture: %w", err)
+			}
+
+			e.logger.Warn("Pinch gesture unsupported, falling back to wheel zoom", zap.Error(err))
+			if fallbackErr := e.sendZoomWheelGesture(step); fallbackErr != nil {
+				e.logger.Error("Failed to dispatch zoom fallback", zap.Error(fallbackErr))
+				return nil, fmt.Errorf("failed to process zoom gesture: %w", fallbackErr)
+			}
+		}
+	}
+
+	return CmdOK, nil
+}
+
+func (e *executor) sendZoomPinchGesture(scaleFactor float64) error {
+	params := map[string]interface{}{
+		"x":                 e.cursorPositionX,
+		"y":                 e.cursorPositionY,
+		"scaleFactor":       scaleFactor,
+		"relativeSpeed":     800,
+		"gestureSourceType": "default",
+	}
+
+	_, err := e.cdp.Send("Input.synthesizePinchGesture", params)
+	if err != nil {
+		return fmt.Errorf("synthesize pinch gesture: %w", err)
+	}
+
+	return nil
+}
+
+func (e *executor) sendZoomWheelGesture(scaleFactor float64) error {
+	if scaleFactor == 1 {
+		return nil
+	}
+
+	deltaY := zoomWheelDeltaY(scaleFactor)
+	if scaleFactor > 1 {
+		deltaY = -deltaY
+	}
+
+	params := map[string]interface{}{
+		"type":      "mouseWheel",
+		"x":         e.cursorPositionX,
+		"y":         e.cursorPositionY,
+		"deltaX":    0,
+		"deltaY":    deltaY,
+		"button":    "none",
+		"buttons":   0,
+		"modifiers": 2,
+	}
+
+	_, err := e.cdp.Send("Input.dispatchMouseEvent", params)
+	if err != nil {
+		return fmt.Errorf("dispatch wheel gesture: %w", err)
+	}
+
+	return nil
+}
+
+func zoomWheelDeltaY(scaleFactor float64) float64 {
+	magnitude := math.Abs(math.Log2(scaleFactor))
+	steps := math.Round(magnitude * 8)
+	if steps < 1 {
+		steps = 1
+	}
+	return 120.0 * steps
+}
+
+func isUnsupportedPinchGestureError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var remoteErr *cdp.RemoteError
+	if !errors.As(err, &remoteErr) {
+		return false
+	}
+
+	return remoteErr.Method == "Input.synthesizePinchGesture" && remoteErr.Unsupported
 }
 
 func (e *executor) shutdown(ctx context.Context) (interface{}, error) {

--- a/components/feral-controld/devicectl/executor.go
+++ b/components/feral-controld/devicectl/executor.go
@@ -1012,9 +1012,8 @@ func (e *executor) handleMouseClickAndDragEvent(args []byte) (result interface{}
 	return CmdOK, nil
 }
 
-// handleZoomGestureEvent synthesizes pinch gestures at the CDP boundary. We
-// keep this in controld so the player UI does not need to understand a separate
-// gesture command.
+// handleZoomGestureEvent dispatches non-Ctrl wheel input at the CDP boundary.
+// This avoids Chromium page zoom while still giving artwork a zoom-like input.
 func (e *executor) handleZoomGestureEvent(ctx context.Context, args []byte) (interface{}, error) {
 	e.initializeScreenDimensions()
 
@@ -1046,59 +1045,13 @@ func (e *executor) handleZoomGestureEvent(ctx context.Context, args []byte) (int
 		}
 
 		x, y := e.zoomGesturePoint(step)
-		if err := e.sendZoomPinchGesture(step, x, y); err != nil {
-			if !isUnsupportedPinchGestureError(err) {
-				e.logger.Error("Failed to synthesize pinch gesture", zap.Error(err))
-				return nil, fmt.Errorf("failed to process zoom gesture: %w", err)
-			}
-
-			e.logger.Warn("Pinch gesture unsupported, falling back to wheel zoom", zap.Error(err))
-			if fallbackErr := e.sendZoomWheelGesture(step, x, y); fallbackErr != nil {
-				e.logger.Error("Failed to dispatch zoom fallback", zap.Error(fallbackErr))
-				return nil, fmt.Errorf("failed to process zoom gesture: %w", fallbackErr)
-			}
-			continue
-		}
-
-		if err := e.resetPageScaleFactor(); err != nil {
-			e.logger.Error("Failed to reset page scale after pinch gesture", zap.Error(err))
+		if err := e.sendZoomWheelGesture(step, x, y); err != nil {
+			e.logger.Error("Failed to dispatch zoom wheel gesture", zap.Error(err))
 			return nil, fmt.Errorf("failed to process zoom gesture: %w", err)
 		}
 	}
 
 	return CmdOK, nil
-}
-
-func (e *executor) sendZoomPinchGesture(scaleFactor, x, y float64) error {
-	params := map[string]interface{}{
-		"x":                 x,
-		"y":                 y,
-		"scaleFactor":       scaleFactor,
-		"relativeSpeed":     3200,
-		"gestureSourceType": "default",
-		"modifiers":         0,
-	}
-
-	_, err := e.cdp.Send("Input.synthesizePinchGesture", params)
-	if err != nil {
-		return fmt.Errorf("synthesize pinch gesture: %w", err)
-	}
-
-	return nil
-}
-
-// Pinch input can leave Chromium's page scale changed even when the gesture is
-// meant to drive artwork behavior, so we normalize the page scale after each
-// successful pinch and keep the browser from retaining zoom state.
-func (e *executor) resetPageScaleFactor() error {
-	_, err := e.cdp.Send("Emulation.setPageScaleFactor", map[string]interface{}{
-		"pageScaleFactor": 1.0,
-	})
-	if err != nil {
-		return fmt.Errorf("set page scale factor: %w", err)
-	}
-
-	return nil
 }
 
 func (e *executor) zoomGesturePoint(scaleFactor float64) (float64, float64) {
@@ -1218,19 +1171,6 @@ func zoomWheelDeltaY(scaleFactor float64) float64 {
 		steps = 1
 	}
 	return 120.0 * steps
-}
-
-func isUnsupportedPinchGestureError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	var remoteErr *cdp.RemoteError
-	if !errors.As(err, &remoteErr) {
-		return false
-	}
-
-	return remoteErr.Method == "Input.synthesizePinchGesture" && remoteErr.Unsupported
 }
 
 func (e *executor) shutdown(ctx context.Context) (interface{}, error) {

--- a/components/feral-controld/devicectl/executor.go
+++ b/components/feral-controld/devicectl/executor.go
@@ -1060,12 +1060,8 @@ func (e *executor) sendZoomPinchGesture(scaleFactor float64) error {
 }
 
 func (e *executor) zoomGesturePoint(scaleFactor float64) (float64, float64) {
-	if scaleFactor < 1 {
-		viewportX, viewportY, viewportWidth, viewportHeight := e.currentVisualViewport()
-		return e.innerToVisualViewport(e.cursorPositionX, e.cursorPositionY, viewportX, viewportY, viewportWidth, viewportHeight)
-	}
-
-	return e.cursorPositionX, e.cursorPositionY
+	viewportX, viewportY, viewportWidth, viewportHeight := e.currentVisualViewport()
+	return e.innerToVisualViewport(e.cursorPositionX, e.cursorPositionY, viewportX, viewportY, viewportWidth, viewportHeight)
 }
 
 func (e *executor) innerToVisualViewport(x, y, viewportX, viewportY, viewportWidth, viewportHeight float64) (float64, float64) {

--- a/components/feral-controld/devicectl/executor.go
+++ b/components/feral-controld/devicectl/executor.go
@@ -39,6 +39,9 @@ const (
 	BetaFeaturesToggleOnFile = "/home/feralfile/.state/beta-features-toggle-on"
 	// SavedVolumeFile stores the user's volume setting to persist across reboots.
 	SavedVolumeFile = "/home/feralfile/.state/saved-volume"
+	// maxZoomGestureSteps bounds a single zoom request so relayer traffic cannot
+	// monopolize the executor on arbitrarily large gesture batches.
+	maxZoomGestureSteps = 16
 )
 
 type Device struct {
@@ -162,7 +165,7 @@ func (e *executor) Execute(ctx context.Context, cmd commands.Command) (interface
 	case commands.CMD_MOUSE_CLICK_AND_DRAG_EVENT:
 		result, err = e.handleMouseClickAndDragEvent(bytes)
 	case commands.CMD_ZOOM_GESTURE:
-		result, err = e.handleZoomGestureEvent(bytes)
+		result, err = e.handleZoomGestureEvent(ctx, bytes)
 	case commands.CMD_PROFILE:
 		result, err = e.getSysMetrics()
 	case commands.CMD_SCREEN_ROTATION:
@@ -1006,7 +1009,7 @@ func (e *executor) handleMouseClickAndDragEvent(args []byte) (result interface{}
 // handleZoomGestureEvent synthesizes pinch gestures at the CDP boundary. We
 // keep this in controld so the player UI does not need to understand a separate
 // gesture command.
-func (e *executor) handleZoomGestureEvent(args []byte) (interface{}, error) {
+func (e *executor) handleZoomGestureEvent(ctx context.Context, args []byte) (interface{}, error) {
 	e.initializeScreenDimensions()
 
 	var in struct {
@@ -1019,6 +1022,9 @@ func (e *executor) handleZoomGestureEvent(args []byte) (interface{}, error) {
 	if len(in.ScaleSteps) == 0 {
 		return CmdOK, nil
 	}
+	if len(in.ScaleSteps) > maxZoomGestureSteps {
+		return nil, fmt.Errorf("invalid arguments: scaleSteps exceeds maximum of %d", maxZoomGestureSteps)
+	}
 
 	for _, step := range in.ScaleSteps {
 		if step <= 0 {
@@ -1027,6 +1033,12 @@ func (e *executor) handleZoomGestureEvent(args []byte) (interface{}, error) {
 	}
 
 	for _, step := range in.ScaleSteps {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
 		x, y := e.zoomGesturePoint(step)
 		if err := e.sendZoomPinchGesture(step, x, y); err != nil {
 			if !isUnsupportedPinchGestureError(err) {

--- a/components/feral-controld/devicectl/executor.go
+++ b/components/feral-controld/devicectl/executor.go
@@ -1039,6 +1039,12 @@ func (e *executor) handleZoomGestureEvent(args []byte) (interface{}, error) {
 				e.logger.Error("Failed to dispatch zoom fallback", zap.Error(fallbackErr))
 				return nil, fmt.Errorf("failed to process zoom gesture: %w", fallbackErr)
 			}
+			continue
+		}
+
+		if err := e.resetPageScaleFactor(); err != nil {
+			e.logger.Error("Failed to reset page scale after pinch gesture", zap.Error(err))
+			return nil, fmt.Errorf("failed to process zoom gesture: %w", err)
 		}
 	}
 
@@ -1058,6 +1064,20 @@ func (e *executor) sendZoomPinchGesture(scaleFactor, x, y float64) error {
 	_, err := e.cdp.Send("Input.synthesizePinchGesture", params)
 	if err != nil {
 		return fmt.Errorf("synthesize pinch gesture: %w", err)
+	}
+
+	return nil
+}
+
+// Pinch input can leave Chromium's page scale changed even when the gesture is
+// meant to drive artwork behavior, so we normalize the page scale after each
+// successful pinch and keep the browser from retaining zoom state.
+func (e *executor) resetPageScaleFactor() error {
+	_, err := e.cdp.Send("Emulation.setPageScaleFactor", map[string]interface{}{
+		"pageScaleFactor": 1.0,
+	})
+	if err != nil {
+		return fmt.Errorf("set page scale factor: %w", err)
 	}
 
 	return nil

--- a/components/feral-controld/devicectl/executor.go
+++ b/components/feral-controld/devicectl/executor.go
@@ -1045,8 +1045,9 @@ func (e *executor) sendZoomPinchGesture(scaleFactor float64) error {
 		"x":                 e.cursorPositionX,
 		"y":                 e.cursorPositionY,
 		"scaleFactor":       scaleFactor,
-		"relativeSpeed":     800,
-		"gestureSourceType": "touch",
+		"relativeSpeed":     3200,
+		"gestureSourceType": "default",
+		"modifiers":         0,
 	}
 
 	_, err := e.cdp.Send("Input.synthesizePinchGesture", params)

--- a/components/feral-controld/devicectl/executor.go
+++ b/components/feral-controld/devicectl/executor.go
@@ -1065,13 +1065,9 @@ func (e *executor) zoomGesturePoint(scaleFactor float64) (float64, float64) {
 }
 
 func (e *executor) innerToVisualViewport(x, y, viewportX, viewportY, viewportWidth, viewportHeight float64) (float64, float64) {
-	if e.screenWidth <= 0 || e.screenHeight <= 0 {
-		return viewportX, viewportY
-	}
-
-	visualX := viewportX + (x/e.screenWidth)*viewportWidth
-	visualY := viewportY + (y/e.screenHeight)*viewportHeight
-	return e.clampToViewport(visualX, visualY, viewportX, viewportY, viewportWidth, viewportHeight)
+	visualX := x - viewportX
+	visualY := y - viewportY
+	return e.clampToViewport(visualX, visualY, 0, 0, viewportWidth, viewportHeight)
 }
 
 func (e *executor) currentVisualViewport() (float64, float64, float64, float64) {

--- a/components/feral-controld/devicectl/executor.go
+++ b/components/feral-controld/devicectl/executor.go
@@ -39,6 +39,9 @@ const (
 	BetaFeaturesToggleOnFile = "/home/feralfile/.state/beta-features-toggle-on"
 	// SavedVolumeFile stores the user's volume setting to persist across reboots.
 	SavedVolumeFile = "/home/feralfile/.state/saved-volume"
+	// maxClickAndDragCursorOffsets bounds a single pressed drag batch so one
+	// relayer request cannot hold Chromium in mouse-down state for unbounded work.
+	maxClickAndDragCursorOffsets = 16
 	// maxZoomGestureSteps bounds a single zoom request so relayer traffic cannot
 	// monopolize the executor on arbitrarily large gesture batches.
 	maxZoomGestureSteps = 16
@@ -953,6 +956,9 @@ func (e *executor) handleMouseClickAndDragEvent(args []byte) (result interface{}
 	}
 	if len(cursorArgs.CursorOffsets) == 0 {
 		return CmdOK, nil
+	}
+	if len(cursorArgs.CursorOffsets) > maxClickAndDragCursorOffsets {
+		return nil, fmt.Errorf("invalid arguments: cursorOffsets exceeds maximum of %d", maxClickAndDragCursorOffsets)
 	}
 
 	e.logger.Info("Mouse click-and-drag event at current position",

--- a/components/feral-controld/devicectl/executor.go
+++ b/components/feral-controld/devicectl/executor.go
@@ -1041,9 +1041,10 @@ func (e *executor) handleZoomGestureEvent(args []byte) (interface{}, error) {
 }
 
 func (e *executor) sendZoomPinchGesture(scaleFactor float64) error {
+	x, y := e.zoomGesturePoint(scaleFactor)
 	params := map[string]interface{}{
-		"x":                 e.cursorPositionX,
-		"y":                 e.cursorPositionY,
+		"x":                 x,
+		"y":                 y,
 		"scaleFactor":       scaleFactor,
 		"relativeSpeed":     3200,
 		"gestureSourceType": "default",
@@ -1056,6 +1057,88 @@ func (e *executor) sendZoomPinchGesture(scaleFactor float64) error {
 	}
 
 	return nil
+}
+
+func (e *executor) zoomGesturePoint(scaleFactor float64) (float64, float64) {
+	if scaleFactor < 1 {
+		viewportX, viewportY, viewportWidth, viewportHeight := e.currentVisualViewport()
+		// Zoom-out pinch gestures are more sensitive to edge proximity in Chromium.
+		// Keep the anchor centered in the current visual viewport so the gesture
+		// stays valid after Chromium has already applied a previous zoom.
+		return viewportX + viewportWidth/2, viewportY + viewportHeight/2
+	}
+
+	return e.cursorPositionX, e.cursorPositionY
+}
+
+func (e *executor) currentVisualViewport() (float64, float64, float64, float64) {
+	viewportX, viewportY := 0.0, 0.0
+	viewportWidth, viewportHeight := e.screenWidth, e.screenHeight
+
+	evalParams := map[string]interface{}{
+		"expression": `
+			(() => {
+				const vv = window.visualViewport;
+				return vv ? {
+					offsetLeft: vv.offsetLeft,
+					offsetTop: vv.offsetTop,
+					width: vv.width,
+					height: vv.height
+				} : null;
+			})()`,
+		"returnByValue": true,
+	}
+
+	result, err := e.cdp.Send("Runtime.evaluate", evalParams)
+	if err != nil {
+		e.logger.Warn("Failed to get visual viewport; using screen bounds", zap.Error(err))
+		return viewportX, viewportY, viewportWidth, viewportHeight
+	}
+
+	if result == nil {
+		return viewportX, viewportY, viewportWidth, viewportHeight
+	}
+
+	viewport, ok := result.(map[string]interface{})
+	if !ok {
+		return viewportX, viewportY, viewportWidth, viewportHeight
+	}
+
+	if offsetLeft, ok := viewport["offsetLeft"].(float64); ok {
+		viewportX = offsetLeft
+	}
+	if offsetTop, ok := viewport["offsetTop"].(float64); ok {
+		viewportY = offsetTop
+	}
+	if width, ok := viewport["width"].(float64); ok && width > 0 {
+		viewportWidth = width
+	}
+	if height, ok := viewport["height"].(float64); ok && height > 0 {
+		viewportHeight = height
+	}
+
+	return viewportX, viewportY, viewportWidth, viewportHeight
+}
+
+func (e *executor) clampToViewport(x, y, viewportX, viewportY, viewportWidth, viewportHeight float64) (float64, float64) {
+	minX := viewportX
+	maxX := viewportX + viewportWidth
+	minY := viewportY
+	maxY := viewportY + viewportHeight
+
+	if x < minX {
+		x = minX
+	} else if x > maxX {
+		x = maxX
+	}
+
+	if y < minY {
+		y = minY
+	} else if y > maxY {
+		y = maxY
+	}
+
+	return x, y
 }
 
 func (e *executor) sendZoomWheelGesture(scaleFactor float64) error {

--- a/components/feral-controld/devicectl/executor.go
+++ b/components/feral-controld/devicectl/executor.go
@@ -1054,24 +1054,6 @@ func (e *executor) sendZoomPinchGesture(scaleFactor float64) error {
 		return fmt.Errorf("synthesize pinch gesture: %w", err)
 	}
 
-	if err := e.resetPageScale(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (e *executor) resetPageScale() error {
-	// Some artwork documents do not consume a synthetic pinch, allowing Chromium
-	// to apply page-scale zoom. Keep browser scale fixed so later gestures do not
-	// operate on a stuck zoomed page.
-	_, err := e.cdp.Send("Emulation.setPageScaleFactor", map[string]interface{}{
-		"pageScaleFactor": 1,
-	})
-	if err != nil {
-		return fmt.Errorf("reset page scale: %w", err)
-	}
-
 	return nil
 }
 

--- a/components/feral-controld/devicectl/executor.go
+++ b/components/feral-controld/devicectl/executor.go
@@ -1062,13 +1062,20 @@ func (e *executor) sendZoomPinchGesture(scaleFactor float64) error {
 func (e *executor) zoomGesturePoint(scaleFactor float64) (float64, float64) {
 	if scaleFactor < 1 {
 		viewportX, viewportY, viewportWidth, viewportHeight := e.currentVisualViewport()
-		// Zoom-out pinch gestures are more sensitive to edge proximity in Chromium.
-		// Keep the anchor centered in the current visual viewport so the gesture
-		// stays valid after Chromium has already applied a previous zoom.
-		return viewportX + viewportWidth/2, viewportY + viewportHeight/2
+		return e.innerToVisualViewport(e.cursorPositionX, e.cursorPositionY, viewportX, viewportY, viewportWidth, viewportHeight)
 	}
 
 	return e.cursorPositionX, e.cursorPositionY
+}
+
+func (e *executor) innerToVisualViewport(x, y, viewportX, viewportY, viewportWidth, viewportHeight float64) (float64, float64) {
+	if e.screenWidth <= 0 || e.screenHeight <= 0 {
+		return viewportX, viewportY
+	}
+
+	visualX := viewportX + (x/e.screenWidth)*viewportWidth
+	visualY := viewportY + (y/e.screenHeight)*viewportHeight
+	return e.clampToViewport(visualX, visualY, viewportX, viewportY, viewportWidth, viewportHeight)
 }
 
 func (e *executor) currentVisualViewport() (float64, float64, float64, float64) {

--- a/components/feral-controld/devicectl/executor.go
+++ b/components/feral-controld/devicectl/executor.go
@@ -861,6 +861,10 @@ func (e *executor) handleMouseDoubleTapEvent(args []byte) (interface{}, error) {
 }
 
 func (e *executor) handleMouseLongPressEvent(ctx context.Context, args []byte) (result interface{}, err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	e.initializeScreenDimensions()
 
 	button, pressedButtons, err := e.parseMouseButton(args)
@@ -1023,14 +1027,15 @@ func (e *executor) handleZoomGestureEvent(args []byte) (interface{}, error) {
 	}
 
 	for _, step := range in.ScaleSteps {
-		if err := e.sendZoomPinchGesture(step); err != nil {
+		x, y := e.zoomGesturePoint(step)
+		if err := e.sendZoomPinchGesture(step, x, y); err != nil {
 			if !isUnsupportedPinchGestureError(err) {
 				e.logger.Error("Failed to synthesize pinch gesture", zap.Error(err))
 				return nil, fmt.Errorf("failed to process zoom gesture: %w", err)
 			}
 
 			e.logger.Warn("Pinch gesture unsupported, falling back to wheel zoom", zap.Error(err))
-			if fallbackErr := e.sendZoomWheelGesture(step); fallbackErr != nil {
+			if fallbackErr := e.sendZoomWheelGesture(step, x, y); fallbackErr != nil {
 				e.logger.Error("Failed to dispatch zoom fallback", zap.Error(fallbackErr))
 				return nil, fmt.Errorf("failed to process zoom gesture: %w", fallbackErr)
 			}
@@ -1040,8 +1045,7 @@ func (e *executor) handleZoomGestureEvent(args []byte) (interface{}, error) {
 	return CmdOK, nil
 }
 
-func (e *executor) sendZoomPinchGesture(scaleFactor float64) error {
-	x, y := e.zoomGesturePoint(scaleFactor)
+func (e *executor) sendZoomPinchGesture(scaleFactor, x, y float64) error {
 	params := map[string]interface{}{
 		"x":                 x,
 		"y":                 y,
@@ -1140,7 +1144,7 @@ func (e *executor) clampToViewport(x, y, viewportX, viewportY, viewportWidth, vi
 	return x, y
 }
 
-func (e *executor) sendZoomWheelGesture(scaleFactor float64) error {
+func (e *executor) sendZoomWheelGesture(scaleFactor, x, y float64) error {
 	if scaleFactor == 1 {
 		return nil
 	}
@@ -1152,8 +1156,8 @@ func (e *executor) sendZoomWheelGesture(scaleFactor float64) error {
 
 	params := map[string]interface{}{
 		"type":      "mouseWheel",
-		"x":         e.cursorPositionX,
-		"y":         e.cursorPositionY,
+		"x":         x,
+		"y":         y,
 		"deltaX":    0,
 		"deltaY":    deltaY,
 		"button":    "none",

--- a/components/feral-controld/devicectl/executor_test.go
+++ b/components/feral-controld/devicectl/executor_test.go
@@ -2690,6 +2690,14 @@ func TestExecutor_ZoomGestureEvent_Success(t *testing.T) {
 			"width":      screenWidth,
 			"height":     screenHeight,
 		}, nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{
+			"offsetLeft": 0.0,
+			"offsetTop":  0.0,
+			"width":      screenWidth,
+			"height":     screenHeight,
+		}, nil)
 	ts.mockJSON.EXPECT().
 		Unmarshal([]byte(argsJSON), gomock.Any()).
 		DoAndReturn(func(_ []byte, v interface{}) error {
@@ -2751,6 +2759,14 @@ func TestExecutor_ZoomGestureEvent_WithMessageID(t *testing.T) {
 	ts.mockCDP.EXPECT().
 		Send("Runtime.evaluate", gomock.Any()).
 		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{
+			"offsetLeft": 0.0,
+			"offsetTop":  0.0,
+			"width":      screenWidth,
+			"height":     screenHeight,
+		}, nil)
 	ts.mockJSON.EXPECT().
 		Unmarshal([]byte(argsJSON), gomock.Any()).
 		DoAndReturn(func(_ []byte, v interface{}) error {
@@ -2833,6 +2849,14 @@ func TestExecutor_ZoomGestureEvent_CDPError(t *testing.T) {
 	ts.mockCDP.EXPECT().
 		Send("Runtime.evaluate", gomock.Any()).
 		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{
+			"offsetLeft": 0.0,
+			"offsetTop":  0.0,
+			"width":      screenWidth,
+			"height":     screenHeight,
+		}, nil)
 	ts.mockJSON.EXPECT().
 		Unmarshal([]byte(argsJSON), gomock.Any()).
 		DoAndReturn(func(_ []byte, v interface{}) error {
@@ -2884,6 +2908,14 @@ func TestExecutor_ZoomGestureEvent_UnsupportedExperimentalMethod(t *testing.T) {
 	ts.mockCDP.EXPECT().
 		Send("Runtime.evaluate", gomock.Any()).
 		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{
+			"offsetLeft": 0.0,
+			"offsetTop":  0.0,
+			"width":      screenWidth,
+			"height":     screenHeight,
+		}, nil)
 	ts.mockJSON.EXPECT().
 		Unmarshal([]byte(argsJSON), gomock.Any()).
 		DoAndReturn(func(_ []byte, v interface{}) error {
@@ -3016,6 +3048,14 @@ func TestExecutor_ZoomGestureEvent_NeutralScaleDoesNotFallback(t *testing.T) {
 	ts.mockCDP.EXPECT().
 		Send("Runtime.evaluate", gomock.Any()).
 		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{
+			"offsetLeft": 0.0,
+			"offsetTop":  0.0,
+			"width":      screenWidth,
+			"height":     screenHeight,
+		}, nil)
 	ts.mockJSON.EXPECT().
 		Unmarshal([]byte(argsJSON), gomock.Any()).
 		DoAndReturn(func(_ []byte, v interface{}) error {
@@ -3066,6 +3106,14 @@ func TestExecutor_ZoomGestureEvent_FallbackMagnitudeGrowsWithScale(t *testing.T)
 	ts.mockCDP.EXPECT().
 		Send("Runtime.evaluate", gomock.Any()).
 		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{
+			"offsetLeft": 0.0,
+			"offsetTop":  0.0,
+			"width":      screenWidth,
+			"height":     screenHeight,
+		}, nil)
 	ts.mockJSON.EXPECT().
 		Unmarshal([]byte(argsJSON), gomock.Any()).
 		DoAndReturn(func(_ []byte, v interface{}) error {
@@ -3128,6 +3176,14 @@ func TestExecutor_ZoomGestureEvent_PinchNotSupportedFails(t *testing.T) {
 	ts.mockCDP.EXPECT().
 		Send("Runtime.evaluate", gomock.Any()).
 		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{
+			"offsetLeft": 0.0,
+			"offsetTop":  0.0,
+			"width":      screenWidth,
+			"height":     screenHeight,
+		}, nil)
 	ts.mockJSON.EXPECT().
 		Unmarshal([]byte(argsJSON), gomock.Any()).
 		DoAndReturn(func(_ []byte, v interface{}) error {
@@ -3321,6 +3377,14 @@ func TestExecutor_ZoomGestureEvent_UnsupportedMethodWithNameFallbacks(t *testing
 	ts.mockCDP.EXPECT().
 		Send("Runtime.evaluate", gomock.Any()).
 		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{
+			"offsetLeft": 0.0,
+			"offsetTop":  0.0,
+			"width":      screenWidth,
+			"height":     screenHeight,
+		}, nil)
 	ts.mockJSON.EXPECT().
 		Unmarshal([]byte(argsJSON), gomock.Any()).
 		DoAndReturn(func(_ []byte, v interface{}) error {
@@ -3383,6 +3447,14 @@ func TestExecutor_ZoomGestureEvent_TargetNotFoundDoesNotFallback(t *testing.T) {
 	ts.mockCDP.EXPECT().
 		Send("Runtime.evaluate", gomock.Any()).
 		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{
+			"offsetLeft": 0.0,
+			"offsetTop":  0.0,
+			"width":      screenWidth,
+			"height":     screenHeight,
+		}, nil)
 	ts.mockJSON.EXPECT().
 		Unmarshal([]byte(argsJSON), gomock.Any()).
 		DoAndReturn(func(_ []byte, v interface{}) error {

--- a/components/feral-controld/devicectl/executor_test.go
+++ b/components/feral-controld/devicectl/executor_test.go
@@ -18,7 +18,6 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
-	"github.com/feral-file/ffos-user/components/feral-controld/cdp"
 	"github.com/feral-file/ffos-user/components/feral-controld/commands"
 	constants "github.com/feral-file/ffos-user/components/feral-controld/constant"
 	"github.com/feral-file/ffos-user/components/feral-controld/dbus"
@@ -108,14 +107,6 @@ func setup(t *testing.T) *testSetup {
 func (ts *testSetup) teardown() {
 	state.ResetForTesting()
 	ts.ctrl.Finish()
-}
-
-func expectPageScaleReset(ts *testSetup) {
-	ts.mockCDP.EXPECT().
-		Send("Emulation.setPageScaleFactor", map[string]interface{}{
-			"pageScaleFactor": 1.0,
-		}).
-		Return(nil, nil)
 }
 
 func TestExecutor_Execute_InvalidCommand(t *testing.T) {
@@ -2758,22 +2749,16 @@ func TestExecutor_ZoomGestureEvent_Success(t *testing.T) {
 	ts.mockCDP.EXPECT().
 		Send("Runtime.evaluate", gomock.Any()).
 		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
-	ts.mockCDP.EXPECT().
-		Send("Runtime.evaluate", gomock.Any()).
-		Return(map[string]interface{}{
-			"offsetLeft": 0.0,
-			"offsetTop":  0.0,
-			"width":      screenWidth,
-			"height":     screenHeight,
-		}, nil)
-	ts.mockCDP.EXPECT().
-		Send("Runtime.evaluate", gomock.Any()).
-		Return(map[string]interface{}{
-			"offsetLeft": 0.0,
-			"offsetTop":  0.0,
-			"width":      screenWidth,
-			"height":     screenHeight,
-		}, nil)
+	for i := 0; i < 2; i++ {
+		ts.mockCDP.EXPECT().
+			Send("Runtime.evaluate", gomock.Any()).
+			Return(map[string]interface{}{
+				"offsetLeft": 0.0,
+				"offsetTop":  0.0,
+				"width":      screenWidth,
+				"height":     screenHeight,
+			}, nil)
+	}
 	ts.mockJSON.EXPECT().
 		Unmarshal([]byte(argsJSON), gomock.Any()).
 		DoAndReturn(func(_ []byte, v interface{}) error {
@@ -2787,28 +2772,23 @@ func TestExecutor_ZoomGestureEvent_Success(t *testing.T) {
 			in.ScaleSteps = []float64{1.05, 0.98}
 			return nil
 		})
-	ts.mockCDP.EXPECT().
-		Send("Input.synthesizePinchGesture", map[string]interface{}{
-			"x":                 centerX,
-			"y":                 centerY,
-			"scaleFactor":       1.05,
-			"relativeSpeed":     3200,
-			"gestureSourceType": "default",
-			"modifiers":         0,
-		}).
-		Return(nil, nil)
-	expectPageScaleReset(ts)
-	ts.mockCDP.EXPECT().
-		Send("Input.synthesizePinchGesture", map[string]interface{}{
-			"x":                 centerX,
-			"y":                 centerY,
-			"scaleFactor":       0.98,
-			"relativeSpeed":     3200,
-			"gestureSourceType": "default",
-			"modifiers":         0,
-		}).
-		Return(nil, nil)
-	expectPageScaleReset(ts)
+	type wheel struct {
+		deltaY float64
+	}
+	for _, want := range []wheel{{deltaY: -120.0}, {deltaY: 120.0}} {
+		ts.mockCDP.EXPECT().
+			Send("Input.dispatchMouseEvent", map[string]interface{}{
+				"type":      "mouseWheel",
+				"x":         centerX,
+				"y":         centerY,
+				"deltaX":    0,
+				"deltaY":    want.deltaY,
+				"button":    "none",
+				"buttons":   0,
+				"modifiers": 0,
+			}).
+			Return(nil, nil)
+	}
 
 	result, err := ts.executor.Execute(ts.ctx, cmd)
 	assert.NoError(t, err)
@@ -2859,26 +2839,27 @@ func TestExecutor_ZoomGestureEvent_MapsAnchorForDifferentScaleSteps(t *testing.T
 		})
 
 	for _, want := range []struct {
-		scale float64
-		x     float64
-		y     float64
+		x      float64
+		y      float64
+		deltaY float64
 	}{
-		{scale: 1.5, x: 960, y: 540},
-		{scale: 0.5, x: 840, y: 460},
-		{scale: 2.25, x: 660, y: 340},
-		{scale: 0.25, x: 460, y: 240},
+		{x: 960, y: 540, deltaY: -600.0},
+		{x: 840, y: 460, deltaY: 960.0},
+		{x: 660, y: 340, deltaY: -1080.0},
+		{x: 460, y: 240, deltaY: 1920.0},
 	} {
 		ts.mockCDP.EXPECT().
-			Send("Input.synthesizePinchGesture", map[string]interface{}{
-				"x":                 want.x,
-				"y":                 want.y,
-				"scaleFactor":       want.scale,
-				"relativeSpeed":     3200,
-				"gestureSourceType": "default",
-				"modifiers":         0,
+			Send("Input.dispatchMouseEvent", map[string]interface{}{
+				"type":      "mouseWheel",
+				"x":         want.x,
+				"y":         want.y,
+				"deltaX":    0,
+				"deltaY":    want.deltaY,
+				"button":    "none",
+				"buttons":   0,
+				"modifiers": 0,
 			}).
 			Return(nil, nil)
-		expectPageScaleReset(ts)
 	}
 
 	result, err := ts.executor.Execute(ts.ctx, cmd)
@@ -2931,16 +2912,17 @@ func TestExecutor_ZoomGestureEvent_WithMessageID(t *testing.T) {
 			return nil
 		})
 	ts.mockCDP.EXPECT().
-		Send("Input.synthesizePinchGesture", map[string]interface{}{
-			"x":                 centerX,
-			"y":                 centerY,
-			"scaleFactor":       1.1,
-			"relativeSpeed":     3200,
-			"gestureSourceType": "default",
-			"modifiers":         0,
+		Send("Input.dispatchMouseEvent", map[string]interface{}{
+			"type":      "mouseWheel",
+			"x":         centerX,
+			"y":         centerY,
+			"deltaX":    0,
+			"deltaY":    -120.0,
+			"button":    "none",
+			"buttons":   0,
+			"modifiers": 0,
 		}).
 		Return(nil, nil)
-	expectPageScaleReset(ts)
 
 	result, err := ts.executor.Execute(ts.ctx, cmd)
 	assert.NoError(t, err)
@@ -3100,75 +3082,6 @@ func TestExecutor_ZoomGestureEvent_CDPError(t *testing.T) {
 			return nil
 		})
 	ts.mockCDP.EXPECT().
-		Send("Input.synthesizePinchGesture", map[string]interface{}{
-			"x":                 centerX,
-			"y":                 centerY,
-			"scaleFactor":       1.01,
-			"relativeSpeed":     3200,
-			"gestureSourceType": "default",
-			"modifiers":         0,
-		}).
-		Return(nil, errors.New("cdp pinch failed"))
-
-	result, err := ts.executor.Execute(ts.ctx, cmd)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to process zoom gesture")
-	assert.Nil(t, result)
-}
-
-func TestExecutor_ZoomGestureEvent_UnsupportedExperimentalMethod(t *testing.T) {
-	ts := setup(t)
-	defer ts.teardown()
-
-	screenWidth := 1920.0
-	screenHeight := 1080.0
-	centerX := screenWidth / 2
-	centerY := screenHeight / 2
-
-	cmd := commands.Command{
-		Type: commands.CMD_ZOOM_GESTURE,
-		Arguments: map[string]interface{}{
-			"scaleSteps": []float64{1.02},
-		},
-	}
-	argsJSON := `{"scaleSteps":[1.02]}`
-
-	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
-	ts.mockCDP.EXPECT().
-		Send("Runtime.evaluate", gomock.Any()).
-		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
-	ts.mockCDP.EXPECT().
-		Send("Runtime.evaluate", gomock.Any()).
-		Return(map[string]interface{}{
-			"offsetLeft": 0.0,
-			"offsetTop":  0.0,
-			"width":      screenWidth,
-			"height":     screenHeight,
-		}, nil)
-	ts.mockJSON.EXPECT().
-		Unmarshal([]byte(argsJSON), gomock.Any()).
-		DoAndReturn(func(_ []byte, v interface{}) error {
-			in, ok := v.(*struct {
-				MessageID  string    `json:"messageID"`
-				ScaleSteps []float64 `json:"scaleSteps"`
-			})
-			if !ok {
-				return errors.New("unexpected type in zoomGesture unmarshal")
-			}
-			in.ScaleSteps = []float64{1.02}
-			return nil
-		})
-	ts.mockCDP.EXPECT().
-		Send("Input.synthesizePinchGesture", map[string]interface{}{
-			"x":                 centerX,
-			"y":                 centerY,
-			"scaleFactor":       1.02,
-			"relativeSpeed":     3200,
-			"gestureSourceType": "default",
-			"modifiers":         0,
-		}).
-		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "unknown method", Unsupported: true})
-	ts.mockCDP.EXPECT().
 		Send("Input.dispatchMouseEvent", map[string]interface{}{
 			"type":      "mouseWheel",
 			"x":         centerX,
@@ -3179,97 +3092,17 @@ func TestExecutor_ZoomGestureEvent_UnsupportedExperimentalMethod(t *testing.T) {
 			"buttons":   0,
 			"modifiers": 0,
 		}).
-		Return(nil, nil)
+		Return(nil, errors.New("cdp wheel failed"))
 
 	result, err := ts.executor.Execute(ts.ctx, cmd)
-	assert.NoError(t, err)
-	assert.Equal(t, devicectl.CmdOK, result)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to process zoom gesture")
+	assert.Nil(t, result)
 }
 
-func TestExecutor_ZoomGestureEvent_PinchUnsupportedUsesFallback(t *testing.T) {
+func TestExecutor_ZoomGestureEvent_NeutralScaleDoesNotDispatchWheel(t *testing.T) {
 	ts := setup(t)
 	defer ts.teardown()
-
-	screenWidth := 1920.0
-	screenHeight := 1080.0
-	centerX := screenWidth / 2
-	centerY := screenHeight / 2
-	viewportX := 120.0
-	viewportY := 80.0
-	viewportW := 1280.0
-	viewportH := 720.0
-	fallbackX := centerX - viewportX
-	fallbackY := centerY - viewportY
-
-	cmd := commands.Command{
-		Type: commands.CMD_ZOOM_GESTURE,
-		Arguments: map[string]interface{}{
-			"scaleSteps": []float64{0.98},
-		},
-	}
-	argsJSON := `{"scaleSteps":[0.98]}`
-
-	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
-	ts.mockCDP.EXPECT().
-		Send("Runtime.evaluate", gomock.Any()).
-		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
-	ts.mockCDP.EXPECT().
-		Send("Runtime.evaluate", gomock.Any()).
-		Return(map[string]interface{}{
-			"offsetLeft": viewportX,
-			"offsetTop":  viewportY,
-			"width":      viewportW,
-			"height":     viewportH,
-		}, nil)
-	ts.mockJSON.EXPECT().
-		Unmarshal([]byte(argsJSON), gomock.Any()).
-		DoAndReturn(func(_ []byte, v interface{}) error {
-			in, ok := v.(*struct {
-				MessageID  string    `json:"messageID"`
-				ScaleSteps []float64 `json:"scaleSteps"`
-			})
-			if !ok {
-				return errors.New("unexpected type in zoomGesture unmarshal")
-			}
-			in.ScaleSteps = []float64{0.98}
-			return nil
-		})
-	ts.mockCDP.EXPECT().
-		Send("Input.synthesizePinchGesture", map[string]interface{}{
-			"x":                 fallbackX,
-			"y":                 fallbackY,
-			"scaleFactor":       0.98,
-			"relativeSpeed":     3200,
-			"gestureSourceType": "default",
-			"modifiers":         0,
-		}).
-		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "Method not found", Unsupported: true})
-	ts.mockCDP.EXPECT().
-		Send("Input.dispatchMouseEvent", map[string]interface{}{
-			"type":      "mouseWheel",
-			"x":         fallbackX,
-			"y":         fallbackY,
-			"deltaX":    0,
-			"deltaY":    120.0,
-			"button":    "none",
-			"buttons":   0,
-			"modifiers": 0,
-		}).
-		Return(nil, nil)
-
-	result, err := ts.executor.Execute(ts.ctx, cmd)
-	assert.NoError(t, err)
-	assert.Equal(t, devicectl.CmdOK, result)
-}
-
-func TestExecutor_ZoomGestureEvent_NeutralScaleDoesNotFallback(t *testing.T) {
-	ts := setup(t)
-	defer ts.teardown()
-
-	screenWidth := 1920.0
-	screenHeight := 1080.0
-	centerX := screenWidth / 2
-	centerY := screenHeight / 2
 
 	cmd := commands.Command{
 		Type: commands.CMD_ZOOM_GESTURE,
@@ -3282,14 +3115,14 @@ func TestExecutor_ZoomGestureEvent_NeutralScaleDoesNotFallback(t *testing.T) {
 	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
 	ts.mockCDP.EXPECT().
 		Send("Runtime.evaluate", gomock.Any()).
-		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+		Return(map[string]interface{}{"width": 1920.0, "height": 1080.0}, nil)
 	ts.mockCDP.EXPECT().
 		Send("Runtime.evaluate", gomock.Any()).
 		Return(map[string]interface{}{
 			"offsetLeft": 0.0,
 			"offsetTop":  0.0,
-			"width":      screenWidth,
-			"height":     screenHeight,
+			"width":      1920.0,
+			"height":     1080.0,
 		}, nil)
 	ts.mockJSON.EXPECT().
 		Unmarshal([]byte(argsJSON), gomock.Any()).
@@ -3304,149 +3137,10 @@ func TestExecutor_ZoomGestureEvent_NeutralScaleDoesNotFallback(t *testing.T) {
 			in.ScaleSteps = []float64{1.0}
 			return nil
 		})
-	ts.mockCDP.EXPECT().
-		Send("Input.synthesizePinchGesture", map[string]interface{}{
-			"x":                 centerX,
-			"y":                 centerY,
-			"scaleFactor":       1.0,
-			"relativeSpeed":     3200,
-			"gestureSourceType": "default",
-			"modifiers":         0,
-		}).
-		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "Method not found", Unsupported: true})
 
 	result, err := ts.executor.Execute(ts.ctx, cmd)
 	assert.NoError(t, err)
 	assert.Equal(t, devicectl.CmdOK, result)
-}
-
-func TestExecutor_ZoomGestureEvent_FallbackMagnitudeGrowsWithScale(t *testing.T) {
-	ts := setup(t)
-	defer ts.teardown()
-
-	screenWidth := 1920.0
-	screenHeight := 1080.0
-	centerX := screenWidth / 2
-	centerY := screenHeight / 2
-
-	cmd := commands.Command{
-		Type: commands.CMD_ZOOM_GESTURE,
-		Arguments: map[string]interface{}{
-			"scaleSteps": []float64{1.5},
-		},
-	}
-	argsJSON := `{"scaleSteps":[1.5]}`
-
-	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
-	ts.mockCDP.EXPECT().
-		Send("Runtime.evaluate", gomock.Any()).
-		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
-	ts.mockCDP.EXPECT().
-		Send("Runtime.evaluate", gomock.Any()).
-		Return(map[string]interface{}{
-			"offsetLeft": 0.0,
-			"offsetTop":  0.0,
-			"width":      screenWidth,
-			"height":     screenHeight,
-		}, nil)
-	ts.mockJSON.EXPECT().
-		Unmarshal([]byte(argsJSON), gomock.Any()).
-		DoAndReturn(func(_ []byte, v interface{}) error {
-			in, ok := v.(*struct {
-				MessageID  string    `json:"messageID"`
-				ScaleSteps []float64 `json:"scaleSteps"`
-			})
-			if !ok {
-				return errors.New("unexpected type in zoomGesture unmarshal")
-			}
-			in.ScaleSteps = []float64{1.5}
-			return nil
-		})
-	ts.mockCDP.EXPECT().
-		Send("Input.synthesizePinchGesture", map[string]interface{}{
-			"x":                 centerX,
-			"y":                 centerY,
-			"scaleFactor":       1.5,
-			"relativeSpeed":     3200,
-			"gestureSourceType": "default",
-			"modifiers":         0,
-		}).
-		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "unknown method", Unsupported: true})
-	ts.mockCDP.EXPECT().
-		Send("Input.dispatchMouseEvent", map[string]interface{}{
-			"type":      "mouseWheel",
-			"x":         centerX,
-			"y":         centerY,
-			"deltaX":    0,
-			"deltaY":    -600.0,
-			"button":    "none",
-			"buttons":   0,
-			"modifiers": 0,
-		}).
-		Return(nil, nil)
-
-	result, err := ts.executor.Execute(ts.ctx, cmd)
-	assert.NoError(t, err)
-	assert.Equal(t, devicectl.CmdOK, result)
-}
-
-func TestExecutor_ZoomGestureEvent_PinchNotSupportedFails(t *testing.T) {
-	ts := setup(t)
-	defer ts.teardown()
-
-	screenWidth := 1920.0
-	screenHeight := 1080.0
-	centerX := screenWidth / 2
-	centerY := screenHeight / 2
-
-	cmd := commands.Command{
-		Type: commands.CMD_ZOOM_GESTURE,
-		Arguments: map[string]interface{}{
-			"scaleSteps": []float64{1.02},
-		},
-	}
-	argsJSON := `{"scaleSteps":[1.02]}`
-
-	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
-	ts.mockCDP.EXPECT().
-		Send("Runtime.evaluate", gomock.Any()).
-		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
-	ts.mockCDP.EXPECT().
-		Send("Runtime.evaluate", gomock.Any()).
-		Return(map[string]interface{}{
-			"offsetLeft": 0.0,
-			"offsetTop":  0.0,
-			"width":      screenWidth,
-			"height":     screenHeight,
-		}, nil)
-	ts.mockJSON.EXPECT().
-		Unmarshal([]byte(argsJSON), gomock.Any()).
-		DoAndReturn(func(_ []byte, v interface{}) error {
-			in, ok := v.(*struct {
-				MessageID  string    `json:"messageID"`
-				ScaleSteps []float64 `json:"scaleSteps"`
-			})
-			if !ok {
-				return errors.New("unexpected type in zoomGesture unmarshal")
-			}
-			in.ScaleSteps = []float64{1.02}
-			return nil
-		})
-	ts.mockCDP.EXPECT().
-		Send("Input.synthesizePinchGesture", map[string]interface{}{
-			"x":                 centerX,
-			"y":                 centerY,
-			"scaleFactor":       1.02,
-			"relativeSpeed":     3200,
-			"gestureSourceType": "default",
-			"modifiers":         0,
-		}).
-		Return(nil, errors.New("feature not supported"))
-
-	result, err := ts.executor.Execute(ts.ctx, cmd)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to process zoom gesture")
-	assert.Nil(t, result)
 }
 
 func TestExecutor_ZoomGestureEvent_InvalidScaleStepFailsFast(t *testing.T) {
@@ -3518,205 +3212,6 @@ func TestExecutor_ZoomGestureEvent_InvalidScaleStepFailsBeforeDispatch(t *testin
 	result, err := ts.executor.Execute(ts.ctx, cmd)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "scaleSteps must be positive")
-	assert.Nil(t, result)
-}
-
-func TestExecutor_ZoomGestureEvent_UnsupportedWordingFallbacks(t *testing.T) {
-	ts := setup(t)
-	defer ts.teardown()
-
-	screenWidth := 1920.0
-	screenHeight := 1080.0
-	centerX := screenWidth / 2
-	centerY := screenHeight / 2
-
-	cmd := commands.Command{
-		Type: commands.CMD_ZOOM_GESTURE,
-		Arguments: map[string]interface{}{
-			"scaleSteps": []float64{0.98},
-		},
-	}
-	argsJSON := `{"scaleSteps":[0.98]}`
-
-	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
-	ts.mockCDP.EXPECT().
-		Send("Runtime.evaluate", gomock.Any()).
-		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
-	ts.mockCDP.EXPECT().
-		Send("Runtime.evaluate", gomock.Any()).
-		Return(map[string]interface{}{
-			"offsetLeft": 0.0,
-			"offsetTop":  0.0,
-			"width":      screenWidth,
-			"height":     screenHeight,
-		}, nil)
-	ts.mockJSON.EXPECT().
-		Unmarshal([]byte(argsJSON), gomock.Any()).
-		DoAndReturn(func(_ []byte, v interface{}) error {
-			in, ok := v.(*struct {
-				MessageID  string    `json:"messageID"`
-				ScaleSteps []float64 `json:"scaleSteps"`
-			})
-			if !ok {
-				return errors.New("unexpected type in zoomGesture unmarshal")
-			}
-			in.ScaleSteps = []float64{0.98}
-			return nil
-		})
-	ts.mockCDP.EXPECT().
-		Send("Input.synthesizePinchGesture", map[string]interface{}{
-			"x":                 centerX,
-			"y":                 centerY,
-			"scaleFactor":       0.98,
-			"relativeSpeed":     3200,
-			"gestureSourceType": "default",
-			"modifiers":         0,
-		}).
-		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "wasn't found", Unsupported: true})
-	ts.mockCDP.EXPECT().
-		Send("Input.dispatchMouseEvent", map[string]interface{}{
-			"type":      "mouseWheel",
-			"x":         centerX,
-			"y":         centerY,
-			"deltaX":    0,
-			"deltaY":    120.0,
-			"button":    "none",
-			"buttons":   0,
-			"modifiers": 0,
-		}).
-		Return(nil, nil)
-
-	result, err := ts.executor.Execute(ts.ctx, cmd)
-	assert.NoError(t, err)
-	assert.Equal(t, devicectl.CmdOK, result)
-}
-
-func TestExecutor_ZoomGestureEvent_UnsupportedMethodWithNameFallbacks(t *testing.T) {
-	ts := setup(t)
-	defer ts.teardown()
-
-	screenWidth := 1920.0
-	screenHeight := 1080.0
-	centerX := screenWidth / 2
-	centerY := screenHeight / 2
-
-	cmd := commands.Command{
-		Type: commands.CMD_ZOOM_GESTURE,
-		Arguments: map[string]interface{}{
-			"scaleSteps": []float64{1.02},
-		},
-	}
-	argsJSON := `{"scaleSteps":[1.02]}`
-
-	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
-	ts.mockCDP.EXPECT().
-		Send("Runtime.evaluate", gomock.Any()).
-		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
-	ts.mockCDP.EXPECT().
-		Send("Runtime.evaluate", gomock.Any()).
-		Return(map[string]interface{}{
-			"offsetLeft": 0.0,
-			"offsetTop":  0.0,
-			"width":      screenWidth,
-			"height":     screenHeight,
-		}, nil)
-	ts.mockJSON.EXPECT().
-		Unmarshal([]byte(argsJSON), gomock.Any()).
-		DoAndReturn(func(_ []byte, v interface{}) error {
-			in, ok := v.(*struct {
-				MessageID  string    `json:"messageID"`
-				ScaleSteps []float64 `json:"scaleSteps"`
-			})
-			if !ok {
-				return errors.New("unexpected type in zoomGesture unmarshal")
-			}
-			in.ScaleSteps = []float64{1.02}
-			return nil
-		})
-	ts.mockCDP.EXPECT().
-		Send("Input.synthesizePinchGesture", map[string]interface{}{
-			"x":                 centerX,
-			"y":                 centerY,
-			"scaleFactor":       1.02,
-			"relativeSpeed":     3200,
-			"gestureSourceType": "default",
-			"modifiers":         0,
-		}).
-		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "method not found", Unsupported: true})
-	ts.mockCDP.EXPECT().
-		Send("Input.dispatchMouseEvent", map[string]interface{}{
-			"type":      "mouseWheel",
-			"x":         centerX,
-			"y":         centerY,
-			"deltaX":    0,
-			"deltaY":    -120.0,
-			"button":    "none",
-			"buttons":   0,
-			"modifiers": 0,
-		}).
-		Return(nil, nil)
-
-	result, err := ts.executor.Execute(ts.ctx, cmd)
-	assert.NoError(t, err)
-	assert.Equal(t, devicectl.CmdOK, result)
-}
-
-func TestExecutor_ZoomGestureEvent_TargetNotFoundDoesNotFallback(t *testing.T) {
-	ts := setup(t)
-	defer ts.teardown()
-
-	screenWidth := 1920.0
-	screenHeight := 1080.0
-	centerX := screenWidth / 2
-	centerY := screenHeight / 2
-
-	cmd := commands.Command{
-		Type: commands.CMD_ZOOM_GESTURE,
-		Arguments: map[string]interface{}{
-			"scaleSteps": []float64{1.02},
-		},
-	}
-	argsJSON := `{"scaleSteps":[1.02]}`
-
-	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
-	ts.mockCDP.EXPECT().
-		Send("Runtime.evaluate", gomock.Any()).
-		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
-	ts.mockCDP.EXPECT().
-		Send("Runtime.evaluate", gomock.Any()).
-		Return(map[string]interface{}{
-			"offsetLeft": 0.0,
-			"offsetTop":  0.0,
-			"width":      screenWidth,
-			"height":     screenHeight,
-		}, nil)
-	ts.mockJSON.EXPECT().
-		Unmarshal([]byte(argsJSON), gomock.Any()).
-		DoAndReturn(func(_ []byte, v interface{}) error {
-			in, ok := v.(*struct {
-				MessageID  string    `json:"messageID"`
-				ScaleSteps []float64 `json:"scaleSteps"`
-			})
-			if !ok {
-				return errors.New("unexpected type in zoomGesture unmarshal")
-			}
-			in.ScaleSteps = []float64{1.02}
-			return nil
-		})
-	ts.mockCDP.EXPECT().
-		Send("Input.synthesizePinchGesture", map[string]interface{}{
-			"x":                 centerX,
-			"y":                 centerY,
-			"scaleFactor":       1.02,
-			"relativeSpeed":     3200,
-			"gestureSourceType": "default",
-			"modifiers":         0,
-		}).
-		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "Target not found", Unsupported: false})
-
-	result, err := ts.executor.Execute(ts.ctx, cmd)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to process zoom gesture")
 	assert.Nil(t, result)
 }
 

--- a/components/feral-controld/devicectl/executor_test.go
+++ b/components/feral-controld/devicectl/executor_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/feral-file/godbus"
 	"github.com/golang/mock/gomock"
@@ -17,6 +18,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
+	"github.com/feral-file/ffos-user/components/feral-controld/cdp"
 	"github.com/feral-file/ffos-user/components/feral-controld/commands"
 	constants "github.com/feral-file/ffos-user/components/feral-controld/constant"
 	"github.com/feral-file/ffos-user/components/feral-controld/dbus"
@@ -1661,6 +1663,17 @@ func TestExecutor_MouseTapEvent_Success(t *testing.T) {
 			"height": screenHeight,
 		}, nil)
 
+	// parseMouseButton default left
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(`{}`), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			args := v.(*struct {
+				Button string `json:"button"`
+			})
+			args.Button = ""
+			return nil
+		})
+
 	// Mock CDP Send for mouse press
 	downParams := map[string]interface{}{
 		"type":       "mousePressed",
@@ -1693,6 +1706,1677 @@ func TestExecutor_MouseTapEvent_Success(t *testing.T) {
 	assert.Equal(t, devicectl.CmdOK, result)
 }
 
+func TestExecutor_MouseTapEvent_RightButton(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	// Set up test data
+	screenWidth := 1920.0
+	screenHeight := 1080.0
+	centerX := screenWidth / 2
+	centerY := screenHeight / 2
+
+	cmd := commands.Command{
+		Type: commands.CMD_MOUSE_TAP_EVENT,
+		Arguments: map[string]interface{}{
+			"button": "right",
+		},
+	}
+
+	ts.mockJSON.EXPECT().
+		Marshal(cmd.Arguments).
+		Return([]byte(`{"button":"right"}`), nil)
+
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{
+			"width":  screenWidth,
+			"height": screenHeight,
+		}, nil)
+
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(`{"button":"right"}`), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			args := v.(*struct {
+				Button string `json:"button"`
+			})
+			args.Button = "right"
+			return nil
+		})
+
+	downParams := map[string]interface{}{
+		"type":       "mousePressed",
+		"x":          centerX,
+		"y":          centerY,
+		"button":     "right",
+		"buttons":    2,
+		"clickCount": 1,
+	}
+	ts.mockCDP.EXPECT().
+		Send("Input.dispatchMouseEvent", downParams).
+		Return(nil, nil)
+
+	upParams := map[string]interface{}{
+		"type":       "mouseReleased",
+		"x":          centerX,
+		"y":          centerY,
+		"button":     "right",
+		"buttons":    0,
+		"clickCount": 1,
+	}
+	ts.mockCDP.EXPECT().
+		Send("Input.dispatchMouseEvent", upParams).
+		Return(nil, nil)
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.NoError(t, err)
+	assert.Equal(t, devicectl.CmdOK, result)
+}
+
+func TestExecutor_MouseTapEvent_InvalidButton(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	cmd := commands.Command{
+		Type: commands.CMD_MOUSE_TAP_EVENT,
+		Arguments: map[string]interface{}{
+			"button": "nope",
+		},
+	}
+
+	ts.mockJSON.EXPECT().
+		Marshal(cmd.Arguments).
+		Return([]byte(`{"button":"nope"}`), nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{"width": 1920.0, "height": 1080.0}, nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(`{"button":"nope"}`), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			p := v.(*struct {
+				Button string `json:"button"`
+			})
+			p.Button = "nope"
+			return nil
+		})
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown mouse button")
+	assert.Nil(t, result)
+}
+
+func TestExecutor_MouseDoubleTapEvent_DefaultLeft(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	screenWidth := 1920.0
+	screenHeight := 1080.0
+	centerX := screenWidth / 2
+	centerY := screenHeight / 2
+
+	cmd := commands.Command{
+		Type:      commands.CMD_MOUSE_DOUBLE_TAP_EVENT,
+		Arguments: map[string]interface{}{},
+	}
+
+	ts.mockJSON.EXPECT().
+		Marshal(cmd.Arguments).
+		Return([]byte(`{}`), nil)
+
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{
+			"width":  screenWidth,
+			"height": screenHeight,
+		}, nil)
+
+	// parseMouseButton default left
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(`{}`), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			args := v.(*struct {
+				Button string `json:"button"`
+			})
+			args.Button = ""
+			return nil
+		})
+
+	firstDown := map[string]interface{}{
+		"type":       "mousePressed",
+		"x":          centerX,
+		"y":          centerY,
+		"button":     "left",
+		"buttons":    1,
+		"clickCount": 1,
+	}
+	firstUp := map[string]interface{}{
+		"type":       "mouseReleased",
+		"x":          centerX,
+		"y":          centerY,
+		"button":     "left",
+		"buttons":    0,
+		"clickCount": 1,
+	}
+	secondDown := map[string]interface{}{
+		"type":       "mousePressed",
+		"x":          centerX,
+		"y":          centerY,
+		"button":     "left",
+		"buttons":    1,
+		"clickCount": 2,
+	}
+	secondUp := map[string]interface{}{
+		"type":       "mouseReleased",
+		"x":          centerX,
+		"y":          centerY,
+		"button":     "left",
+		"buttons":    0,
+		"clickCount": 2,
+	}
+	ts.mockCDP.EXPECT().Send("Input.dispatchMouseEvent", firstDown).Return(nil, nil)
+	ts.mockCDP.EXPECT().Send("Input.dispatchMouseEvent", firstUp).Return(nil, nil)
+	ts.mockCDP.EXPECT().Send("Input.dispatchMouseEvent", secondDown).Return(nil, nil)
+	ts.mockCDP.EXPECT().Send("Input.dispatchMouseEvent", secondUp).Return(nil, nil)
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.NoError(t, err)
+	assert.Equal(t, devicectl.CmdOK, result)
+}
+
+func TestExecutor_MouseDoubleTapEvent_ReleaseFailureAttemptsCleanup(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	screenWidth := 1920.0
+	screenHeight := 1080.0
+	centerX := screenWidth / 2
+	centerY := screenHeight / 2
+
+	cmd := commands.Command{
+		Type:      commands.CMD_MOUSE_DOUBLE_TAP_EVENT,
+		Arguments: map[string]interface{}{},
+	}
+
+	ts.mockJSON.EXPECT().
+		Marshal(cmd.Arguments).
+		Return([]byte(`{}`), nil)
+
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{
+			"width":  screenWidth,
+			"height": screenHeight,
+		}, nil)
+
+	// parseMouseButton default left
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(`{}`), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			args := v.(*struct {
+				Button string `json:"button"`
+			})
+			args.Button = ""
+			return nil
+		})
+
+	firstDown := map[string]interface{}{
+		"type":       "mousePressed",
+		"x":          centerX,
+		"y":          centerY,
+		"button":     "left",
+		"buttons":    1,
+		"clickCount": 1,
+	}
+	firstUp := map[string]interface{}{
+		"type":       "mouseReleased",
+		"x":          centerX,
+		"y":          centerY,
+		"button":     "left",
+		"buttons":    0,
+		"clickCount": 1,
+	}
+
+	releaseErr := errors.New("release failed")
+	gomock.InOrder(
+		ts.mockCDP.EXPECT().Send("Input.dispatchMouseEvent", firstDown).Return(nil, nil),
+		ts.mockCDP.EXPECT().Send("Input.dispatchMouseEvent", firstUp).Return(nil, releaseErr),
+		// cleanup attempt
+		ts.mockCDP.EXPECT().Send("Input.dispatchMouseEvent", firstUp).Return(nil, nil),
+	)
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to release mouse button")
+	assert.Nil(t, result)
+}
+
+func TestExecutor_MouseLongPressEvent_SleepsAndReleases(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	screenWidth := 1920.0
+	screenHeight := 1080.0
+	centerX := screenWidth / 2
+	centerY := screenHeight / 2
+
+	cmd := commands.Command{
+		Type:      commands.CMD_MOUSE_LONG_PRESS_EVENT,
+		Arguments: map[string]interface{}{},
+	}
+
+	ts.mockJSON.EXPECT().
+		Marshal(cmd.Arguments).
+		Return([]byte(`{}`), nil)
+
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{
+			"width":  screenWidth,
+			"height": screenHeight,
+		}, nil)
+
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(`{}`), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			args := v.(*struct {
+				Button string `json:"button"`
+			})
+			args.Button = ""
+			return nil
+		})
+
+	downParams := map[string]interface{}{
+		"type":       "mousePressed",
+		"x":          centerX,
+		"y":          centerY,
+		"button":     "left",
+		"buttons":    1,
+		"clickCount": 1,
+	}
+	upParams := map[string]interface{}{
+		"type":       "mouseReleased",
+		"x":          centerX,
+		"y":          centerY,
+		"button":     "left",
+		"buttons":    0,
+		"clickCount": 1,
+	}
+
+	gomock.InOrder(
+		ts.mockCDP.EXPECT().Send("Input.dispatchMouseEvent", downParams).Return(nil, nil),
+		ts.mockClock.EXPECT().SleepContext(ts.ctx, 1*time.Second).Return(nil),
+		ts.mockCDP.EXPECT().Send("Input.dispatchMouseEvent", upParams).Return(nil, nil),
+	)
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.NoError(t, err)
+	assert.Equal(t, devicectl.CmdOK, result)
+}
+
+func TestExecutor_MouseLongPressEvent_ContextCanceledDuringHoldReleasesDefer(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	screenWidth := 1920.0
+	screenHeight := 1080.0
+	centerX := screenWidth / 2
+	centerY := screenHeight / 2
+
+	cmd := commands.Command{
+		Type:      commands.CMD_MOUSE_LONG_PRESS_EVENT,
+		Arguments: map[string]interface{}{},
+	}
+
+	ts.mockJSON.EXPECT().
+		Marshal(cmd.Arguments).
+		Return([]byte(`{}`), nil)
+
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{
+			"width":  screenWidth,
+			"height": screenHeight,
+		}, nil)
+
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(`{}`), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			args := v.(*struct {
+				Button string `json:"button"`
+			})
+			args.Button = ""
+			return nil
+		})
+
+	downParams := map[string]interface{}{
+		"type":       "mousePressed",
+		"x":          centerX,
+		"y":          centerY,
+		"button":     "left",
+		"buttons":    1,
+		"clickCount": 1,
+	}
+	upParams := map[string]interface{}{
+		"type":       "mouseReleased",
+		"x":          centerX,
+		"y":          centerY,
+		"button":     "left",
+		"buttons":    0,
+		"clickCount": 1,
+	}
+
+	gomock.InOrder(
+		ts.mockCDP.EXPECT().Send("Input.dispatchMouseEvent", downParams).Return(nil, nil),
+		ts.mockClock.EXPECT().SleepContext(ts.ctx, 1*time.Second).Return(context.Canceled),
+		ts.mockCDP.EXPECT().Send("Input.dispatchMouseEvent", upParams).Return(nil, nil),
+	)
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, result)
+}
+
+func TestExecutor_MouseLongPressEvent_ContextCanceledDuringHold_CleanupReleaseFails(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	screenWidth := 1920.0
+	screenHeight := 1080.0
+	centerX := screenWidth / 2
+	centerY := screenHeight / 2
+
+	cmd := commands.Command{
+		Type:      commands.CMD_MOUSE_LONG_PRESS_EVENT,
+		Arguments: map[string]interface{}{},
+	}
+
+	ts.mockJSON.EXPECT().
+		Marshal(cmd.Arguments).
+		Return([]byte(`{}`), nil)
+
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{
+			"width":  screenWidth,
+			"height": screenHeight,
+		}, nil)
+
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(`{}`), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			args := v.(*struct {
+				Button string `json:"button"`
+			})
+			args.Button = ""
+			return nil
+		})
+
+	downParams := map[string]interface{}{
+		"type":       "mousePressed",
+		"x":          centerX,
+		"y":          centerY,
+		"button":     "left",
+		"buttons":    1,
+		"clickCount": 1,
+	}
+	upParams := map[string]interface{}{
+		"type":       "mouseReleased",
+		"x":          centerX,
+		"y":          centerY,
+		"button":     "left",
+		"buttons":    0,
+		"clickCount": 1,
+	}
+
+	cleanupErr := errors.New("cdp release failed during cleanup")
+	gomock.InOrder(
+		ts.mockCDP.EXPECT().Send("Input.dispatchMouseEvent", downParams).Return(nil, nil),
+		ts.mockClock.EXPECT().SleepContext(ts.ctx, 1*time.Second).Return(context.Canceled),
+		ts.mockCDP.EXPECT().Send("Input.dispatchMouseEvent", upParams).Return(nil, cleanupErr),
+	)
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.ErrorIs(t, err, cleanupErr)
+	assert.Contains(t, err.Error(), "failed to release mouse button during cleanup")
+}
+
+func TestExecutor_MouseLongPressEvent_ReleaseFailureAttemptsCleanup(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	screenWidth := 1920.0
+	screenHeight := 1080.0
+	centerX := screenWidth / 2
+	centerY := screenHeight / 2
+
+	cmd := commands.Command{
+		Type:      commands.CMD_MOUSE_LONG_PRESS_EVENT,
+		Arguments: map[string]interface{}{},
+	}
+
+	ts.mockJSON.EXPECT().
+		Marshal(cmd.Arguments).
+		Return([]byte(`{}`), nil)
+
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{
+			"width":  screenWidth,
+			"height": screenHeight,
+		}, nil)
+
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(`{}`), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			args := v.(*struct {
+				Button string `json:"button"`
+			})
+			args.Button = ""
+			return nil
+		})
+
+	downParams := map[string]interface{}{
+		"type":       "mousePressed",
+		"x":          centerX,
+		"y":          centerY,
+		"button":     "left",
+		"buttons":    1,
+		"clickCount": 1,
+	}
+	upParams := map[string]interface{}{
+		"type":       "mouseReleased",
+		"x":          centerX,
+		"y":          centerY,
+		"button":     "left",
+		"buttons":    0,
+		"clickCount": 1,
+	}
+
+	releaseErr := errors.New("release failed")
+	gomock.InOrder(
+		ts.mockCDP.EXPECT().Send("Input.dispatchMouseEvent", downParams).Return(nil, nil),
+		ts.mockClock.EXPECT().SleepContext(ts.ctx, 1*time.Second).Return(nil),
+		ts.mockCDP.EXPECT().Send("Input.dispatchMouseEvent", upParams).Return(nil, releaseErr),
+		// cleanup attempt
+		ts.mockCDP.EXPECT().Send("Input.dispatchMouseEvent", upParams).Return(nil, nil),
+	)
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to release mouse button")
+	assert.Nil(t, result)
+}
+
+func TestExecutor_MouseLongPressEvent_MiddleButton(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	screenWidth := 1920.0
+	screenHeight := 1080.0
+	centerX := screenWidth / 2
+	centerY := screenHeight / 2
+
+	cmd := commands.Command{
+		Type: commands.CMD_MOUSE_LONG_PRESS_EVENT,
+		Arguments: map[string]interface{}{
+			"button": "middle",
+		},
+	}
+
+	ts.mockJSON.EXPECT().
+		Marshal(cmd.Arguments).
+		Return([]byte(`{"button":"middle"}`), nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(`{"button":"middle"}`), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			args := v.(*struct {
+				Button string `json:"button"`
+			})
+			args.Button = "middle"
+			return nil
+		})
+
+	downParams := map[string]interface{}{
+		"type":       "mousePressed",
+		"x":          centerX,
+		"y":          centerY,
+		"button":     "middle",
+		"buttons":    4,
+		"clickCount": 1,
+	}
+	upParams := map[string]interface{}{
+		"type":       "mouseReleased",
+		"x":          centerX,
+		"y":          centerY,
+		"button":     "middle",
+		"buttons":    0,
+		"clickCount": 1,
+	}
+	gomock.InOrder(
+		ts.mockCDP.EXPECT().Send("Input.dispatchMouseEvent", downParams).Return(nil, nil),
+		ts.mockClock.EXPECT().SleepContext(ts.ctx, 1*time.Second).Return(nil),
+		ts.mockCDP.EXPECT().Send("Input.dispatchMouseEvent", upParams).Return(nil, nil),
+	)
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.NoError(t, err)
+	assert.Equal(t, devicectl.CmdOK, result)
+}
+
+func TestExecutor_MouseClickAndDragEvent_Success(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	screenWidth := 1920.0
+	screenHeight := 1080.0
+	centerX := screenWidth / 2
+	centerY := screenHeight / 2
+
+	cmd := commands.Command{
+		Type: commands.CMD_MOUSE_CLICK_AND_DRAG_EVENT,
+		Arguments: map[string]interface{}{
+			"messageID": "test-msg-id",
+			"cursorOffsets": []map[string]interface{}{
+				{"dx": 10.0, "dy": 5.0},
+			},
+		},
+	}
+
+	argsJSON := `{"messageID":"test-msg-id","cursorOffsets":[{"dx":10.0,"dy":5.0}]}`
+	ts.mockJSON.EXPECT().
+		Marshal(cmd.Arguments).
+		Return([]byte(argsJSON), nil)
+
+	// Screen init
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{
+			"width":  screenWidth,
+			"height": screenHeight,
+		}, nil)
+
+	// First unmarshal: clickAndDrag checks offsets are non-empty
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(argsJSON), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			args := v.(*struct {
+				CursorOffsets []struct {
+					DX float64 `json:"dx"`
+					DY float64 `json:"dy"`
+				} `json:"cursorOffsets"`
+			})
+			args.CursorOffsets = []struct {
+				DX float64 `json:"dx"`
+				DY float64 `json:"dy"`
+			}{
+				{DX: 10.0, DY: 5.0},
+			}
+			return nil
+		})
+
+	downParams := map[string]interface{}{
+		"type":       "mousePressed",
+		"x":          centerX,
+		"y":          centerY,
+		"button":     "left",
+		"buttons":    1,
+		"clickCount": 1,
+	}
+	ts.mockCDP.EXPECT().
+		Send("Input.dispatchMouseEvent", downParams).
+		Return(nil, nil)
+
+	// Second unmarshal: handleMouseMoveEventWithButtons does full decode
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(argsJSON), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			args := v.(*struct {
+				MessageID     string `json:"messageID"`
+				CursorOffsets []struct {
+					DX float64 `json:"dx"`
+					DY float64 `json:"dy"`
+				} `json:"cursorOffsets"`
+			})
+			args.MessageID = "test-msg-id"
+			args.CursorOffsets = []struct {
+				DX float64 `json:"dx"`
+				DY float64 `json:"dy"`
+			}{
+				{DX: 10.0, DY: 5.0},
+			}
+			return nil
+		})
+
+	// magnitude sqrt(10^2 + 5^2)
+	ts.mockMath.EXPECT().Sqrt(125.0).Return(11.180339887498949)
+
+	// bounds after one step: (960,540) -> (970,545)
+	ts.mockMath.EXPECT().Min(970.0, 1920.0).Return(970.0)
+	ts.mockMath.EXPECT().Max(0.0, 970.0).Return(970.0)
+	ts.mockMath.EXPECT().Min(545.0, 1080.0).Return(545.0)
+	ts.mockMath.EXPECT().Max(0.0, 545.0).Return(545.0)
+
+	ts.mockJSON.EXPECT().
+		Marshal(map[string]interface{}{
+			"messageID": "test-msg-id",
+			"message": map[string]interface{}{
+				"command": "cursorUpdate",
+				"request": map[string]interface{}{
+					"positions": []map[string]float64{
+						{"x": 970.0, "y": 545.0},
+					},
+				},
+			},
+		}).
+		Return([]byte(`{"messageID":"test-msg-id","message":{"command":"cursorUpdate","request":{"positions":[{"x":970,"y":545}]}}}`), nil)
+
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", map[string]interface{}{
+			"expression": `window.handleCDPRequest({"messageID":"test-msg-id","message":{"command":"cursorUpdate","request":{"positions":[{"x":970,"y":545}]}}})`,
+		}).
+		Return(nil, nil)
+
+	ts.mockCDP.EXPECT().
+		Send("Input.dispatchMouseEvent", map[string]interface{}{
+			"type":       "mouseMoved",
+			"x":          970.0,
+			"y":          545.0,
+			"button":     "none",
+			"buttons":    1,
+			"clickCount": 0,
+		}).
+		Return(nil, nil)
+
+	ts.mockCDP.EXPECT().
+		Send("Input.dispatchMouseEvent", map[string]interface{}{
+			"type":       "mouseReleased",
+			"x":          970.0,
+			"y":          545.0,
+			"button":     "left",
+			"buttons":    0,
+			"clickCount": 1,
+		}).
+		Return(nil, nil)
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.NoError(t, err)
+	assert.Equal(t, devicectl.CmdOK, result)
+}
+
+func TestExecutor_MouseClickAndDragEvent_ReleaseFailureReturnsError(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	screenWidth := 1920.0
+	screenHeight := 1080.0
+	centerX := screenWidth / 2
+	centerY := screenHeight / 2
+
+	cmd := commands.Command{
+		Type: commands.CMD_MOUSE_CLICK_AND_DRAG_EVENT,
+		Arguments: map[string]interface{}{
+			"messageID": "release-failure",
+			"cursorOffsets": []map[string]interface{}{
+				{"dx": 2.0, "dy": 0.0},
+			},
+		},
+	}
+	argsJSON := `{"messageID":"release-failure","cursorOffsets":[{"dx":2.0,"dy":0.0}]}`
+
+	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(argsJSON), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			args, ok := v.(*struct {
+				CursorOffsets []struct {
+					DX float64 `json:"dx"`
+					DY float64 `json:"dy"`
+				} `json:"cursorOffsets"`
+			})
+			if !ok {
+				return errors.New("unexpected unmarshal type (click-and-drag probe)")
+			}
+			args.CursorOffsets = []struct {
+				DX float64 `json:"dx"`
+				DY float64 `json:"dy"`
+			}{{DX: 2, DY: 0}}
+			return nil
+		}).
+		Times(1)
+	down := map[string]interface{}{
+		"type":       "mousePressed",
+		"x":          centerX,
+		"y":          centerY,
+		"button":     "left",
+		"buttons":    1,
+		"clickCount": 1,
+	}
+	ts.mockCDP.EXPECT().Send("Input.dispatchMouseEvent", down).Return(nil, nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			args, ok := v.(*struct {
+				MessageID     string `json:"messageID"`
+				CursorOffsets []struct {
+					DX float64 `json:"dx"`
+					DY float64 `json:"dy"`
+				} `json:"cursorOffsets"`
+			})
+			if !ok {
+				return errors.New("unexpected unmarshal type (click-and-drag move)")
+			}
+			args.MessageID = "release-failure"
+			args.CursorOffsets = []struct {
+				DX float64 `json:"dx"`
+				DY float64 `json:"dy"`
+			}{{DX: 2, DY: 0}}
+			return nil
+		})
+	ts.mockMath.EXPECT().Sqrt(4.0).Return(2.0)
+	ts.mockMath.EXPECT().Min(962.0, 1920.0).Return(962.0)
+	ts.mockMath.EXPECT().Max(0.0, 962.0).Return(962.0)
+	ts.mockMath.EXPECT().Min(540.0, 1080.0).Return(540.0)
+	ts.mockMath.EXPECT().Max(0.0, 540.0).Return(540.0)
+	ts.mockJSON.EXPECT().
+		Marshal(map[string]interface{}{
+			"messageID": "release-failure",
+			"message": map[string]interface{}{
+				"command": "cursorUpdate",
+				"request": map[string]interface{}{
+					"positions": []map[string]float64{{"x": 962.0, "y": 540.0}},
+				},
+			},
+		}).
+		Return([]byte(`{"messageID":"release-failure","message":{"command":"cursorUpdate","request":{"positions":[{"x":962,"y":540}]}}}`), nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", map[string]interface{}{
+			"expression": `window.handleCDPRequest({"messageID":"release-failure","message":{"command":"cursorUpdate","request":{"positions":[{"x":962,"y":540}]}}})`,
+		}).
+		Return(nil, nil)
+	ts.mockCDP.EXPECT().
+		Send("Input.dispatchMouseEvent", map[string]interface{}{
+			"type":       "mouseMoved",
+			"x":          962.0,
+			"y":          540.0,
+			"button":     "none",
+			"buttons":    1,
+			"clickCount": 0,
+		}).
+		Return(nil, nil)
+	ts.mockCDP.EXPECT().
+		Send("Input.dispatchMouseEvent", map[string]interface{}{
+			"type":       "mouseReleased",
+			"x":          962.0,
+			"y":          540.0,
+			"button":     "left",
+			"buttons":    0,
+			"clickCount": 1,
+		}).
+		Return(nil, errors.New("release failed"))
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to release mouse button")
+	assert.Nil(t, result)
+}
+
+func TestExecutor_MouseClickAndDragEvent_ReleasesOnMoveError(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	screenWidth := 1920.0
+	screenHeight := 1080.0
+	centerX := screenWidth / 2
+	centerY := screenHeight / 2
+
+	cmd := commands.Command{
+		Type: commands.CMD_MOUSE_CLICK_AND_DRAG_EVENT,
+		Arguments: map[string]interface{}{
+			"messageID": "m1",
+			"cursorOffsets": []map[string]interface{}{
+				{"dx": 1.0, "dy": 0.0},
+			},
+		},
+	}
+	argsJSON := `{"messageID":"m1","cursorOffsets":[{"dx":1.0,"dy":0.0}]}`
+
+	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			args, ok := v.(*struct {
+				CursorOffsets []struct {
+					DX float64 `json:"dx"`
+					DY float64 `json:"dy"`
+				} `json:"cursorOffsets"`
+			})
+			if !ok {
+				return errors.New("unexpected unmarshal type (click-and-drag probe)")
+			}
+			args.CursorOffsets = []struct {
+				DX float64 `json:"dx"`
+				DY float64 `json:"dy"`
+			}{{DX: 1, DY: 0}}
+			return nil
+		}).
+		Times(1)
+	down := map[string]interface{}{
+		"type": "mousePressed", "x": centerX, "y": centerY,
+		"button": "left", "buttons": 1, "clickCount": 1,
+	}
+	ts.mockCDP.EXPECT().Send("Input.dispatchMouseEvent", down).Return(nil, nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal(gomock.Any(), gomock.Any()).
+		Return(errors.New("unmarshal move failed")).
+		Times(1)
+	// best-effort release at current cursor (still at center) when move step fails
+	release := map[string]interface{}{
+		"type": "mouseReleased", "x": centerX, "y": centerY,
+		"button": "left", "buttons": 0, "clickCount": 1,
+	}
+	ts.mockCDP.EXPECT().Send("Input.dispatchMouseEvent", release).Return(nil, nil)
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal move failed")
+	assert.Nil(t, result)
+}
+
+func TestExecutor_MouseClickAndDragEvent_MoveErrorAndCleanupReleaseErrorJoined(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	screenWidth := 1920.0
+	screenHeight := 1080.0
+	centerX := screenWidth / 2
+	centerY := screenHeight / 2
+
+	cmd := commands.Command{
+		Type: commands.CMD_MOUSE_CLICK_AND_DRAG_EVENT,
+		Arguments: map[string]interface{}{
+			"messageID": "m2",
+			"cursorOffsets": []map[string]interface{}{
+				{"dx": 1.0, "dy": 0.0},
+			},
+		},
+	}
+	argsJSON := `{"messageID":"m2","cursorOffsets":[{"dx":1.0,"dy":0.0}]}`
+
+	moveRoot := errors.New("unmarshal move failed")
+	cleanupRoot := errors.New("cdp cleanup release failed")
+
+	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			args, ok := v.(*struct {
+				CursorOffsets []struct {
+					DX float64 `json:"dx"`
+					DY float64 `json:"dy"`
+				} `json:"cursorOffsets"`
+			})
+			if !ok {
+				return errors.New("unexpected unmarshal type (click-and-drag probe)")
+			}
+			args.CursorOffsets = []struct {
+				DX float64 `json:"dx"`
+				DY float64 `json:"dy"`
+			}{{DX: 1, DY: 0}}
+			return nil
+		}).
+		Times(1)
+	down := map[string]interface{}{
+		"type": "mousePressed", "x": centerX, "y": centerY,
+		"button": "left", "buttons": 1, "clickCount": 1,
+	}
+	ts.mockCDP.EXPECT().Send("Input.dispatchMouseEvent", down).Return(nil, nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal(gomock.Any(), gomock.Any()).
+		Return(moveRoot).
+		Times(1)
+	release := map[string]interface{}{
+		"type": "mouseReleased", "x": centerX, "y": centerY,
+		"button": "left", "buttons": 0, "clickCount": 1,
+	}
+	ts.mockCDP.EXPECT().Send("Input.dispatchMouseEvent", release).Return(nil, cleanupRoot)
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.True(t, errors.Is(err, moveRoot), "expected move error in joined result")
+	assert.True(t, errors.Is(err, cleanupRoot), "expected cleanup release error in joined result")
+}
+
+func TestExecutor_ZoomGestureEvent_Success(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	screenWidth := 1920.0
+	screenHeight := 1080.0
+	centerX := screenWidth / 2
+	centerY := screenHeight / 2
+
+	cmd := commands.Command{
+		Type: commands.CMD_ZOOM_GESTURE,
+		Arguments: map[string]interface{}{
+			"scaleSteps": []float64{1.05, 0.98},
+		},
+	}
+	argsJSON := `{"scaleSteps":[1.05,0.98]}`
+
+	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(argsJSON), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			in, ok := v.(*struct {
+				MessageID  string    `json:"messageID"`
+				ScaleSteps []float64 `json:"scaleSteps"`
+			})
+			if !ok {
+				return errors.New("unexpected type in zoomGesture unmarshal")
+			}
+			in.ScaleSteps = []float64{1.05, 0.98}
+			return nil
+		})
+	ts.mockCDP.EXPECT().
+		Send("Input.synthesizePinchGesture", map[string]interface{}{
+			"x":                 centerX,
+			"y":                 centerY,
+			"scaleFactor":       1.05,
+			"relativeSpeed":     800,
+			"gestureSourceType": "default",
+		}).
+		Return(nil, nil)
+	ts.mockCDP.EXPECT().
+		Send("Input.synthesizePinchGesture", map[string]interface{}{
+			"x":                 centerX,
+			"y":                 centerY,
+			"scaleFactor":       0.98,
+			"relativeSpeed":     800,
+			"gestureSourceType": "default",
+		}).
+		Return(nil, nil)
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.NoError(t, err)
+	assert.Equal(t, devicectl.CmdOK, result)
+}
+
+func TestExecutor_ZoomGestureEvent_WithMessageID(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	screenWidth := 1920.0
+	screenHeight := 1080.0
+	centerX := screenWidth / 2
+	centerY := screenHeight / 2
+
+	cmd := commands.Command{
+		Type: commands.CMD_ZOOM_GESTURE,
+		Arguments: map[string]interface{}{
+			"messageID":  "z1",
+			"scaleSteps": []float64{1.1},
+		},
+	}
+	argsJSON := `{"messageID":"z1","scaleSteps":[1.1]}`
+
+	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(argsJSON), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			in, ok := v.(*struct {
+				MessageID  string    `json:"messageID"`
+				ScaleSteps []float64 `json:"scaleSteps"`
+			})
+			if !ok {
+				return errors.New("unexpected type in zoomGesture unmarshal")
+			}
+			in.MessageID = "z1"
+			in.ScaleSteps = []float64{1.1}
+			return nil
+		})
+	ts.mockCDP.EXPECT().
+		Send("Input.synthesizePinchGesture", map[string]interface{}{
+			"x":                 centerX,
+			"y":                 centerY,
+			"scaleFactor":       1.1,
+			"relativeSpeed":     800,
+			"gestureSourceType": "default",
+		}).
+		Return(nil, nil)
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.NoError(t, err)
+	assert.Equal(t, devicectl.CmdOK, result)
+}
+
+func TestExecutor_ZoomGestureEvent_EmptyScaleSteps(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	cmd := commands.Command{
+		Type:      commands.CMD_ZOOM_GESTURE,
+		Arguments: map[string]interface{}{"scaleSteps": []float64{}},
+	}
+	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(`{"scaleSteps":[]}`), nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{"width": 1920.0, "height": 1080.0}, nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(`{"scaleSteps":[]}`), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			in, ok := v.(*struct {
+				MessageID  string    `json:"messageID"`
+				ScaleSteps []float64 `json:"scaleSteps"`
+			})
+			if !ok {
+				return errors.New("unexpected type in zoomGesture unmarshal")
+			}
+			in.ScaleSteps = nil
+			return nil
+		})
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.NoError(t, err)
+	assert.Equal(t, devicectl.CmdOK, result)
+}
+
+func TestExecutor_ZoomGestureEvent_CDPError(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	screenWidth := 1920.0
+	screenHeight := 1080.0
+	centerX := screenWidth / 2
+	centerY := screenHeight / 2
+
+	cmd := commands.Command{
+		Type: commands.CMD_ZOOM_GESTURE,
+		Arguments: map[string]interface{}{
+			"scaleSteps": []float64{1.01},
+		},
+	}
+	argsJSON := `{"scaleSteps":[1.01]}`
+
+	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(argsJSON), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			in, ok := v.(*struct {
+				MessageID  string    `json:"messageID"`
+				ScaleSteps []float64 `json:"scaleSteps"`
+			})
+			if !ok {
+				return errors.New("unexpected type in zoomGesture unmarshal")
+			}
+			in.ScaleSteps = []float64{1.01}
+			return nil
+		})
+	ts.mockCDP.EXPECT().
+		Send("Input.synthesizePinchGesture", map[string]interface{}{
+			"x":                 centerX,
+			"y":                 centerY,
+			"scaleFactor":       1.01,
+			"relativeSpeed":     800,
+			"gestureSourceType": "default",
+		}).
+		Return(nil, errors.New("cdp pinch failed"))
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to process zoom gesture")
+	assert.Nil(t, result)
+}
+
+func TestExecutor_ZoomGestureEvent_UnsupportedExperimentalMethod(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	screenWidth := 1920.0
+	screenHeight := 1080.0
+	centerX := screenWidth / 2
+	centerY := screenHeight / 2
+
+	cmd := commands.Command{
+		Type: commands.CMD_ZOOM_GESTURE,
+		Arguments: map[string]interface{}{
+			"scaleSteps": []float64{1.02},
+		},
+	}
+	argsJSON := `{"scaleSteps":[1.02]}`
+
+	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(argsJSON), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			in, ok := v.(*struct {
+				MessageID  string    `json:"messageID"`
+				ScaleSteps []float64 `json:"scaleSteps"`
+			})
+			if !ok {
+				return errors.New("unexpected type in zoomGesture unmarshal")
+			}
+			in.ScaleSteps = []float64{1.02}
+			return nil
+		})
+	ts.mockCDP.EXPECT().
+		Send("Input.synthesizePinchGesture", map[string]interface{}{
+			"x":                 centerX,
+			"y":                 centerY,
+			"scaleFactor":       1.02,
+			"relativeSpeed":     800,
+			"gestureSourceType": "default",
+		}).
+		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "unknown method", Unsupported: true})
+	ts.mockCDP.EXPECT().
+		Send("Input.dispatchMouseEvent", map[string]interface{}{
+			"type":      "mouseWheel",
+			"x":         centerX,
+			"y":         centerY,
+			"deltaX":    0,
+			"deltaY":    -120.0,
+			"button":    "none",
+			"buttons":   0,
+			"modifiers": 2,
+		}).
+		Return(nil, nil)
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.NoError(t, err)
+	assert.Equal(t, devicectl.CmdOK, result)
+}
+
+func TestExecutor_ZoomGestureEvent_PinchUnsupportedUsesFallback(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	screenWidth := 1920.0
+	screenHeight := 1080.0
+	centerX := screenWidth / 2
+	centerY := screenHeight / 2
+
+	cmd := commands.Command{
+		Type: commands.CMD_ZOOM_GESTURE,
+		Arguments: map[string]interface{}{
+			"scaleSteps": []float64{0.98},
+		},
+	}
+	argsJSON := `{"scaleSteps":[0.98]}`
+
+	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(argsJSON), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			in, ok := v.(*struct {
+				MessageID  string    `json:"messageID"`
+				ScaleSteps []float64 `json:"scaleSteps"`
+			})
+			if !ok {
+				return errors.New("unexpected type in zoomGesture unmarshal")
+			}
+			in.ScaleSteps = []float64{0.98}
+			return nil
+		})
+	ts.mockCDP.EXPECT().
+		Send("Input.synthesizePinchGesture", map[string]interface{}{
+			"x":                 centerX,
+			"y":                 centerY,
+			"scaleFactor":       0.98,
+			"relativeSpeed":     800,
+			"gestureSourceType": "default",
+		}).
+		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "Method not found", Unsupported: true})
+	ts.mockCDP.EXPECT().
+		Send("Input.dispatchMouseEvent", map[string]interface{}{
+			"type":      "mouseWheel",
+			"x":         centerX,
+			"y":         centerY,
+			"deltaX":    0,
+			"deltaY":    120.0,
+			"button":    "none",
+			"buttons":   0,
+			"modifiers": 2,
+		}).
+		Return(nil, nil)
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.NoError(t, err)
+	assert.Equal(t, devicectl.CmdOK, result)
+}
+
+func TestExecutor_ZoomGestureEvent_NeutralScaleDoesNotFallback(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	screenWidth := 1920.0
+	screenHeight := 1080.0
+	centerX := screenWidth / 2
+	centerY := screenHeight / 2
+
+	cmd := commands.Command{
+		Type: commands.CMD_ZOOM_GESTURE,
+		Arguments: map[string]interface{}{
+			"scaleSteps": []float64{1.0},
+		},
+	}
+	argsJSON := `{"scaleSteps":[1]}`
+
+	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(argsJSON), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			in, ok := v.(*struct {
+				MessageID  string    `json:"messageID"`
+				ScaleSteps []float64 `json:"scaleSteps"`
+			})
+			if !ok {
+				return errors.New("unexpected type in zoomGesture unmarshal")
+			}
+			in.ScaleSteps = []float64{1.0}
+			return nil
+		})
+	ts.mockCDP.EXPECT().
+		Send("Input.synthesizePinchGesture", map[string]interface{}{
+			"x":                 centerX,
+			"y":                 centerY,
+			"scaleFactor":       1.0,
+			"relativeSpeed":     800,
+			"gestureSourceType": "default",
+		}).
+		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "Method not found", Unsupported: true})
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.NoError(t, err)
+	assert.Equal(t, devicectl.CmdOK, result)
+}
+
+func TestExecutor_ZoomGestureEvent_FallbackMagnitudeGrowsWithScale(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	screenWidth := 1920.0
+	screenHeight := 1080.0
+	centerX := screenWidth / 2
+	centerY := screenHeight / 2
+
+	cmd := commands.Command{
+		Type: commands.CMD_ZOOM_GESTURE,
+		Arguments: map[string]interface{}{
+			"scaleSteps": []float64{1.5},
+		},
+	}
+	argsJSON := `{"scaleSteps":[1.5]}`
+
+	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(argsJSON), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			in, ok := v.(*struct {
+				MessageID  string    `json:"messageID"`
+				ScaleSteps []float64 `json:"scaleSteps"`
+			})
+			if !ok {
+				return errors.New("unexpected type in zoomGesture unmarshal")
+			}
+			in.ScaleSteps = []float64{1.5}
+			return nil
+		})
+	ts.mockCDP.EXPECT().
+		Send("Input.synthesizePinchGesture", map[string]interface{}{
+			"x":                 centerX,
+			"y":                 centerY,
+			"scaleFactor":       1.5,
+			"relativeSpeed":     800,
+			"gestureSourceType": "default",
+		}).
+		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "unknown method", Unsupported: true})
+	ts.mockCDP.EXPECT().
+		Send("Input.dispatchMouseEvent", map[string]interface{}{
+			"type":      "mouseWheel",
+			"x":         centerX,
+			"y":         centerY,
+			"deltaX":    0,
+			"deltaY":    -600.0,
+			"button":    "none",
+			"buttons":   0,
+			"modifiers": 2,
+		}).
+		Return(nil, nil)
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.NoError(t, err)
+	assert.Equal(t, devicectl.CmdOK, result)
+}
+
+func TestExecutor_ZoomGestureEvent_PinchNotSupportedFails(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	screenWidth := 1920.0
+	screenHeight := 1080.0
+	centerX := screenWidth / 2
+	centerY := screenHeight / 2
+
+	cmd := commands.Command{
+		Type: commands.CMD_ZOOM_GESTURE,
+		Arguments: map[string]interface{}{
+			"scaleSteps": []float64{1.02},
+		},
+	}
+	argsJSON := `{"scaleSteps":[1.02]}`
+
+	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(argsJSON), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			in, ok := v.(*struct {
+				MessageID  string    `json:"messageID"`
+				ScaleSteps []float64 `json:"scaleSteps"`
+			})
+			if !ok {
+				return errors.New("unexpected type in zoomGesture unmarshal")
+			}
+			in.ScaleSteps = []float64{1.02}
+			return nil
+		})
+	ts.mockCDP.EXPECT().
+		Send("Input.synthesizePinchGesture", map[string]interface{}{
+			"x":                 centerX,
+			"y":                 centerY,
+			"scaleFactor":       1.02,
+			"relativeSpeed":     800,
+			"gestureSourceType": "default",
+		}).
+		Return(nil, errors.New("feature not supported"))
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to process zoom gesture")
+	assert.Nil(t, result)
+}
+
+func TestExecutor_ZoomGestureEvent_InvalidScaleStepFailsFast(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	cmd := commands.Command{
+		Type: commands.CMD_ZOOM_GESTURE,
+		Arguments: map[string]interface{}{
+			"scaleSteps": []float64{0},
+		},
+	}
+	argsJSON := `{"scaleSteps":[0]}`
+
+	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{"width": 1920.0, "height": 1080.0}, nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(argsJSON), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			in, ok := v.(*struct {
+				MessageID  string    `json:"messageID"`
+				ScaleSteps []float64 `json:"scaleSteps"`
+			})
+			if !ok {
+				return errors.New("unexpected type in zoomGesture unmarshal")
+			}
+			in.ScaleSteps = []float64{0}
+			return nil
+		})
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "scaleSteps must be positive")
+	assert.Nil(t, result)
+}
+
+func TestExecutor_ZoomGestureEvent_InvalidScaleStepFailsBeforeDispatch(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	cmd := commands.Command{
+		Type: commands.CMD_ZOOM_GESTURE,
+		Arguments: map[string]interface{}{
+			"scaleSteps": []float64{1.05, 0},
+		},
+	}
+	argsJSON := `{"scaleSteps":[1.05,0]}`
+
+	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{"width": 1920.0, "height": 1080.0}, nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(argsJSON), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			in, ok := v.(*struct {
+				MessageID  string    `json:"messageID"`
+				ScaleSteps []float64 `json:"scaleSteps"`
+			})
+			if !ok {
+				return errors.New("unexpected type in zoomGesture unmarshal")
+			}
+			in.ScaleSteps = []float64{1.05, 0}
+			return nil
+		})
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "scaleSteps must be positive")
+	assert.Nil(t, result)
+}
+
+func TestExecutor_ZoomGestureEvent_UnsupportedWordingFallbacks(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	screenWidth := 1920.0
+	screenHeight := 1080.0
+	centerX := screenWidth / 2
+	centerY := screenHeight / 2
+
+	cmd := commands.Command{
+		Type: commands.CMD_ZOOM_GESTURE,
+		Arguments: map[string]interface{}{
+			"scaleSteps": []float64{0.98},
+		},
+	}
+	argsJSON := `{"scaleSteps":[0.98]}`
+
+	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(argsJSON), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			in, ok := v.(*struct {
+				MessageID  string    `json:"messageID"`
+				ScaleSteps []float64 `json:"scaleSteps"`
+			})
+			if !ok {
+				return errors.New("unexpected type in zoomGesture unmarshal")
+			}
+			in.ScaleSteps = []float64{0.98}
+			return nil
+		})
+	ts.mockCDP.EXPECT().
+		Send("Input.synthesizePinchGesture", map[string]interface{}{
+			"x":                 centerX,
+			"y":                 centerY,
+			"scaleFactor":       0.98,
+			"relativeSpeed":     800,
+			"gestureSourceType": "default",
+		}).
+		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "wasn't found", Unsupported: true})
+	ts.mockCDP.EXPECT().
+		Send("Input.dispatchMouseEvent", map[string]interface{}{
+			"type":      "mouseWheel",
+			"x":         centerX,
+			"y":         centerY,
+			"deltaX":    0,
+			"deltaY":    120.0,
+			"button":    "none",
+			"buttons":   0,
+			"modifiers": 2,
+		}).
+		Return(nil, nil)
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.NoError(t, err)
+	assert.Equal(t, devicectl.CmdOK, result)
+}
+
+func TestExecutor_ZoomGestureEvent_UnsupportedMethodWithNameFallbacks(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	screenWidth := 1920.0
+	screenHeight := 1080.0
+	centerX := screenWidth / 2
+	centerY := screenHeight / 2
+
+	cmd := commands.Command{
+		Type: commands.CMD_ZOOM_GESTURE,
+		Arguments: map[string]interface{}{
+			"scaleSteps": []float64{1.02},
+		},
+	}
+	argsJSON := `{"scaleSteps":[1.02]}`
+
+	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(argsJSON), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			in, ok := v.(*struct {
+				MessageID  string    `json:"messageID"`
+				ScaleSteps []float64 `json:"scaleSteps"`
+			})
+			if !ok {
+				return errors.New("unexpected type in zoomGesture unmarshal")
+			}
+			in.ScaleSteps = []float64{1.02}
+			return nil
+		})
+	ts.mockCDP.EXPECT().
+		Send("Input.synthesizePinchGesture", map[string]interface{}{
+			"x":                 centerX,
+			"y":                 centerY,
+			"scaleFactor":       1.02,
+			"relativeSpeed":     800,
+			"gestureSourceType": "default",
+		}).
+		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "method not found", Unsupported: true})
+	ts.mockCDP.EXPECT().
+		Send("Input.dispatchMouseEvent", map[string]interface{}{
+			"type":      "mouseWheel",
+			"x":         centerX,
+			"y":         centerY,
+			"deltaX":    0,
+			"deltaY":    -120.0,
+			"button":    "none",
+			"buttons":   0,
+			"modifiers": 2,
+		}).
+		Return(nil, nil)
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.NoError(t, err)
+	assert.Equal(t, devicectl.CmdOK, result)
+}
+
+func TestExecutor_ZoomGestureEvent_TargetNotFoundDoesNotFallback(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	screenWidth := 1920.0
+	screenHeight := 1080.0
+	centerX := screenWidth / 2
+	centerY := screenHeight / 2
+
+	cmd := commands.Command{
+		Type: commands.CMD_ZOOM_GESTURE,
+		Arguments: map[string]interface{}{
+			"scaleSteps": []float64{1.02},
+		},
+	}
+	argsJSON := `{"scaleSteps":[1.02]}`
+
+	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(argsJSON), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			in, ok := v.(*struct {
+				MessageID  string    `json:"messageID"`
+				ScaleSteps []float64 `json:"scaleSteps"`
+			})
+			if !ok {
+				return errors.New("unexpected type in zoomGesture unmarshal")
+			}
+			in.ScaleSteps = []float64{1.02}
+			return nil
+		})
+	ts.mockCDP.EXPECT().
+		Send("Input.synthesizePinchGesture", map[string]interface{}{
+			"x":                 centerX,
+			"y":                 centerY,
+			"scaleFactor":       1.02,
+			"relativeSpeed":     800,
+			"gestureSourceType": "default",
+		}).
+		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "Target not found", Unsupported: false})
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to process zoom gesture")
+	assert.Nil(t, result)
+}
+
 func TestExecutor_MouseTapEvent_Errors(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -1721,6 +3405,17 @@ func TestExecutor_MouseTapEvent_Errors(t *testing.T) {
 				ts.mockCDP.EXPECT().
 					Send("Runtime.evaluate", gomock.Any()).
 					Return(nil, errors.New("cdp screen failed"))
+
+				// parseMouseButton default left
+				ts.mockJSON.EXPECT().
+					Unmarshal([]byte(`{}`), gomock.Any()).
+					DoAndReturn(func(_ []byte, v interface{}) error {
+						args := v.(*struct {
+							Button string `json:"button"`
+						})
+						args.Button = ""
+						return nil
+					})
 
 				// Mock CDP Send for mouse press (should still work with default dimensions)
 				ts.mockCDP.EXPECT().
@@ -1768,6 +3463,17 @@ func TestExecutor_MouseTapEvent_Errors(t *testing.T) {
 						"height": 1080.0,
 					}, nil)
 
+				// parseMouseButton default left
+				ts.mockJSON.EXPECT().
+					Unmarshal([]byte(`{}`), gomock.Any()).
+					DoAndReturn(func(_ []byte, v interface{}) error {
+						args := v.(*struct {
+							Button string `json:"button"`
+						})
+						args.Button = ""
+						return nil
+					})
+
 				// Mock CDP Send for mouse press to fail
 				ts.mockCDP.EXPECT().
 					Send("Input.dispatchMouseEvent", gomock.Any()).
@@ -1791,24 +3497,47 @@ func TestExecutor_MouseTapEvent_Errors(t *testing.T) {
 						"height": 1080.0,
 					}, nil)
 
-				// Mock CDP Send for mouse press success
-				ts.mockCDP.EXPECT().
-					Send("Input.dispatchMouseEvent", gomock.Any()).
-					DoAndReturn(func(method string, params map[string]interface{}) (interface{}, error) {
-						// Verify mousePressed event
-						assert.Equal(t, "mousePressed", params["type"])
-						assert.Equal(t, 960.0, params["x"]) // Screen center
-						assert.Equal(t, 540.0, params["y"])
-						assert.Equal(t, "left", params["button"])
-						assert.Equal(t, 1, params["buttons"])
-						assert.Equal(t, 1, params["clickCount"])
-						return nil, nil
+				// parseMouseButton default left
+				ts.mockJSON.EXPECT().
+					Unmarshal([]byte(`{}`), gomock.Any()).
+					DoAndReturn(func(_ []byte, v interface{}) error {
+						args := v.(*struct {
+							Button string `json:"button"`
+						})
+						args.Button = ""
+						return nil
 					})
 
-				// Mock CDP Send for mouse release to fail
-				ts.mockCDP.EXPECT().
-					Send("Input.dispatchMouseEvent", gomock.Any()).
-					Return(nil, errors.New("cdp mouse release failed"))
+				releaseErr := errors.New("cdp mouse release failed")
+				gomock.InOrder(
+					// Mock CDP Send for mouse press success
+					ts.mockCDP.EXPECT().
+						Send("Input.dispatchMouseEvent", gomock.Any()).
+						DoAndReturn(func(method string, params map[string]interface{}) (interface{}, error) {
+							// Verify mousePressed event
+							assert.Equal(t, "mousePressed", params["type"])
+							assert.Equal(t, 960.0, params["x"]) // Screen center
+							assert.Equal(t, 540.0, params["y"])
+							assert.Equal(t, "left", params["button"])
+							assert.Equal(t, 1, params["buttons"])
+							assert.Equal(t, 1, params["clickCount"])
+							return nil, nil
+						}),
+					// Mock CDP Send for mouse release to fail
+					ts.mockCDP.EXPECT().
+						Send("Input.dispatchMouseEvent", gomock.Any()).
+						DoAndReturn(func(method string, params map[string]interface{}) (interface{}, error) {
+							assert.Equal(t, "mouseReleased", params["type"])
+							return nil, releaseErr
+						}),
+					// Cleanup: best-effort release retry
+					ts.mockCDP.EXPECT().
+						Send("Input.dispatchMouseEvent", gomock.Any()).
+						DoAndReturn(func(method string, params map[string]interface{}) (interface{}, error) {
+							assert.Equal(t, "mouseReleased", params["type"])
+							return nil, nil
+						}),
+				)
 			},
 			wantErr: "failed to release mouse button",
 		},

--- a/components/feral-controld/devicectl/executor_test.go
+++ b/components/feral-controld/devicectl/executor_test.go
@@ -2737,6 +2737,76 @@ func TestExecutor_ZoomGestureEvent_Success(t *testing.T) {
 	assert.Equal(t, devicectl.CmdOK, result)
 }
 
+func TestExecutor_ZoomGestureEvent_MapsAnchorForDifferentScaleSteps(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	screenWidth := 1920.0
+	screenHeight := 1080.0
+
+	cmd := commands.Command{
+		Type: commands.CMD_ZOOM_GESTURE,
+		Arguments: map[string]interface{}{
+			"scaleSteps": []float64{1.5, 0.5, 2.25, 0.25},
+		},
+	}
+	argsJSON := `{"scaleSteps":[1.5,0.5,2.25,0.25]}`
+
+	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	for _, viewport := range []map[string]interface{}{
+		{"offsetLeft": 0.0, "offsetTop": 0.0, "width": 1920.0, "height": 1080.0},
+		{"offsetLeft": 120.0, "offsetTop": 80.0, "width": 1280.0, "height": 720.0},
+		{"offsetLeft": 300.0, "offsetTop": 200.0, "width": 960.0, "height": 540.0},
+		{"offsetLeft": 500.0, "offsetTop": 300.0, "width": 640.0, "height": 360.0},
+	} {
+		ts.mockCDP.EXPECT().
+			Send("Runtime.evaluate", gomock.Any()).
+			Return(viewport, nil)
+	}
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(argsJSON), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			in, ok := v.(*struct {
+				MessageID  string    `json:"messageID"`
+				ScaleSteps []float64 `json:"scaleSteps"`
+			})
+			if !ok {
+				return errors.New("unexpected type in zoomGesture unmarshal")
+			}
+			in.ScaleSteps = []float64{1.5, 0.5, 2.25, 0.25}
+			return nil
+		})
+
+	for _, want := range []struct {
+		scale float64
+		x     float64
+		y     float64
+	}{
+		{scale: 1.5, x: 960, y: 540},
+		{scale: 0.5, x: 840, y: 460},
+		{scale: 2.25, x: 660, y: 340},
+		{scale: 0.25, x: 460, y: 240},
+	} {
+		ts.mockCDP.EXPECT().
+			Send("Input.synthesizePinchGesture", map[string]interface{}{
+				"x":                 want.x,
+				"y":                 want.y,
+				"scaleFactor":       want.scale,
+				"relativeSpeed":     3200,
+				"gestureSourceType": "default",
+				"modifiers":         0,
+			}).
+			Return(nil, nil)
+	}
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.NoError(t, err)
+	assert.Equal(t, devicectl.CmdOK, result)
+}
+
 func TestExecutor_ZoomGestureEvent_WithMessageID(t *testing.T) {
 	ts := setup(t)
 	defer ts.teardown()

--- a/components/feral-controld/devicectl/executor_test.go
+++ b/components/feral-controld/devicectl/executor_test.go
@@ -2014,6 +2014,27 @@ func TestExecutor_MouseLongPressEvent_SleepsAndReleases(t *testing.T) {
 	assert.Equal(t, devicectl.CmdOK, result)
 }
 
+func TestExecutor_MouseLongPressEvent_ContextCanceledBeforeDispatch(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	cmd := commands.Command{
+		Type:      commands.CMD_MOUSE_LONG_PRESS_EVENT,
+		Arguments: map[string]interface{}{},
+	}
+
+	ts.mockJSON.EXPECT().
+		Marshal(cmd.Arguments).
+		Return([]byte(`{}`), nil)
+
+	ctx, cancel := context.WithCancel(ts.ctx)
+	cancel()
+
+	result, err := ts.executor.Execute(ctx, cmd)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, result)
+}
+
 func TestExecutor_MouseLongPressEvent_ContextCanceledDuringHoldReleasesDefer(t *testing.T) {
 	ts := setup(t)
 	defer ts.teardown()
@@ -3035,6 +3056,12 @@ func TestExecutor_ZoomGestureEvent_PinchUnsupportedUsesFallback(t *testing.T) {
 	screenHeight := 1080.0
 	centerX := screenWidth / 2
 	centerY := screenHeight / 2
+	viewportX := 120.0
+	viewportY := 80.0
+	viewportW := 1280.0
+	viewportH := 720.0
+	fallbackX := centerX - viewportX
+	fallbackY := centerY - viewportY
 
 	cmd := commands.Command{
 		Type: commands.CMD_ZOOM_GESTURE,
@@ -3051,10 +3078,10 @@ func TestExecutor_ZoomGestureEvent_PinchUnsupportedUsesFallback(t *testing.T) {
 	ts.mockCDP.EXPECT().
 		Send("Runtime.evaluate", gomock.Any()).
 		Return(map[string]interface{}{
-			"offsetLeft": 0.0,
-			"offsetTop":  0.0,
-			"width":      screenWidth,
-			"height":     screenHeight,
+			"offsetLeft": viewportX,
+			"offsetTop":  viewportY,
+			"width":      viewportW,
+			"height":     viewportH,
 		}, nil)
 	ts.mockJSON.EXPECT().
 		Unmarshal([]byte(argsJSON), gomock.Any()).
@@ -3071,8 +3098,8 @@ func TestExecutor_ZoomGestureEvent_PinchUnsupportedUsesFallback(t *testing.T) {
 		})
 	ts.mockCDP.EXPECT().
 		Send("Input.synthesizePinchGesture", map[string]interface{}{
-			"x":                 centerX,
-			"y":                 centerY,
+			"x":                 fallbackX,
+			"y":                 fallbackY,
 			"scaleFactor":       0.98,
 			"relativeSpeed":     3200,
 			"gestureSourceType": "default",
@@ -3082,8 +3109,8 @@ func TestExecutor_ZoomGestureEvent_PinchUnsupportedUsesFallback(t *testing.T) {
 	ts.mockCDP.EXPECT().
 		Send("Input.dispatchMouseEvent", map[string]interface{}{
 			"type":      "mouseWheel",
-			"x":         centerX,
-			"y":         centerY,
+			"x":         fallbackX,
+			"y":         fallbackY,
 			"deltaX":    0,
 			"deltaY":    120.0,
 			"button":    "none",

--- a/components/feral-controld/devicectl/executor_test.go
+++ b/components/feral-controld/devicectl/executor_test.go
@@ -2705,22 +2705,12 @@ func TestExecutor_ZoomGestureEvent_Success(t *testing.T) {
 		}).
 		Return(nil, nil)
 	ts.mockCDP.EXPECT().
-		Send("Emulation.setPageScaleFactor", map[string]interface{}{
-			"pageScaleFactor": 1,
-		}).
-		Return(nil, nil)
-	ts.mockCDP.EXPECT().
 		Send("Input.synthesizePinchGesture", map[string]interface{}{
 			"x":                 centerX,
 			"y":                 centerY,
 			"scaleFactor":       0.98,
 			"relativeSpeed":     800,
 			"gestureSourceType": "touch",
-		}).
-		Return(nil, nil)
-	ts.mockCDP.EXPECT().
-		Send("Emulation.setPageScaleFactor", map[string]interface{}{
-			"pageScaleFactor": 1,
 		}).
 		Return(nil, nil)
 
@@ -2772,11 +2762,6 @@ func TestExecutor_ZoomGestureEvent_WithMessageID(t *testing.T) {
 			"scaleFactor":       1.1,
 			"relativeSpeed":     800,
 			"gestureSourceType": "touch",
-		}).
-		Return(nil, nil)
-	ts.mockCDP.EXPECT().
-		Send("Emulation.setPageScaleFactor", map[string]interface{}{
-			"pageScaleFactor": 1,
 		}).
 		Return(nil, nil)
 
@@ -2863,61 +2848,6 @@ func TestExecutor_ZoomGestureEvent_CDPError(t *testing.T) {
 	result, err := ts.executor.Execute(ts.ctx, cmd)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to process zoom gesture")
-	assert.Nil(t, result)
-}
-
-func TestExecutor_ZoomGestureEvent_PageScaleResetError(t *testing.T) {
-	ts := setup(t)
-	defer ts.teardown()
-
-	screenWidth := 1920.0
-	screenHeight := 1080.0
-	centerX := screenWidth / 2
-	centerY := screenHeight / 2
-
-	cmd := commands.Command{
-		Type: commands.CMD_ZOOM_GESTURE,
-		Arguments: map[string]interface{}{
-			"scaleSteps": []float64{1.01},
-		},
-	}
-	argsJSON := `{"scaleSteps":[1.01]}`
-
-	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
-	ts.mockCDP.EXPECT().
-		Send("Runtime.evaluate", gomock.Any()).
-		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
-	ts.mockJSON.EXPECT().
-		Unmarshal([]byte(argsJSON), gomock.Any()).
-		DoAndReturn(func(_ []byte, v interface{}) error {
-			in, ok := v.(*struct {
-				MessageID  string    `json:"messageID"`
-				ScaleSteps []float64 `json:"scaleSteps"`
-			})
-			if !ok {
-				return errors.New("unexpected type in zoomGesture unmarshal")
-			}
-			in.ScaleSteps = []float64{1.01}
-			return nil
-		})
-	ts.mockCDP.EXPECT().
-		Send("Input.synthesizePinchGesture", map[string]interface{}{
-			"x":                 centerX,
-			"y":                 centerY,
-			"scaleFactor":       1.01,
-			"relativeSpeed":     800,
-			"gestureSourceType": "touch",
-		}).
-		Return(nil, nil)
-	ts.mockCDP.EXPECT().
-		Send("Emulation.setPageScaleFactor", map[string]interface{}{
-			"pageScaleFactor": 1,
-		}).
-		Return(nil, errors.New("scale reset failed"))
-
-	result, err := ts.executor.Execute(ts.ctx, cmd)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "reset page scale")
 	assert.Nil(t, result)
 }
 

--- a/components/feral-controld/devicectl/executor_test.go
+++ b/components/feral-controld/devicectl/executor_test.go
@@ -2701,7 +2701,12 @@ func TestExecutor_ZoomGestureEvent_Success(t *testing.T) {
 			"y":                 centerY,
 			"scaleFactor":       1.05,
 			"relativeSpeed":     800,
-			"gestureSourceType": "default",
+			"gestureSourceType": "touch",
+		}).
+		Return(nil, nil)
+	ts.mockCDP.EXPECT().
+		Send("Emulation.setPageScaleFactor", map[string]interface{}{
+			"pageScaleFactor": 1,
 		}).
 		Return(nil, nil)
 	ts.mockCDP.EXPECT().
@@ -2710,7 +2715,12 @@ func TestExecutor_ZoomGestureEvent_Success(t *testing.T) {
 			"y":                 centerY,
 			"scaleFactor":       0.98,
 			"relativeSpeed":     800,
-			"gestureSourceType": "default",
+			"gestureSourceType": "touch",
+		}).
+		Return(nil, nil)
+	ts.mockCDP.EXPECT().
+		Send("Emulation.setPageScaleFactor", map[string]interface{}{
+			"pageScaleFactor": 1,
 		}).
 		Return(nil, nil)
 
@@ -2761,7 +2771,12 @@ func TestExecutor_ZoomGestureEvent_WithMessageID(t *testing.T) {
 			"y":                 centerY,
 			"scaleFactor":       1.1,
 			"relativeSpeed":     800,
-			"gestureSourceType": "default",
+			"gestureSourceType": "touch",
+		}).
+		Return(nil, nil)
+	ts.mockCDP.EXPECT().
+		Send("Emulation.setPageScaleFactor", map[string]interface{}{
+			"pageScaleFactor": 1,
 		}).
 		Return(nil, nil)
 
@@ -2841,13 +2856,68 @@ func TestExecutor_ZoomGestureEvent_CDPError(t *testing.T) {
 			"y":                 centerY,
 			"scaleFactor":       1.01,
 			"relativeSpeed":     800,
-			"gestureSourceType": "default",
+			"gestureSourceType": "touch",
 		}).
 		Return(nil, errors.New("cdp pinch failed"))
 
 	result, err := ts.executor.Execute(ts.ctx, cmd)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to process zoom gesture")
+	assert.Nil(t, result)
+}
+
+func TestExecutor_ZoomGestureEvent_PageScaleResetError(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	screenWidth := 1920.0
+	screenHeight := 1080.0
+	centerX := screenWidth / 2
+	centerY := screenHeight / 2
+
+	cmd := commands.Command{
+		Type: commands.CMD_ZOOM_GESTURE,
+		Arguments: map[string]interface{}{
+			"scaleSteps": []float64{1.01},
+		},
+	}
+	argsJSON := `{"scaleSteps":[1.01]}`
+
+	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(argsJSON), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			in, ok := v.(*struct {
+				MessageID  string    `json:"messageID"`
+				ScaleSteps []float64 `json:"scaleSteps"`
+			})
+			if !ok {
+				return errors.New("unexpected type in zoomGesture unmarshal")
+			}
+			in.ScaleSteps = []float64{1.01}
+			return nil
+		})
+	ts.mockCDP.EXPECT().
+		Send("Input.synthesizePinchGesture", map[string]interface{}{
+			"x":                 centerX,
+			"y":                 centerY,
+			"scaleFactor":       1.01,
+			"relativeSpeed":     800,
+			"gestureSourceType": "touch",
+		}).
+		Return(nil, nil)
+	ts.mockCDP.EXPECT().
+		Send("Emulation.setPageScaleFactor", map[string]interface{}{
+			"pageScaleFactor": 1,
+		}).
+		Return(nil, errors.New("scale reset failed"))
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "reset page scale")
 	assert.Nil(t, result)
 }
 
@@ -2891,7 +2961,7 @@ func TestExecutor_ZoomGestureEvent_UnsupportedExperimentalMethod(t *testing.T) {
 			"y":                 centerY,
 			"scaleFactor":       1.02,
 			"relativeSpeed":     800,
-			"gestureSourceType": "default",
+			"gestureSourceType": "touch",
 		}).
 		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "unknown method", Unsupported: true})
 	ts.mockCDP.EXPECT().
@@ -2903,7 +2973,7 @@ func TestExecutor_ZoomGestureEvent_UnsupportedExperimentalMethod(t *testing.T) {
 			"deltaY":    -120.0,
 			"button":    "none",
 			"buttons":   0,
-			"modifiers": 2,
+			"modifiers": 0,
 		}).
 		Return(nil, nil)
 
@@ -2952,7 +3022,7 @@ func TestExecutor_ZoomGestureEvent_PinchUnsupportedUsesFallback(t *testing.T) {
 			"y":                 centerY,
 			"scaleFactor":       0.98,
 			"relativeSpeed":     800,
-			"gestureSourceType": "default",
+			"gestureSourceType": "touch",
 		}).
 		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "Method not found", Unsupported: true})
 	ts.mockCDP.EXPECT().
@@ -2964,7 +3034,7 @@ func TestExecutor_ZoomGestureEvent_PinchUnsupportedUsesFallback(t *testing.T) {
 			"deltaY":    120.0,
 			"button":    "none",
 			"buttons":   0,
-			"modifiers": 2,
+			"modifiers": 0,
 		}).
 		Return(nil, nil)
 
@@ -3013,7 +3083,7 @@ func TestExecutor_ZoomGestureEvent_NeutralScaleDoesNotFallback(t *testing.T) {
 			"y":                 centerY,
 			"scaleFactor":       1.0,
 			"relativeSpeed":     800,
-			"gestureSourceType": "default",
+			"gestureSourceType": "touch",
 		}).
 		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "Method not found", Unsupported: true})
 
@@ -3062,7 +3132,7 @@ func TestExecutor_ZoomGestureEvent_FallbackMagnitudeGrowsWithScale(t *testing.T)
 			"y":                 centerY,
 			"scaleFactor":       1.5,
 			"relativeSpeed":     800,
-			"gestureSourceType": "default",
+			"gestureSourceType": "touch",
 		}).
 		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "unknown method", Unsupported: true})
 	ts.mockCDP.EXPECT().
@@ -3074,7 +3144,7 @@ func TestExecutor_ZoomGestureEvent_FallbackMagnitudeGrowsWithScale(t *testing.T)
 			"deltaY":    -600.0,
 			"button":    "none",
 			"buttons":   0,
-			"modifiers": 2,
+			"modifiers": 0,
 		}).
 		Return(nil, nil)
 
@@ -3123,7 +3193,7 @@ func TestExecutor_ZoomGestureEvent_PinchNotSupportedFails(t *testing.T) {
 			"y":                 centerY,
 			"scaleFactor":       1.02,
 			"relativeSpeed":     800,
-			"gestureSourceType": "default",
+			"gestureSourceType": "touch",
 		}).
 		Return(nil, errors.New("feature not supported"))
 
@@ -3245,7 +3315,7 @@ func TestExecutor_ZoomGestureEvent_UnsupportedWordingFallbacks(t *testing.T) {
 			"y":                 centerY,
 			"scaleFactor":       0.98,
 			"relativeSpeed":     800,
-			"gestureSourceType": "default",
+			"gestureSourceType": "touch",
 		}).
 		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "wasn't found", Unsupported: true})
 	ts.mockCDP.EXPECT().
@@ -3257,7 +3327,7 @@ func TestExecutor_ZoomGestureEvent_UnsupportedWordingFallbacks(t *testing.T) {
 			"deltaY":    120.0,
 			"button":    "none",
 			"buttons":   0,
-			"modifiers": 2,
+			"modifiers": 0,
 		}).
 		Return(nil, nil)
 
@@ -3306,7 +3376,7 @@ func TestExecutor_ZoomGestureEvent_UnsupportedMethodWithNameFallbacks(t *testing
 			"y":                 centerY,
 			"scaleFactor":       1.02,
 			"relativeSpeed":     800,
-			"gestureSourceType": "default",
+			"gestureSourceType": "touch",
 		}).
 		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "method not found", Unsupported: true})
 	ts.mockCDP.EXPECT().
@@ -3318,7 +3388,7 @@ func TestExecutor_ZoomGestureEvent_UnsupportedMethodWithNameFallbacks(t *testing
 			"deltaY":    -120.0,
 			"button":    "none",
 			"buttons":   0,
-			"modifiers": 2,
+			"modifiers": 0,
 		}).
 		Return(nil, nil)
 
@@ -3367,7 +3437,7 @@ func TestExecutor_ZoomGestureEvent_TargetNotFoundDoesNotFallback(t *testing.T) {
 			"y":                 centerY,
 			"scaleFactor":       1.02,
 			"relativeSpeed":     800,
-			"gestureSourceType": "default",
+			"gestureSourceType": "touch",
 		}).
 		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "Target not found", Unsupported: false})
 

--- a/components/feral-controld/devicectl/executor_test.go
+++ b/components/feral-controld/devicectl/executor_test.go
@@ -2700,8 +2700,9 @@ func TestExecutor_ZoomGestureEvent_Success(t *testing.T) {
 			"x":                 centerX,
 			"y":                 centerY,
 			"scaleFactor":       1.05,
-			"relativeSpeed":     800,
-			"gestureSourceType": "touch",
+			"relativeSpeed":     3200,
+			"gestureSourceType": "default",
+			"modifiers":         0,
 		}).
 		Return(nil, nil)
 	ts.mockCDP.EXPECT().
@@ -2709,8 +2710,9 @@ func TestExecutor_ZoomGestureEvent_Success(t *testing.T) {
 			"x":                 centerX,
 			"y":                 centerY,
 			"scaleFactor":       0.98,
-			"relativeSpeed":     800,
-			"gestureSourceType": "touch",
+			"relativeSpeed":     3200,
+			"gestureSourceType": "default",
+			"modifiers":         0,
 		}).
 		Return(nil, nil)
 
@@ -2760,8 +2762,9 @@ func TestExecutor_ZoomGestureEvent_WithMessageID(t *testing.T) {
 			"x":                 centerX,
 			"y":                 centerY,
 			"scaleFactor":       1.1,
-			"relativeSpeed":     800,
-			"gestureSourceType": "touch",
+			"relativeSpeed":     3200,
+			"gestureSourceType": "default",
+			"modifiers":         0,
 		}).
 		Return(nil, nil)
 
@@ -2840,8 +2843,9 @@ func TestExecutor_ZoomGestureEvent_CDPError(t *testing.T) {
 			"x":                 centerX,
 			"y":                 centerY,
 			"scaleFactor":       1.01,
-			"relativeSpeed":     800,
-			"gestureSourceType": "touch",
+			"relativeSpeed":     3200,
+			"gestureSourceType": "default",
+			"modifiers":         0,
 		}).
 		Return(nil, errors.New("cdp pinch failed"))
 
@@ -2890,8 +2894,9 @@ func TestExecutor_ZoomGestureEvent_UnsupportedExperimentalMethod(t *testing.T) {
 			"x":                 centerX,
 			"y":                 centerY,
 			"scaleFactor":       1.02,
-			"relativeSpeed":     800,
-			"gestureSourceType": "touch",
+			"relativeSpeed":     3200,
+			"gestureSourceType": "default",
+			"modifiers":         0,
 		}).
 		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "unknown method", Unsupported: true})
 	ts.mockCDP.EXPECT().
@@ -2951,8 +2956,9 @@ func TestExecutor_ZoomGestureEvent_PinchUnsupportedUsesFallback(t *testing.T) {
 			"x":                 centerX,
 			"y":                 centerY,
 			"scaleFactor":       0.98,
-			"relativeSpeed":     800,
-			"gestureSourceType": "touch",
+			"relativeSpeed":     3200,
+			"gestureSourceType": "default",
+			"modifiers":         0,
 		}).
 		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "Method not found", Unsupported: true})
 	ts.mockCDP.EXPECT().
@@ -3012,8 +3018,9 @@ func TestExecutor_ZoomGestureEvent_NeutralScaleDoesNotFallback(t *testing.T) {
 			"x":                 centerX,
 			"y":                 centerY,
 			"scaleFactor":       1.0,
-			"relativeSpeed":     800,
-			"gestureSourceType": "touch",
+			"relativeSpeed":     3200,
+			"gestureSourceType": "default",
+			"modifiers":         0,
 		}).
 		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "Method not found", Unsupported: true})
 
@@ -3061,8 +3068,9 @@ func TestExecutor_ZoomGestureEvent_FallbackMagnitudeGrowsWithScale(t *testing.T)
 			"x":                 centerX,
 			"y":                 centerY,
 			"scaleFactor":       1.5,
-			"relativeSpeed":     800,
-			"gestureSourceType": "touch",
+			"relativeSpeed":     3200,
+			"gestureSourceType": "default",
+			"modifiers":         0,
 		}).
 		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "unknown method", Unsupported: true})
 	ts.mockCDP.EXPECT().
@@ -3122,8 +3130,9 @@ func TestExecutor_ZoomGestureEvent_PinchNotSupportedFails(t *testing.T) {
 			"x":                 centerX,
 			"y":                 centerY,
 			"scaleFactor":       1.02,
-			"relativeSpeed":     800,
-			"gestureSourceType": "touch",
+			"relativeSpeed":     3200,
+			"gestureSourceType": "default",
+			"modifiers":         0,
 		}).
 		Return(nil, errors.New("feature not supported"))
 
@@ -3244,8 +3253,9 @@ func TestExecutor_ZoomGestureEvent_UnsupportedWordingFallbacks(t *testing.T) {
 			"x":                 centerX,
 			"y":                 centerY,
 			"scaleFactor":       0.98,
-			"relativeSpeed":     800,
-			"gestureSourceType": "touch",
+			"relativeSpeed":     3200,
+			"gestureSourceType": "default",
+			"modifiers":         0,
 		}).
 		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "wasn't found", Unsupported: true})
 	ts.mockCDP.EXPECT().
@@ -3305,8 +3315,9 @@ func TestExecutor_ZoomGestureEvent_UnsupportedMethodWithNameFallbacks(t *testing
 			"x":                 centerX,
 			"y":                 centerY,
 			"scaleFactor":       1.02,
-			"relativeSpeed":     800,
-			"gestureSourceType": "touch",
+			"relativeSpeed":     3200,
+			"gestureSourceType": "default",
+			"modifiers":         0,
 		}).
 		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "method not found", Unsupported: true})
 	ts.mockCDP.EXPECT().
@@ -3366,8 +3377,9 @@ func TestExecutor_ZoomGestureEvent_TargetNotFoundDoesNotFallback(t *testing.T) {
 			"x":                 centerX,
 			"y":                 centerY,
 			"scaleFactor":       1.02,
-			"relativeSpeed":     800,
-			"gestureSourceType": "touch",
+			"relativeSpeed":     3200,
+			"gestureSourceType": "default",
+			"modifiers":         0,
 		}).
 		Return(nil, &cdp.RemoteError{Method: "Input.synthesizePinchGesture", Description: "Target not found", Unsupported: false})
 

--- a/components/feral-controld/devicectl/executor_test.go
+++ b/components/feral-controld/devicectl/executor_test.go
@@ -2682,6 +2682,14 @@ func TestExecutor_ZoomGestureEvent_Success(t *testing.T) {
 	ts.mockCDP.EXPECT().
 		Send("Runtime.evaluate", gomock.Any()).
 		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{
+			"offsetLeft": 0.0,
+			"offsetTop":  0.0,
+			"width":      screenWidth,
+			"height":     screenHeight,
+		}, nil)
 	ts.mockJSON.EXPECT().
 		Unmarshal([]byte(argsJSON), gomock.Any()).
 		DoAndReturn(func(_ []byte, v interface{}) error {
@@ -2938,6 +2946,14 @@ func TestExecutor_ZoomGestureEvent_PinchUnsupportedUsesFallback(t *testing.T) {
 	ts.mockCDP.EXPECT().
 		Send("Runtime.evaluate", gomock.Any()).
 		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{
+			"offsetLeft": 0.0,
+			"offsetTop":  0.0,
+			"width":      screenWidth,
+			"height":     screenHeight,
+		}, nil)
 	ts.mockJSON.EXPECT().
 		Unmarshal([]byte(argsJSON), gomock.Any()).
 		DoAndReturn(func(_ []byte, v interface{}) error {
@@ -3235,6 +3251,14 @@ func TestExecutor_ZoomGestureEvent_UnsupportedWordingFallbacks(t *testing.T) {
 	ts.mockCDP.EXPECT().
 		Send("Runtime.evaluate", gomock.Any()).
 		Return(map[string]interface{}{"width": screenWidth, "height": screenHeight}, nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{
+			"offsetLeft": 0.0,
+			"offsetTop":  0.0,
+			"width":      screenWidth,
+			"height":     screenHeight,
+		}, nil)
 	ts.mockJSON.EXPECT().
 		Unmarshal([]byte(argsJSON), gomock.Any()).
 		DoAndReturn(func(_ []byte, v interface{}) error {

--- a/components/feral-controld/devicectl/executor_test.go
+++ b/components/feral-controld/devicectl/executor_test.go
@@ -2931,6 +2931,85 @@ func TestExecutor_ZoomGestureEvent_EmptyScaleSteps(t *testing.T) {
 	assert.Equal(t, devicectl.CmdOK, result)
 }
 
+func TestExecutor_ZoomGestureEvent_RejectsOversizedScaleSteps(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	steps := make([]float64, 0, 17)
+	for i := 0; i < cap(steps); i++ {
+		steps = append(steps, 1.01)
+	}
+
+	cmd := commands.Command{
+		Type: commands.CMD_ZOOM_GESTURE,
+		Arguments: map[string]interface{}{
+			"scaleSteps": steps,
+		},
+	}
+	argsJSON := `{"scaleSteps":[1.01,1.01,1.01,1.01,1.01,1.01,1.01,1.01,1.01,1.01,1.01,1.01,1.01,1.01,1.01,1.01,1.01]}`
+
+	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{"width": 1920.0, "height": 1080.0}, nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(argsJSON), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			in, ok := v.(*struct {
+				MessageID  string    `json:"messageID"`
+				ScaleSteps []float64 `json:"scaleSteps"`
+			})
+			if !ok {
+				return errors.New("unexpected type in zoomGesture unmarshal")
+			}
+			in.ScaleSteps = steps
+			return nil
+		})
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "scaleSteps exceeds maximum")
+}
+
+func TestExecutor_ZoomGestureEvent_StopsOnContextCancellation(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	ctx, cancel := context.WithCancel(ts.ctx)
+	cancel()
+
+	cmd := commands.Command{
+		Type: commands.CMD_ZOOM_GESTURE,
+		Arguments: map[string]interface{}{
+			"scaleSteps": []float64{1.05, 0.98},
+		},
+	}
+	argsJSON := `{"scaleSteps":[1.05,0.98]}`
+
+	ts.mockJSON.EXPECT().Marshal(cmd.Arguments).Return([]byte(argsJSON), nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{"width": 1920.0, "height": 1080.0}, nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(argsJSON), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			in, ok := v.(*struct {
+				MessageID  string    `json:"messageID"`
+				ScaleSteps []float64 `json:"scaleSteps"`
+			})
+			if !ok {
+				return errors.New("unexpected type in zoomGesture unmarshal")
+			}
+			in.ScaleSteps = []float64{1.05, 0.98}
+			return nil
+		})
+
+	result, err := ts.executor.Execute(ctx, cmd)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, result)
+}
+
 func TestExecutor_ZoomGestureEvent_CDPError(t *testing.T) {
 	ts := setup(t)
 	defer ts.teardown()

--- a/components/feral-controld/devicectl/executor_test.go
+++ b/components/feral-controld/devicectl/executor_test.go
@@ -2437,6 +2437,53 @@ func TestExecutor_MouseClickAndDragEvent_Success(t *testing.T) {
 	assert.Equal(t, devicectl.CmdOK, result)
 }
 
+func TestExecutor_MouseClickAndDragEvent_RejectsOversizedCursorOffsets(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	cursorOffsets := make([]map[string]interface{}, 0, 17)
+	for i := 0; i < 17; i++ {
+		cursorOffsets = append(cursorOffsets, map[string]interface{}{"dx": 1.0, "dy": 0.0})
+	}
+
+	cmd := commands.Command{
+		Type: commands.CMD_MOUSE_CLICK_AND_DRAG_EVENT,
+		Arguments: map[string]interface{}{
+			"messageID":     "oversized",
+			"cursorOffsets": cursorOffsets,
+		},
+	}
+
+	argsJSON := `{"messageID":"oversized","cursorOffsets":[{"dx":1.0,"dy":0.0},{"dx":1.0,"dy":0.0},{"dx":1.0,"dy":0.0},{"dx":1.0,"dy":0.0},{"dx":1.0,"dy":0.0},{"dx":1.0,"dy":0.0},{"dx":1.0,"dy":0.0},{"dx":1.0,"dy":0.0},{"dx":1.0,"dy":0.0},{"dx":1.0,"dy":0.0},{"dx":1.0,"dy":0.0},{"dx":1.0,"dy":0.0},{"dx":1.0,"dy":0.0},{"dx":1.0,"dy":0.0},{"dx":1.0,"dy":0.0},{"dx":1.0,"dy":0.0},{"dx":1.0,"dy":0.0}]}`
+
+	ts.mockJSON.EXPECT().
+		Marshal(cmd.Arguments).
+		Return([]byte(argsJSON), nil)
+	ts.mockCDP.EXPECT().
+		Send("Runtime.evaluate", gomock.Any()).
+		Return(map[string]interface{}{"width": 1920.0, "height": 1080.0}, nil)
+	ts.mockJSON.EXPECT().
+		Unmarshal([]byte(argsJSON), gomock.Any()).
+		DoAndReturn(func(_ []byte, v interface{}) error {
+			args := v.(*struct {
+				CursorOffsets []struct {
+					DX float64 `json:"dx"`
+					DY float64 `json:"dy"`
+				} `json:"cursorOffsets"`
+			})
+			args.CursorOffsets = make([]struct {
+				DX float64 `json:"dx"`
+				DY float64 `json:"dy"`
+			}, 17)
+			return nil
+		})
+
+	result, err := ts.executor.Execute(ts.ctx, cmd)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "cursorOffsets exceeds maximum of 16")
+}
+
 func TestExecutor_MouseClickAndDragEvent_ReleaseFailureReturnsError(t *testing.T) {
 	ts := setup(t)
 	defer ts.teardown()

--- a/components/feral-controld/devicectl/executor_test.go
+++ b/components/feral-controld/devicectl/executor_test.go
@@ -110,6 +110,14 @@ func (ts *testSetup) teardown() {
 	ts.ctrl.Finish()
 }
 
+func expectPageScaleReset(ts *testSetup) {
+	ts.mockCDP.EXPECT().
+		Send("Emulation.setPageScaleFactor", map[string]interface{}{
+			"pageScaleFactor": 1.0,
+		}).
+		Return(nil, nil)
+}
+
 func TestExecutor_Execute_InvalidCommand(t *testing.T) {
 	ts := setup(t)
 	defer ts.teardown()
@@ -2742,6 +2750,7 @@ func TestExecutor_ZoomGestureEvent_Success(t *testing.T) {
 			"modifiers":         0,
 		}).
 		Return(nil, nil)
+	expectPageScaleReset(ts)
 	ts.mockCDP.EXPECT().
 		Send("Input.synthesizePinchGesture", map[string]interface{}{
 			"x":                 centerX,
@@ -2752,6 +2761,7 @@ func TestExecutor_ZoomGestureEvent_Success(t *testing.T) {
 			"modifiers":         0,
 		}).
 		Return(nil, nil)
+	expectPageScaleReset(ts)
 
 	result, err := ts.executor.Execute(ts.ctx, cmd)
 	assert.NoError(t, err)
@@ -2821,6 +2831,7 @@ func TestExecutor_ZoomGestureEvent_MapsAnchorForDifferentScaleSteps(t *testing.T
 				"modifiers":         0,
 			}).
 			Return(nil, nil)
+		expectPageScaleReset(ts)
 	}
 
 	result, err := ts.executor.Execute(ts.ctx, cmd)
@@ -2882,6 +2893,7 @@ func TestExecutor_ZoomGestureEvent_WithMessageID(t *testing.T) {
 			"modifiers":         0,
 		}).
 		Return(nil, nil)
+	expectPageScaleReset(ts)
 
 	result, err := ts.executor.Execute(ts.ctx, cmd)
 	assert.NoError(t, err)

--- a/components/feral-controld/devicectl/executor_zoom_viewport_test.go
+++ b/components/feral-controld/devicectl/executor_zoom_viewport_test.go
@@ -1,0 +1,21 @@
+package devicectl
+
+import "testing"
+
+func TestExecutor_ClampToViewport_ClampsInsideBounds(t *testing.T) {
+	e := &executor{}
+
+	x, y := e.clampToViewport(2000, -50, 100, 200, 800, 600)
+	if x != 900 || y != 200 {
+		t.Fatalf("expected clamped point (900,200), got (%v,%v)", x, y)
+	}
+}
+
+func TestExecutor_ClampToViewport_KeepsPointInsideBounds(t *testing.T) {
+	e := &executor{}
+
+	x, y := e.clampToViewport(500, 450, 100, 200, 800, 600)
+	if x != 500 || y != 450 {
+		t.Fatalf("expected unchanged point (500,450), got (%v,%v)", x, y)
+	}
+}

--- a/components/feral-controld/devicectl/executor_zoom_viewport_test.go
+++ b/components/feral-controld/devicectl/executor_zoom_viewport_test.go
@@ -2,20 +2,26 @@ package devicectl
 
 import "testing"
 
-func TestExecutor_ClampToViewport_ClampsInsideBounds(t *testing.T) {
-	e := &executor{}
+func TestExecutor_InnerToVisualViewport_MapsProportionally(t *testing.T) {
+	e := &executor{
+		screenWidth:  1920,
+		screenHeight: 1080,
+	}
 
-	x, y := e.clampToViewport(2000, -50, 100, 200, 800, 600)
-	if x != 900 || y != 200 {
-		t.Fatalf("expected clamped point (900,200), got (%v,%v)", x, y)
+	x, y := e.innerToVisualViewport(960, 540, 100, 200, 960, 540)
+	if x != 580 || y != 470 {
+		t.Fatalf("expected mapped point (580,470), got (%v,%v)", x, y)
 	}
 }
 
-func TestExecutor_ClampToViewport_KeepsPointInsideBounds(t *testing.T) {
-	e := &executor{}
+func TestExecutor_InnerToVisualViewport_ClampsToVisualBounds(t *testing.T) {
+	e := &executor{
+		screenWidth:  1920,
+		screenHeight: 1080,
+	}
 
-	x, y := e.clampToViewport(500, 450, 100, 200, 800, 600)
-	if x != 500 || y != 450 {
-		t.Fatalf("expected unchanged point (500,450), got (%v,%v)", x, y)
+	x, y := e.innerToVisualViewport(3000, -10, 100, 200, 960, 540)
+	if x != 1060 || y != 200 {
+		t.Fatalf("expected clamped point (1060,200), got (%v,%v)", x, y)
 	}
 }

--- a/components/feral-controld/devicectl/executor_zoom_viewport_test.go
+++ b/components/feral-controld/devicectl/executor_zoom_viewport_test.go
@@ -2,26 +2,20 @@ package devicectl
 
 import "testing"
 
-func TestExecutor_InnerToVisualViewport_MapsProportionally(t *testing.T) {
-	e := &executor{
-		screenWidth:  1920,
-		screenHeight: 1080,
-	}
+func TestExecutor_InnerToVisualViewport_TranslatesByVisualOffset(t *testing.T) {
+	e := &executor{}
 
-	x, y := e.innerToVisualViewport(960, 540, 100, 200, 960, 540)
-	if x != 580 || y != 470 {
-		t.Fatalf("expected mapped point (580,470), got (%v,%v)", x, y)
+	x, y := e.innerToVisualViewport(480, 270, 120, 80, 960, 540)
+	if x != 360 || y != 190 {
+		t.Fatalf("expected translated point (360,190), got (%v,%v)", x, y)
 	}
 }
 
 func TestExecutor_InnerToVisualViewport_ClampsToVisualBounds(t *testing.T) {
-	e := &executor{
-		screenWidth:  1920,
-		screenHeight: 1080,
-	}
+	e := &executor{}
 
 	x, y := e.innerToVisualViewport(3000, -10, 100, 200, 960, 540)
-	if x != 1060 || y != 200 {
-		t.Fatalf("expected clamped point (1060,200), got (%v,%v)", x, y)
+	if x != 960 || y != 0 {
+		t.Fatalf("expected clamped point (960,0), got (%v,%v)", x, y)
 	}
 }

--- a/components/feral-controld/devicectl/executor_zoom_viewport_test.go
+++ b/components/feral-controld/devicectl/executor_zoom_viewport_test.go
@@ -16,7 +16,7 @@ func TestExecutor_InnerToVisualViewport_ClampsToVisualBounds(t *testing.T) {
 
 	x, y := e.innerToVisualViewport(3000, -10, 100, 200, 960, 540)
 	if x != 960 || y != 0 {
-		t.Fatalf("expected clamped point (960,0), got (%v,%v)", x, y)
+		t.Fatalf("expected clamped point (960,0), got (%v,%v) ", x, y)
 	}
 }
 

--- a/components/feral-controld/devicectl/executor_zoom_viewport_test.go
+++ b/components/feral-controld/devicectl/executor_zoom_viewport_test.go
@@ -36,3 +36,95 @@ func TestExecutor_InnerToVisualViewport_KeepsSameInnerAnchorAcrossViewportChange
 		t.Fatalf("expected translated visual point (360,190), got (%v,%v)", nextX, nextY)
 	}
 }
+
+func TestExecutor_InnerToVisualViewport_MapsDifferentInnerMousePositions(t *testing.T) {
+	e := &executor{}
+
+	tests := []struct {
+		name      string
+		innerX    float64
+		innerY    float64
+		viewportX float64
+		viewportY float64
+		viewportW float64
+		viewportH float64
+		wantX     float64
+		wantY     float64
+	}{
+		{
+			name:      "top left visible",
+			innerX:    120,
+			innerY:    80,
+			viewportX: 120,
+			viewportY: 80,
+			viewportW: 960,
+			viewportH: 540,
+			wantX:     0,
+			wantY:     0,
+		},
+		{
+			name:      "first quadrant",
+			innerX:    480,
+			innerY:    270,
+			viewportX: 120,
+			viewportY: 80,
+			viewportW: 960,
+			viewportH: 540,
+			wantX:     360,
+			wantY:     190,
+		},
+		{
+			name:      "center",
+			innerX:    960,
+			innerY:    540,
+			viewportX: 120,
+			viewportY: 80,
+			viewportW: 960,
+			viewportH: 540,
+			wantX:     840,
+			wantY:     460,
+		},
+		{
+			name:      "right edge clamps",
+			innerX:    1400,
+			innerY:    540,
+			viewportX: 120,
+			viewportY: 80,
+			viewportW: 960,
+			viewportH: 540,
+			wantX:     960,
+			wantY:     460,
+		},
+		{
+			name:      "above visible clamps",
+			innerX:    480,
+			innerY:    20,
+			viewportX: 120,
+			viewportY: 80,
+			viewportW: 960,
+			viewportH: 540,
+			wantX:     360,
+			wantY:     0,
+		},
+		{
+			name:      "bottom visible edge",
+			innerX:    1080,
+			innerY:    620,
+			viewportX: 120,
+			viewportY: 80,
+			viewportW: 960,
+			viewportH: 540,
+			wantX:     960,
+			wantY:     540,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotX, gotY := e.innerToVisualViewport(tt.innerX, tt.innerY, tt.viewportX, tt.viewportY, tt.viewportW, tt.viewportH)
+			if gotX != tt.wantX || gotY != tt.wantY {
+				t.Fatalf("expected (%v,%v), got (%v,%v)", tt.wantX, tt.wantY, gotX, gotY)
+			}
+		})
+	}
+}

--- a/components/feral-controld/devicectl/executor_zoom_viewport_test.go
+++ b/components/feral-controld/devicectl/executor_zoom_viewport_test.go
@@ -19,3 +19,20 @@ func TestExecutor_InnerToVisualViewport_ClampsToVisualBounds(t *testing.T) {
 		t.Fatalf("expected clamped point (960,0), got (%v,%v)", x, y)
 	}
 }
+
+func TestExecutor_InnerToVisualViewport_KeepsSameInnerAnchorAcrossViewportChanges(t *testing.T) {
+	e := &executor{}
+
+	const innerMouseX = 1920.0 / 4
+	const innerMouseY = 1080.0 / 4
+
+	firstX, firstY := e.innerToVisualViewport(innerMouseX, innerMouseY, 0, 0, 1920, 1080)
+	if firstX != 480 || firstY != 270 {
+		t.Fatalf("expected initial visual point (480,270), got (%v,%v)", firstX, firstY)
+	}
+
+	nextX, nextY := e.innerToVisualViewport(innerMouseX, innerMouseY, 120, 80, 1280, 720)
+	if nextX != 360 || nextY != 190 {
+		t.Fatalf("expected translated visual point (360,190), got (%v,%v)", nextX, nextY)
+	}
+}

--- a/components/feral-controld/mocks/clock.go
+++ b/components/feral-controld/mocks/clock.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	"context"
 	reflect "reflect"
 	time "time"
 
@@ -74,6 +75,20 @@ func (m *MockClock) Sleep(d time.Duration) {
 func (mr *MockClockMockRecorder) Sleep(d interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sleep", reflect.TypeOf((*MockClock)(nil).Sleep), d)
+}
+
+// SleepContext mocks base method.
+func (m *MockClock) SleepContext(ctx context.Context, d time.Duration) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SleepContext", ctx, d)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SleepContext indicates an expected call of SleepContext.
+func (mr *MockClockMockRecorder) SleepContext(ctx, d interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SleepContext", reflect.TypeOf((*MockClock)(nil).SleepContext), ctx, d)
 }
 
 // MockTicker is a mock of Ticker interface.

--- a/components/feral-controld/wrapper/clock.go
+++ b/components/feral-controld/wrapper/clock.go
@@ -1,12 +1,17 @@
 //nolint:gosec
 package wrapper
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 //go:generate mockgen -source=clock.go -destination=../mocks/clock.go -package=mocks -mock_names=Clock=MockClock
 type Clock interface {
 	Now() time.Time
 	Sleep(d time.Duration)
+	// SleepContext waits until d elapses unless ctx is canceled first. Returns ctx.Err() when ctx is done before d.
+	SleepContext(ctx context.Context, d time.Duration) error
 	NewTicker(d time.Duration) Ticker
 }
 
@@ -22,6 +27,23 @@ func (t *clock) Now() time.Time {
 
 func (t *clock) Sleep(d time.Duration) {
 	time.Sleep(d)
+}
+
+func (t *clock) SleepContext(ctx context.Context, d time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func (t *clock) NewTicker(d time.Duration) Ticker {

--- a/components/feral-controld/wrapper/clock_test.go
+++ b/components/feral-controld/wrapper/clock_test.go
@@ -1,0 +1,39 @@
+package wrapper
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClock_SleepContext_AlreadyCanceled(t *testing.T) {
+	c := NewClock()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := c.SleepContext(ctx, time.Hour)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestClock_SleepContext_Completes(t *testing.T) {
+	c := NewClock()
+	ctx := context.Background()
+	start := time.Now()
+	err := c.SleepContext(ctx, 50*time.Millisecond)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, time.Since(start), 45*time.Millisecond)
+}
+
+func TestClock_SleepContext_DeadlineWinsBeforeTimer(t *testing.T) {
+	c := NewClock()
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(30*time.Millisecond))
+	defer cancel()
+	start := time.Now()
+	err := c.SleepContext(ctx, time.Hour)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, time.Since(start), 500*time.Millisecond)
+}

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -116,7 +116,7 @@ The following command names are routed to `devicectl` and use the standard relay
 | `tapGesture` | `button` | `button` selects left, right, or middle; missing or empty defaults to left. |
 | `doubleTapGesture` | `button` | Same button selection as `tapGesture`. |
 | `longPressGesture` | `button` | Same button selection as `tapGesture`. |
-| `clickAndDragGesture` | `cursorOffsets` | Press, move, then release. The executor treats release failure as an error because Chromium can remain pressed. |
+| `clickAndDragGesture` | `cursorOffsets` | Press, move, then release. The executor treats release failure as an error because Chromium can remain pressed. Batches are capped at 16 offsets to keep a single request from monopolizing the executor. |
 | `zoomGesture` | `scaleSteps` | Array of positive float scale factors. The executor uses `Input.synthesizePinchGesture` with the default gesture source, resets Chromium page scale after each successful pinch, and falls back to non-Ctrl wheel input only when pinch synthesis is unsupported. |
 | `setSleepSchedule` | `enabled`, optional `sleepTime`, `wakeTime` (HH:MM) | Persists the FF1 sleep/wake window and enables or disables automatic transitions. |
 | `sleepNow` | — | Manual override toward sleep until the next schedule boundary (when the schedule is enabled). |

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -117,7 +117,7 @@ The following command names are routed to `devicectl` and use the standard relay
 | `doubleTapGesture` | `button` | Same button selection as `tapGesture`. |
 | `longPressGesture` | `button` | Same button selection as `tapGesture`. |
 | `clickAndDragGesture` | `cursorOffsets` | Press, move, then release. The executor treats release failure as an error because Chromium can remain pressed. |
-| `zoomGesture` | `scaleSteps` | Array of positive float scale factors. The executor uses `Input.synthesizePinchGesture` with the default gesture source, and falls back to non-Ctrl wheel input only when pinch synthesis is unsupported. |
+| `zoomGesture` | `scaleSteps` | Array of positive float scale factors. The executor uses `Input.synthesizePinchGesture` with the default gesture source, resets Chromium page scale after each successful pinch, and falls back to non-Ctrl wheel input only when pinch synthesis is unsupported. |
 | `setSleepSchedule` | `enabled`, optional `sleepTime`, `wakeTime` (HH:MM) | Persists the FF1 sleep/wake window and enables or disables automatic transitions. |
 | `sleepNow` | — | Manual override toward sleep until the next schedule boundary (when the schedule is enabled). |
 | `wakeNow` | — | Manual override toward awake until the next schedule boundary (when the schedule is enabled). |

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -112,7 +112,7 @@ The following command names are routed to `devicectl` and use the standard relay
 
 | Command | Request fields | Notes |
 |---|---|---|
-| `dragGesture` | `cursorOffsets` | Array of `{dx, dy}` step deltas . |
+| `dragGesture` | `cursorOffsets` | Array of `{dx, dy}` step deltas. |
 | `tapGesture` | `button` | `button` selects left, right, or middle; missing or empty defaults to left. |
 | `doubleTapGesture` | `button` | Same button selection as `tapGesture`. |
 | `longPressGesture` | `button` | Same button selection as `tapGesture`. |

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -117,7 +117,7 @@ The following command names are routed to `devicectl` and use the standard relay
 | `doubleTapGesture` | `button` | Same button selection as `tapGesture`. |
 | `longPressGesture` | `button` | Same button selection as `tapGesture`. |
 | `clickAndDragGesture` | `cursorOffsets` | Press, move, then release. The executor treats release failure as an error because Chromium can remain pressed. |
-| `zoomGesture` | `scaleSteps` | Array of positive float scale factors. Pinch synthesis is attempted first and falls back to wheel zoom only when the method is unsupported. |
+| `zoomGesture` | `scaleSteps` | Array of positive float scale factors. Touch-source pinch synthesis is attempted first and resets Chromium page scale afterward so browser zoom cannot remain stuck; it falls back to non-Ctrl wheel input only when the pinch method is unsupported. |
 | `setSleepSchedule` | `enabled`, optional `sleepTime`, `wakeTime` (HH:MM) | Persists the FF1 sleep/wake window and enables or disables automatic transitions. |
 | `sleepNow` | — | Manual override toward sleep until the next schedule boundary (when the schedule is enabled). |
 | `wakeNow` | — | Manual override toward awake until the next schedule boundary (when the schedule is enabled). |

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -112,6 +112,12 @@ The following command names are routed to `devicectl` and use the standard relay
 
 | Command | Request fields | Notes |
 |---|---|---|
+| `dragGesture` | `cursorOffsets` | Array of `{dx, dy}` step deltas. |
+| `tapGesture` | `button` | `button` selects left, right, or middle; missing or empty defaults to left. |
+| `doubleTapGesture` | `button` | Same button selection as `tapGesture`. |
+| `longPressGesture` | `button` | Same button selection as `tapGesture`. |
+| `clickAndDragGesture` | `cursorOffsets` | Press, move, then release. The executor treats release failure as an error because Chromium can remain pressed. |
+| `zoomGesture` | `scaleSteps` | Array of positive float scale factors. Pinch synthesis is attempted first and falls back to wheel zoom only when the method is unsupported. |
 | `setSleepSchedule` | `enabled`, optional `sleepTime`, `wakeTime` (HH:MM) | Persists the FF1 sleep/wake window and enables or disables automatic transitions. |
 | `sleepNow` | — | Manual override toward sleep until the next schedule boundary (when the schedule is enabled). |
 | `wakeNow` | — | Manual override toward awake until the next schedule boundary (when the schedule is enabled). |

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -112,7 +112,7 @@ The following command names are routed to `devicectl` and use the standard relay
 
 | Command | Request fields | Notes |
 |---|---|---|
-| `dragGesture` | `cursorOffsets` | Array of `{dx, dy}` step deltas. |
+| `dragGesture` | `cursorOffsets` | Array of `{dx, dy}` step deltas . |
 | `tapGesture` | `button` | `button` selects left, right, or middle; missing or empty defaults to left. |
 | `doubleTapGesture` | `button` | Same button selection as `tapGesture`. |
 | `longPressGesture` | `button` | Same button selection as `tapGesture`. |

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -117,7 +117,7 @@ The following command names are routed to `devicectl` and use the standard relay
 | `doubleTapGesture` | `button` | Same button selection as `tapGesture`. |
 | `longPressGesture` | `button` | Same button selection as `tapGesture`. |
 | `clickAndDragGesture` | `cursorOffsets` | Press, move, then release. The executor treats release failure as an error because Chromium can remain pressed. Batches are capped at 16 offsets to keep a single request from monopolizing the executor. |
-| `zoomGesture` | `scaleSteps` | Array of positive float scale factors. The executor uses `Input.synthesizePinchGesture` with the default gesture source, resets Chromium page scale after each successful pinch, and falls back to non-Ctrl wheel input only when pinch synthesis is unsupported. |
+| `zoomGesture` | `scaleSteps` | Array of positive float scale factors. The executor dispatches non-Ctrl `mouseWheel` input at the current cursor anchor so Chromium does not apply browser/page zoom. |
 | `setSleepSchedule` | `enabled`, optional `sleepTime`, `wakeTime` (HH:MM) | Persists the FF1 sleep/wake window and enables or disables automatic transitions. |
 | `sleepNow` | — | Manual override toward sleep until the next schedule boundary (when the schedule is enabled). |
 | `wakeNow` | — | Manual override toward awake until the next schedule boundary (when the schedule is enabled). |

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -117,7 +117,7 @@ The following command names are routed to `devicectl` and use the standard relay
 | `doubleTapGesture` | `button` | Same button selection as `tapGesture`. |
 | `longPressGesture` | `button` | Same button selection as `tapGesture`. |
 | `clickAndDragGesture` | `cursorOffsets` | Press, move, then release. The executor treats release failure as an error because Chromium can remain pressed. |
-| `zoomGesture` | `scaleSteps` | Array of positive float scale factors. Touch-source pinch synthesis is attempted first and resets Chromium page scale afterward so browser zoom cannot remain stuck; it falls back to non-Ctrl wheel input only when the pinch method is unsupported. |
+| `zoomGesture` | `scaleSteps` | Array of positive float scale factors. The executor uses `Input.synthesizePinchGesture` with the default gesture source, and falls back to non-Ctrl wheel input only when pinch synthesis is unsupported. |
 | `setSleepSchedule` | `enabled`, optional `sleepTime`, `wakeTime` (HH:MM) | Persists the FF1 sleep/wake window and enables or disables automatic transitions. |
 | `sleepNow` | — | Manual override toward sleep until the next schedule boundary (when the schedule is enabled). |
 | `wakeNow` | — | Manual override toward awake until the next schedule boundary (when the schedule is enabled). |


### PR DESCRIPTION
## Summary
- Reapply the FF1 mouse gesture work after the revert branch.
- Prevent `zoomGesture` from leaving Chromium page zoom stuck by using the documented pinch input path with page-scale reset.
- Remove Ctrl from the wheel fallback so it cannot trigger Chromium browser zoom.

## Root Cause
Controld translated `zoomGesture` into CDP input that Chromium could handle at the browser/page layer when an artwork did not consume the gesture. The fallback path sent Ctrl+wheel, which is Chromium page zoom by design.

## Validation
- `go test ./...` in `components/feral-controld`
- `go vet ./...` in `components/feral-controld`
- `golangci-lint run --new-from-rev=HEAD~1 ./...` in `components/feral-controld`
- `git diff --check`