### PR TITLE
fix: send relayer app ping messages

### DIFF
--- a/components/feral-controld/relayer/relayer.go
+++ b/components/feral-controld/relayer/relayer.go
@@ -422,6 +422,8 @@ func (r *relayer) background(ctx context.Context) {
 					zap.Int("message_length", len(msg)),
 				)
 
+				// Application pong is the relayer keepalive response: refresh the
+				// deadline, then stop before command handlers see the control frame.
 				if payload.Type == "pong" {
 					r.logger.Info("Received application pong from relayer")
 					if err := conn.SetReadDeadline(time.Time{}); err != nil {

--- a/components/feral-controld/relayer/relayer.go
+++ b/components/feral-controld/relayer/relayer.go
@@ -282,8 +282,7 @@ func (r *relayer) Connect(ctx context.Context) error {
 		zap.String("cf_ray", cfRay),
 	)
 
-	// Keep the transport pong handler during rollout so older relayer builds can
-	// still keep the socket alive before the JSON ping/pong path is deployed.
+	// Set pong handler
 	conn.SetPongHandler(func(_ string) error {
 		r.logger.Info("Received pong from relayer")
 		return conn.SetReadDeadline(time.Time{})
@@ -423,9 +422,8 @@ func (r *relayer) background(ctx context.Context) {
 					zap.Int("message_length", len(msg)),
 				)
 
-				// Application pong is the relayer keepalive response when the new
-				// protocol is deployed. Transport pong stays enabled as a rollout
-				// fallback so older relayer builds do not time out during release.
+				// Application pong is the relayer keepalive response: refresh the
+				// deadline, then stop before command handlers see the control frame.
 				if payload.Type == "pong" {
 					r.logger.Info("Received application pong from relayer")
 					if err := conn.SetReadDeadline(time.Time{}); err != nil {
@@ -489,7 +487,8 @@ func (r *relayer) Send(ctx context.Context, data interface{}) error {
 	return r.conn.WriteMessage(websocket.TextMessage, jsonData)
 }
 
-// ping sends a ping to keep the connection alive
+// ping sends both transport and application keepalive frames so older and newer
+// relayer builds can keep the connection alive during rollout.
 func (r *relayer) ping() {
 	r.Lock()
 	defer r.Unlock()
@@ -499,14 +498,18 @@ func (r *relayer) ping() {
 	}
 
 	r.logger.Info("Sending relayer ping")
+	deadline := r.clock.Now().Add(PONG_WAIT)
+
+	if err := r.conn.SetReadDeadline(deadline); err != nil {
+		r.logger.Error("Failed to set read deadline before transport ping", zap.Error(err))
+	}
+
+	if err := r.conn.WriteControl(websocket.PingMessage, nil, deadline); err != nil {
+		r.logger.Error("Failed to send transport ping", zap.Error(err))
+	}
+
 	if err := r.conn.WriteJSON(map[string]string{"type": "ping"}); err != nil {
-		r.logger.Error("Failed to send ping", zap.Error(err))
-		return
-	} else {
-		err = r.conn.SetReadDeadline(r.clock.Now().Add(PONG_WAIT))
-		if err != nil {
-			r.logger.Error("Failed to set read deadline", zap.Error(err))
-		}
+		r.logger.Error("Failed to send application ping", zap.Error(err))
 	}
 }
 

--- a/components/feral-controld/relayer/relayer.go
+++ b/components/feral-controld/relayer/relayer.go
@@ -282,7 +282,8 @@ func (r *relayer) Connect(ctx context.Context) error {
 		zap.String("cf_ray", cfRay),
 	)
 
-	// Set pong handler
+	// Keep the transport pong handler during rollout so older relayer builds can
+	// still keep the socket alive before the JSON ping/pong path is deployed.
 	conn.SetPongHandler(func(_ string) error {
 		r.logger.Info("Received pong from relayer")
 		return conn.SetReadDeadline(time.Time{})
@@ -422,8 +423,9 @@ func (r *relayer) background(ctx context.Context) {
 					zap.Int("message_length", len(msg)),
 				)
 
-				// Application pong is the relayer keepalive response: refresh the
-				// deadline, then stop before command handlers see the control frame.
+				// Application pong is the relayer keepalive response when the new
+				// protocol is deployed. Transport pong stays enabled as a rollout
+				// fallback so older relayer builds do not time out during release.
 				if payload.Type == "pong" {
 					r.logger.Info("Received application pong from relayer")
 					if err := conn.SetReadDeadline(time.Time{}); err != nil {

--- a/components/feral-controld/relayer/relayer.go
+++ b/components/feral-controld/relayer/relayer.go
@@ -49,6 +49,7 @@ type Response struct {
 }
 
 type Payload struct {
+	Type      string  `json:"type,omitempty"`
 	MessageID string  `json:"messageID"`
 	Message   Message `json:"message"`
 }
@@ -414,11 +415,20 @@ func (r *relayer) background(ctx context.Context) {
 
 				r.logger.Info("Received message",
 					zap.ByteString("message", logMsg),
+					zap.String("type", payload.Type),
 					zap.String("messageID", payload.MessageID),
 					zap.String("command", derefString(payload.Message.Command)),
 					zap.String("topicID", derefString(payload.Message.TopicID)),
 					zap.Int("message_length", len(msg)),
 				)
+
+				if payload.Type == "pong" {
+					r.logger.Info("Received application pong from relayer")
+					if err := conn.SetReadDeadline(time.Time{}); err != nil {
+						r.logger.Error("Failed to clear read deadline after pong", zap.Error(err))
+					}
+					continue
+				}
 
 				// Forward payload to handlers
 				for _, handler := range r.handlers {
@@ -485,7 +495,7 @@ func (r *relayer) ping() {
 	}
 
 	r.logger.Info("Sending relayer ping")
-	if err := r.conn.WriteMessage(websocket.PingMessage, []byte("ping")); err != nil {
+	if err := r.conn.WriteJSON(map[string]string{"type": "ping"}); err != nil {
 		r.logger.Error("Failed to send ping", zap.Error(err))
 		return
 	} else {

--- a/components/feral-controld/relayer/relayer_test.go
+++ b/components/feral-controld/relayer/relayer_test.go
@@ -134,7 +134,7 @@ func TestClient_Connect_Success(t *testing.T) {
 
 	// Expect conn to write ping
 	ts.mockConn.EXPECT().
-		WriteMessage(websocket.PingMessage, gomock.Any()).
+		WriteJSON(gomock.Any()).
 		Return(nil).
 		AnyTimes()
 
@@ -198,7 +198,7 @@ func TestClient_Connect_Async(t *testing.T) {
 
 	// Expect conn to write ping
 	ts.mockConn.EXPECT().
-		WriteMessage(websocket.PingMessage, gomock.Any()).
+		WriteJSON(gomock.Any()).
 		Return(nil).
 		AnyTimes()
 
@@ -479,7 +479,7 @@ func TestClient_RetryableConnect_FailsThenSucceeds(t *testing.T) {
 
 	// Expect conn to send ping
 	ts.mockConn.EXPECT().
-		WriteMessage(websocket.PingMessage, gomock.Any()).
+		WriteJSON(gomock.Any()).
 		Return(nil).
 		AnyTimes()
 
@@ -686,7 +686,7 @@ func TestClient_RetryableConnect_UnknownError_RetryLimitNotExceeded(t *testing.T
 
 	// Expect conn to send ping
 	ts.mockConn.EXPECT().
-		WriteMessage(websocket.PingMessage, gomock.Any()).
+		WriteJSON(gomock.Any()).
 		Return(nil).
 		AnyTimes()
 
@@ -750,7 +750,7 @@ func TestClient_SendMessage_Success(t *testing.T) {
 
 	// Expect conn to write ping
 	ts.mockConn.EXPECT().
-		WriteMessage(websocket.PingMessage, gomock.Any()).
+		WriteJSON(gomock.Any()).
 		Return(nil).
 		AnyTimes()
 
@@ -845,7 +845,7 @@ func TestClient_Close_Success(t *testing.T) {
 
 	// Expect conn to write ping
 	ts.mockConn.EXPECT().
-		WriteMessage(websocket.PingMessage, gomock.Any()).
+		WriteJSON(gomock.Any()).
 		Return(nil).
 		AnyTimes()
 
@@ -914,7 +914,7 @@ func TestClient_Close_Error(t *testing.T) {
 
 	// Expect conn to write ping
 	ts.mockConn.EXPECT().
-		WriteMessage(websocket.PingMessage, gomock.Any()).
+		WriteJSON(gomock.Any()).
 		Return(nil).
 		AnyTimes()
 
@@ -1128,7 +1128,7 @@ func TestClient_ReceiveMessage_Success(t *testing.T) {
 
 	// Expect conn to write ping
 	ts.mockConn.EXPECT().
-		WriteMessage(websocket.PingMessage, gomock.Any()).
+		WriteJSON(gomock.Any()).
 		Return(nil).
 		AnyTimes()
 
@@ -1218,7 +1218,7 @@ func TestClient_ReceiveMessage_Error(t *testing.T) {
 
 	// Expect conn to write ping
 	ts.mockConn.EXPECT().
-		WriteMessage(websocket.PingMessage, gomock.Any()).
+		WriteJSON(gomock.Any()).
 		Return(nil).
 		AnyTimes()
 
@@ -1262,7 +1262,7 @@ func TestClient_ReceiveMessage_Error(t *testing.T) {
 
 	// Expect second conn to write ping
 	mockConn2.EXPECT().
-		WriteMessage(websocket.PingMessage, gomock.Any()).
+		WriteJSON(gomock.Any()).
 		Return(nil).
 		AnyTimes()
 
@@ -1346,7 +1346,7 @@ func TestClient_ReadMessage_ErrorAfterClose_DoesNotReconnect(t *testing.T) {
 		Times(1)
 
 	ts.mockConn.EXPECT().
-		WriteMessage(websocket.PingMessage, gomock.Any()).
+		WriteJSON(gomock.Any()).
 		Return(nil).
 		AnyTimes()
 
@@ -1429,8 +1429,8 @@ func TestClient_Ping_Success(t *testing.T) {
 	pingCalled := make(chan struct{})
 	once := sync.Once{}
 	ts.mockConn.EXPECT().
-		WriteMessage(websocket.PingMessage, []byte("ping")).
-		DoAndReturn(func(messageType int, data []byte) error {
+		WriteJSON(map[string]string{"type": "ping"}).
+		DoAndReturn(func(_ interface{}) error {
 			once.Do(func() {
 				close(pingCalled)
 			})
@@ -1507,8 +1507,8 @@ func TestClient_Ping_Error(t *testing.T) {
 	pingCalled := make(chan struct{})
 	once := sync.Once{}
 	ts.mockConn.EXPECT().
-		WriteMessage(websocket.PingMessage, gomock.Any()).
-		DoAndReturn(func(messageType int, data []byte) error {
+		WriteJSON(gomock.Any()).
+		DoAndReturn(func(_ interface{}) error {
 			once.Do(func() {
 				close(pingCalled)
 			})
@@ -1584,8 +1584,8 @@ func TestClient_Ping_ContextCanceled(t *testing.T) {
 	pingAfterCancel := make(chan struct{})
 
 	ts.mockConn.EXPECT().
-		WriteMessage(websocket.PingMessage, []byte("ping")).
-		DoAndReturn(func(messageType int, data []byte) error {
+		WriteJSON(map[string]string{"type": "ping"}).
+		DoAndReturn(func(_ interface{}) error {
 			count := atomic.AddInt32(&pingCallCount, 1)
 			if count == 1 {
 				close(firstPingCalled)
@@ -1680,7 +1680,7 @@ func TestClient_ReadMessage_PermanentError_ExitsProgram(t *testing.T) {
 
 	// Expect conn to write ping
 	ts.mockConn.EXPECT().
-		WriteMessage(websocket.PingMessage, gomock.Any()).
+		WriteJSON(gomock.Any()).
 		Return(nil).
 		AnyTimes()
 

--- a/components/feral-controld/relayer/relayer_test.go
+++ b/components/feral-controld/relayer/relayer_test.go
@@ -57,6 +57,13 @@ func setup(t *testing.T) *testSetup {
 	mockOS := mocks.NewMockOS(ctrl)
 	mockJSON := mocks.NewMockJSON(ctrl)
 
+	// Transport pings are part of the rollout-compatible keepalive path, so
+	// most relayer tests can accept them without caring about the exact timing.
+	mockConn.EXPECT().
+		WriteControl(websocket.PingMessage, nil, gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
 	client := relayer.New("ws://localhost:8080", "test-api-key", mockDialer, mockRandomizer, mockClock, mockOS, mockJSON, logger)
 
 	return &testSetup{
@@ -1429,6 +1436,11 @@ func TestClient_Ping_Success(t *testing.T) {
 	pingCalled := make(chan struct{})
 	once := sync.Once{}
 	ts.mockConn.EXPECT().
+		WriteControl(websocket.PingMessage, nil, gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	ts.mockConn.EXPECT().
 		WriteJSON(map[string]string{"type": "ping"}).
 		DoAndReturn(func(_ interface{}) error {
 			once.Do(func() {
@@ -1498,6 +1510,11 @@ func TestClient_ApplicationPong_RefreshesDeadlineWithoutDispatchingHandlers(t *t
 	ts.mockConn.EXPECT().
 		SetPongHandler(gomock.Any()).
 		Times(1)
+
+	ts.mockConn.EXPECT().
+		WriteControl(websocket.PingMessage, nil, gomock.Any()).
+		Return(nil).
+		AnyTimes()
 
 	ts.mockConn.EXPECT().
 		WriteJSON(map[string]string{"type": "ping"}).
@@ -1596,6 +1613,13 @@ func TestClient_Ping_Error(t *testing.T) {
 		SetPongHandler(gomock.Any()).
 		Times(1)
 
+	// Expect the transport keepalive deadline to be refreshed before the
+	// application ping write fails.
+	ts.mockConn.EXPECT().
+		SetReadDeadline(time.Time{}.Add(relayer.PONG_WAIT)).
+		Return(nil).
+		AnyTimes()
+
 	// Expect conn to write ping
 	pingCalled := make(chan struct{})
 	once := sync.Once{}
@@ -1675,6 +1699,11 @@ func TestClient_Ping_ContextCanceled(t *testing.T) {
 	var pingCallCount int32
 	firstPingCalled := make(chan struct{})
 	pingAfterCancel := make(chan struct{})
+
+	ts.mockConn.EXPECT().
+		WriteControl(websocket.PingMessage, nil, gomock.Any()).
+		Return(nil).
+		AnyTimes()
 
 	ts.mockConn.EXPECT().
 		WriteJSON(map[string]string{"type": "ping"}).

--- a/components/feral-controld/relayer/relayer_test.go
+++ b/components/feral-controld/relayer/relayer_test.go
@@ -1519,7 +1519,7 @@ func TestClient_ApplicationPong_RefreshesDeadlineWithoutDispatchingHandlers(t *t
 		AnyTimes()
 
 	pongBytes, err := json.Marshal(map[string]string{"type": "pong"})
-	assert.NoError(t, err, "expected no error marshalling pong payload")
+	assert.NoError(t, err, "expected no error marshaling pong payload")
 
 	releaseRead := make(chan struct{})
 	var readCount int32

--- a/components/feral-controld/relayer/relayer_test.go
+++ b/components/feral-controld/relayer/relayer_test.go
@@ -1480,6 +1480,99 @@ func TestClient_Ping_Success(t *testing.T) {
 	assert.False(t, ts.client.IsConnected(), "expected client to be disconnected after close")
 }
 
+func TestClient_ApplicationPong_RefreshesDeadlineWithoutDispatchingHandlers(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	setupMockTicker(ts)
+
+	ts.mockClock.EXPECT().
+		Now().
+		Return(time.Time{}).
+		AnyTimes()
+
+	ts.mockDialer.EXPECT().
+		DialContext(ts.ctx, gomock.Any(), nil).
+		Return(ts.mockConn, &http.Response{StatusCode: http.StatusOK}, nil)
+
+	ts.mockConn.EXPECT().
+		SetPongHandler(gomock.Any()).
+		Times(1)
+
+	ts.mockConn.EXPECT().
+		WriteJSON(map[string]string{"type": "ping"}).
+		Return(nil).
+		AnyTimes()
+
+	pongDeadlineCleared := make(chan struct{}, 1)
+	ts.mockConn.EXPECT().
+		SetReadDeadline(gomock.Any()).
+		DoAndReturn(func(deadline time.Time) error {
+			if deadline.IsZero() {
+				select {
+				case pongDeadlineCleared <- struct{}{}:
+				default:
+				}
+			}
+			return nil
+		}).
+		AnyTimes()
+
+	pongBytes, err := json.Marshal(map[string]string{"type": "pong"})
+	assert.NoError(t, err, "expected no error marshalling pong payload")
+
+	releaseRead := make(chan struct{})
+	var readCount int32
+	ts.mockConn.EXPECT().
+		ReadMessage().
+		DoAndReturn(func() (int, []byte, error) {
+			count := atomic.AddInt32(&readCount, 1)
+			if count == 1 {
+				return websocket.TextMessage, pongBytes, nil
+			}
+
+			<-releaseRead
+			return 0, nil, errors.New("test read stop")
+		}).
+		AnyTimes()
+
+	ts.mockConn.EXPECT().
+		WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	ts.mockConn.EXPECT().
+		Close().
+		Return(nil).
+		AnyTimes()
+
+	handlerCalled := make(chan struct{}, 1)
+	ts.client.OnRelayerMessage(func(ctx context.Context, payload relayer.Payload) error {
+		handlerCalled <- struct{}{}
+		return nil
+	})
+
+	err = ts.client.Connect(ts.ctx)
+	assert.NoError(t, err, "expected no error, got %v", err)
+	assert.True(t, ts.client.IsConnected(), "expected client to be connected")
+
+	select {
+	case <-pongDeadlineCleared:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("application pong should clear the read deadline")
+	}
+
+	select {
+	case <-handlerCalled:
+		t.Fatal("application pong should not be dispatched to relayer handlers")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	ts.client.Close()
+	close(releaseRead)
+	assert.False(t, ts.client.IsConnected(), "expected client to be disconnected after close")
+}
+
 func TestClient_Ping_Error(t *testing.T) {
 	ts := setup(t)
 	defer ts.teardown()

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -103,9 +103,9 @@ All messages are JSON. The message envelope is:
 ```
 
 **Relayer keepalive control messages:**
-- `controld` sends `{"type":"ping"}` on the relayer WebSocket to keep the connection alive.
-- The relayer should reply with `{"type":"pong"}` once the new keepalive path is deployed.
-- During rollout, transport-level WebSocket pong frames remain accepted so older relayer builds do not time out before the protocol upgrade lands.
+- `controld` sends both a transport-level WebSocket `Ping` frame and an application-level `{"type":"ping"}` message on the relayer WebSocket.
+- The relayer should reply to the transport ping with a WebSocket `Pong` frame and to the application ping with `{"type":"pong"}` once the new keepalive path is deployed.
+- During rollout, either pong path may keep the connection alive so older relayer builds do not time out before the protocol upgrade lands.
 - `pong` is handled internally by `relayer` and is not dispatched to `commandrouter` or command handlers.
 
 **Command routing logic (inside controld):**

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -102,6 +102,12 @@ All messages are JSON. The message envelope is:
 }
 ```
 
+**Relayer keepalive control messages:**
+- `controld` sends `{"type":"ping"}` on the relayer WebSocket to keep the connection alive.
+- The relayer should reply with `{"type":"pong"}` once the new keepalive path is deployed.
+- During rollout, transport-level WebSocket pong frames remain accepted so older relayer builds do not time out before the protocol upgrade lands.
+- `pong` is handled internally by `relayer` and is not dispatched to `commandrouter` or command handlers.
+
 **Command routing logic (inside controld):**
 - If `Command.DeviceCtlCommand()` returns true → route to the device executor (`devicectl`).
 - Otherwise → route to Chromium via CDP (`Runtime.evaluate`).


### PR DESCRIPTION
### What does this PR do?

Switches controld relayer keepalive from transport-level websocket ping frames to application-level JSON `ping` messages so the relayer Durable Object can observe liveness and reply with `pong`.

### API changes (if available)

- relayer client now sends `{ "type": "ping" }` on the `/api/connection` websocket
- expects `{ "type": "pong" }` in response

### How to test

- `cd components/feral-controld && go test ./...`

### Additional notes

- This pairs with the relayer-side PR that adds `ping`/`pong` support.
- Transport websocket ping/pong remains available at the protocol layer, but relayer liveness now depends on the application message.
