### PR TITLE
feat(setupd): version-check TV progress and classified errors

### DIFF
--- a/components/feral-setupd/AGENTS.md
+++ b/components/feral-setupd/AGENTS.md
@@ -109,6 +109,14 @@ with an error.
 Runs/monitors the updater systemd unit, tails the updater log file, extracts
 progress/messages via regex, and streams progress/error lines back to callers.
 
+Distributor version metadata (`/api/latest/...`) is fetched with bounded retries;
+failures are classified (network vs HTTP class vs parse) for TV copy, and
+`check_and_update_system` can attach a progress channel so the launcher shows
+a short “checking for updates” line while those HTTP retries run.
+Only `refresh_remote_version`, `is_too_old_to_upgrade`, `is_update_required`, and
+`is_update_available` accept that channel; helpers like `latest_version` read
+metadata without driving the progress UI.
+
 Two enums control update behaviour:
 
 - `UpdateMode::Required` — check only against the distributor's minimum

--- a/components/feral-setupd/src/constant.rs
+++ b/components/feral-setupd/src/constant.rs
@@ -22,7 +22,20 @@ pub const UPDATER_PROCESS_LOG_FILE: &str = "/var/log/updaterd.log";
 pub const UPDATER_VERSION_CHECK_RETRIES: u32 = 3;
 pub const UPDATER_VERSION_CHECK_RETRY_DELAY: u64 = 2 * 1000; // 2 seconds between retries
 pub const UPDATER_REMOTE_VERSION_REFRESH_INTERVAL: u64 = 60 * 60 * 1000; // 1 hour
-pub const UPDATER_FAILED_TO_CHECK_VERSION_MSG: &str = "FF1 needs to check for critical updates before playing art. If your network is stable and this persists, contact support@feralfile.com - your device may need hands-on help.";
+
+/// Shown on the TV between HTTP retry attempts while checking for updates.
+pub const VERSION_CHECK_PROGRESS_TV_MSG: &str = "Checking for updates...";
+
+/// Unclassified distributor/config failures; keep umbrella guidance for odd edge cases.
+pub const VERSION_CHECK_FAILED_UNKNOWN_MSG: &str = "FF1 needs to check for critical updates before playing art. If your network is stable and this persists, contact support@feralfile.com - your device may need hands-on help.";
+
+pub const VERSION_CHECK_FAILED_NETWORK_MSG: &str = "We could not reach the update server. Your Wi-Fi may be unstable—move closer to the router, wait a moment, then try again from the app.";
+
+pub const VERSION_CHECK_FAILED_SERVER_MSG: &str = "The update service is temporarily unavailable. Please wait a few minutes and try again from the app.";
+
+pub const VERSION_CHECK_FAILED_CLIENT_MSG: &str = "The update server rejected this request (configuration issue). If this keeps happening, contact support@feralfile.com.";
+
+pub const VERSION_CHECK_FAILED_PARSE_MSG: &str = "We received an unexpected response from the update server. Please try again later or contact support@feralfile.com.";
 
 // Bluetooth configuration
 pub const SERVICE_UUID: Uuid = Uuid::from_u128(0xf7826da64fa24e988024bc5b71e0893e_u128);

--- a/components/feral-setupd/src/main.rs
+++ b/components/feral-setupd/src/main.rs
@@ -24,7 +24,7 @@ use std::time::Instant;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::signal::unix::{SignalKind, signal as unix_signal};
 use tokio::{
-    sync::Mutex,
+    sync::{Mutex, mpsc},
     task,
     time::{self, Duration},
 };
@@ -1031,7 +1031,10 @@ async fn on_startup_with_internet(app_state: Arc<AppState>, chrome: Arc<Cdp>) ->
 }
 
 async fn update(app_state: Arc<AppState>, chrome: Arc<Cdp>) -> Result<()> {
-    let latest_version = updater::latest_version().await.unwrap_or_default();
+    let latest_version = updater::latest_version().await.unwrap_or_else(|e| {
+        eprintln!("MAIN: latest_version for update banner: {e:#?}");
+        "Unknown".to_string()
+    });
     let base_msg = format!("{} {}", &constant::UPDATING_MSG_PREFIX, latest_version);
     let default_subtext = constant::UPDATING_MSG_SUBTEXT;
     let _ = show_system_upgrade(
@@ -1094,20 +1097,48 @@ async fn check_and_update_system(
     mode: UpdateMode,
     execution: UpdateExecution,
 ) -> Result<UpdateCheckResult> {
+    // TV progress while HTTP retries run inside `fetch_remote_version` (sender dropped before
+    // the final classified failure copy so the last screen is stable).
+    let (prog_tx, prog_rx) = mpsc::channel::<(u32, u32)>(16);
+    let progress_task = {
+        let chrome = chrome.clone();
+        let app_state = app_state.clone();
+        tokio::spawn(async move {
+            while let Some((_attempt, _max)) = prog_rx.recv().await {
+                if let Err(e) =
+                    show_message(&chrome, &app_state, constant::VERSION_CHECK_PROGRESS_TV_MSG).await
+                {
+                    eprintln!("MAIN: version-check progress UI failed: {e:#?}");
+                }
+            }
+        })
+    };
+
     // Always fetch the remote version first to ensure we have the latest info
-    updater::refresh_remote_version().await;
+    updater::refresh_remote_version(Some(prog_tx.clone())).await;
     // First check if device is too old to auto-upgrade
-    match updater::is_too_old_to_upgrade().await {
+    match updater::is_too_old_to_upgrade(Some(prog_tx.clone())).await {
         Ok(true) => {
+            // Finish progress UI before reflashing screens; otherwise queued progress
+            // navigations can overwrite the QR/message we are about to show.
+            drop(prog_tx);
+            if let Err(join_err) = progress_task.await {
+                eprintln!("MAIN: version-check progress task ended with: {join_err:#?}");
+            }
+
             // Device is too old, show reflashing QR code
             if let Ok(Some(flashing_guide)) = updater::flashing_guide_url().await {
                 let current_version = app_state.current_version.clone();
-                let latest_version = updater::latest_version()
-                    .await
-                    .unwrap_or_else(|_| "Unknown".to_string());
+                let latest_version = updater::latest_version().await.unwrap_or_else(|e| {
+                    eprintln!("MAIN: latest_version for reflashing banner: {e:#?}");
+                    "Unknown".to_string()
+                });
                 let min_upgradeable = updater::min_upgradeable_version()
                     .await
-                    .unwrap_or(None)
+                    .unwrap_or_else(|e| {
+                        eprintln!("MAIN: min_upgradeable_version for reflashing banner: {e:#?}");
+                        None
+                    })
                     .unwrap_or_else(|| "Unknown".to_string());
 
                 match execution {
@@ -1173,9 +1204,14 @@ async fn check_and_update_system(
 
     // Check if update is needed based on mode
     let needs_update = match mode {
-        UpdateMode::Required => updater::is_update_required().await,
-        UpdateMode::Available => updater::is_update_available().await,
+        UpdateMode::Required => updater::is_update_required(Some(prog_tx.clone())).await,
+        UpdateMode::Available => updater::is_update_available(Some(prog_tx.clone())).await,
     };
+
+    drop(prog_tx);
+    if let Err(join_err) = progress_task.await {
+        eprintln!("MAIN: version-check progress task ended with: {join_err:#?}");
+    }
 
     match needs_update {
         Ok(true) => {
@@ -1195,28 +1231,20 @@ async fn check_and_update_system(
             }
             Ok(UpdateCheckResult::NoUpdateNeeded)
         }
-        Err(e) => {
-            eprintln!("MAIN: Error checking for update: {e:#?}");
+        Err(ve) => {
+            eprintln!("MAIN: Error checking for update: {ve:#?}");
+            let tv_msg = ve.kind().tv_message();
             match execution {
                 UpdateExecution::Blocking => {
-                    show_message(
-                        chrome,
-                        app_state,
-                        constant::UPDATER_FAILED_TO_CHECK_VERSION_MSG,
-                    )
-                    .await?;
+                    show_message(chrome, app_state, tv_msg).await?;
                 }
                 UpdateExecution::NonBlocking => {
+                    let tv_msg = tv_msg.to_string();
                     task::spawn({
                         let app_state = app_state.clone();
                         let chrome = chrome.clone();
                         async move {
-                            let _ = show_message(
-                                &chrome,
-                                &app_state,
-                                constant::UPDATER_FAILED_TO_CHECK_VERSION_MSG,
-                            )
-                            .await;
+                            let _ = show_message(&chrome, &app_state, &tv_msg).await;
                         }
                     });
                 }
@@ -1252,7 +1280,8 @@ async fn show_webapp(app_state: &Arc<AppState>, chrome: &Arc<Cdp>) -> Result<()>
 }
 
 async fn show_message(chrome: &Arc<Cdp>, app_state: &Arc<AppState>, message: &str) -> Result<()> {
-    let message_url = format!("{}{}", constant::MSG_URL_PREFIX, message);
+    let encoded = urlencoding::encode(message);
+    let message_url = format!("{}{}", constant::MSG_URL_PREFIX, encoded);
     chrome
         .navigate(&message_url)
         .await

--- a/components/feral-setupd/src/updater.rs
+++ b/components/feral-setupd/src/updater.rs
@@ -472,3 +472,73 @@ async fn fetch_remote_version_once(url: &str) -> Result<UpstreamVersion> {
 
     Ok(versions)
 }
+
+#[cfg(test)]
+mod classify_version_fetch_error_tests {
+    use super::{classify_version_fetch_error, VersionFetchFailureKind};
+    use anyhow::Context;
+
+    #[test]
+    fn http_status_line_5xx_is_server() {
+        let e = anyhow::anyhow!(
+            "HTTP 503 Service Unavailable from distributor at https://example.invalid: body"
+        );
+        assert_eq!(
+            classify_version_fetch_error(&e),
+            VersionFetchFailureKind::Server
+        );
+    }
+
+    #[test]
+    fn http_status_line_4xx_is_client() {
+        let e = anyhow::anyhow!(
+            "HTTP 404 Not Found from distributor at https://example.invalid: body"
+        );
+        assert_eq!(
+            classify_version_fetch_error(&e),
+            VersionFetchFailureKind::Client
+        );
+    }
+
+    #[test]
+    fn decoding_distributor_json_context_is_parse() {
+        let e = Err::<(), _>(anyhow::anyhow!("invalid JSON"))
+            .context("decoding distributor JSON")
+            .unwrap_err();
+        assert_eq!(
+            classify_version_fetch_error(&e),
+            VersionFetchFailureKind::Parse
+        );
+    }
+
+    #[test]
+    fn parsing_upstream_semver_context_is_parse() {
+        let e = Err::<(), _>(anyhow::anyhow!("not a semver"))
+            .context("parsing upstream semver")
+            .unwrap_err();
+        assert_eq!(
+            classify_version_fetch_error(&e),
+            VersionFetchFailureKind::Parse
+        );
+    }
+
+    #[test]
+    fn parsing_min_upgradeable_semver_context_is_parse() {
+        let e = Err::<(), _>(anyhow::anyhow!("bad"))
+            .context("parsing min_upgradeable_version semver")
+            .unwrap_err();
+        assert_eq!(
+            classify_version_fetch_error(&e),
+            VersionFetchFailureKind::Parse
+        );
+    }
+
+    #[test]
+    fn unrelated_message_is_unknown() {
+        let e = anyhow::anyhow!("something else entirely");
+        assert_eq!(
+            classify_version_fetch_error(&e),
+            VersionFetchFailureKind::Unknown
+        );
+    }
+}

--- a/components/feral-setupd/src/updater.rs
+++ b/components/feral-setupd/src/updater.rs
@@ -5,6 +5,7 @@ use rand::Rng;
 use regex::Regex;
 use semver::Version;
 use serde::Deserialize;
+use std::fmt;
 use std::{process::Stdio, sync::RwLock, time::Duration};
 use tokio::{
     fs,
@@ -19,11 +20,116 @@ use tokio::{
 // ---------- Cache ----------
 static REMOTE_VERSIONS: RwLock<Option<UpstreamVersion>> = RwLock::new(None);
 
+// ---------- Version fetch errors / progress ----------
+
+/// Notifies `(current_attempt, max_attempts)` **before** each HTTP attempt (1-based),
+/// so setup UI can refresh a generic “checking for updates” line while `fetch_remote_version` retries.
+pub type FetchProgressTx = mpsc::Sender<(u32, u32)>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VersionFetchFailureKind {
+    Network,
+    Server,
+    Client,
+    Parse,
+    Unknown,
+}
+
+impl VersionFetchFailureKind {
+    #[must_use]
+    pub fn tv_message(self) -> &'static str {
+        match self {
+            Self::Network => constant::VERSION_CHECK_FAILED_NETWORK_MSG,
+            Self::Server => constant::VERSION_CHECK_FAILED_SERVER_MSG,
+            Self::Client => constant::VERSION_CHECK_FAILED_CLIENT_MSG,
+            Self::Parse => constant::VERSION_CHECK_FAILED_PARSE_MSG,
+            Self::Unknown => constant::VERSION_CHECK_FAILED_UNKNOWN_MSG,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct VersionFetchError {
+    kind: VersionFetchFailureKind,
+    source: anyhow::Error,
+}
+
+impl VersionFetchError {
+    pub fn new(kind: VersionFetchFailureKind, source: anyhow::Error) -> Self {
+        Self { kind, source }
+    }
+
+    #[must_use]
+    pub fn kind(&self) -> VersionFetchFailureKind {
+        self.kind
+    }
+}
+
+impl fmt::Display for VersionFetchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}: {}", self.kind, self.source)
+    }
+}
+
+impl std::error::Error for VersionFetchError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.source.as_ref())
+    }
+}
+
+fn classify_version_fetch_error(err: &anyhow::Error) -> VersionFetchFailureKind {
+    let full = err.to_string();
+    const HTTP_PREFIX: &str = "HTTP ";
+    if full.starts_with(HTTP_PREFIX) {
+        if let Some(rest) = full.strip_prefix(HTTP_PREFIX) {
+            if let Some(c) = rest.chars().next() {
+                if c == '4' {
+                    return VersionFetchFailureKind::Client;
+                }
+                if c == '5' {
+                    return VersionFetchFailureKind::Server;
+                }
+            }
+        }
+    }
+
+    for cause in err.chain() {
+        if let Some(re) = cause.downcast_ref::<reqwest::Error>() {
+            if re.is_decode() {
+                return VersionFetchFailureKind::Parse;
+            }
+            if let Some(status) = re.status() {
+                if status.is_server_error() {
+                    return VersionFetchFailureKind::Server;
+                }
+                if status.is_client_error() {
+                    return VersionFetchFailureKind::Client;
+                }
+            }
+            if re.is_timeout() || re.is_connect() {
+                return VersionFetchFailureKind::Network;
+            }
+        }
+    }
+
+    if full.contains("decoding distributor JSON")
+        || full.contains("parsing upstream semver")
+        || full.contains("parsing min_upgradeable_version semver")
+    {
+        return VersionFetchFailureKind::Parse;
+    }
+
+    VersionFetchFailureKind::Unknown
+}
+
 // ---------- Public API ----------
 
 /// Force refresh the cached remote version information.
-pub async fn refresh_remote_version() {
-    let _ = fetch_remote_version(true).await;
+///
+/// `progress` is used during setup to drive TV copy between HTTP attempts; periodic
+/// refresh passes `None` so we never spam the UI from the background task.
+pub async fn refresh_remote_version(progress: Option<FetchProgressTx>) {
+    let _ = fetch_remote_version(true, progress).await;
 }
 
 /// Spawn a background task that periodically refreshes the cached remote version.
@@ -34,37 +140,49 @@ pub fn spawn_remote_version_refresher() {
         loop {
             time::sleep(interval).await;
             println!("UPDATER: Periodic remote version refresh triggered");
-            refresh_remote_version().await;
+            refresh_remote_version(None).await;
         }
     });
 }
 
 /// Return `Ok(true)` when the running build is **below** the distributor's
 /// minimum supported version and an update is therefore required.
-pub async fn is_update_required() -> Result<bool> {
-    let current = cfg::current_version().await?;
-    let remote_versions = fetch_remote_version(false).await?;
+pub async fn is_update_required(
+    progress: Option<FetchProgressTx>,
+) -> std::result::Result<bool, VersionFetchError> {
+    let current = cfg::current_version()
+        .await
+        .map_err(|e| VersionFetchError::new(VersionFetchFailureKind::Unknown, e.into()))?;
+    let remote_versions = fetch_remote_version(false, progress).await?;
     Ok(current < remote_versions.min_runtime_version)
 }
 
 /// Return `Ok(true)` when a newer version is available from the distributor.
-pub async fn is_update_available() -> Result<bool> {
-    let current = cfg::current_version().await?;
-    let remote_versions = fetch_remote_version(false).await?;
+pub async fn is_update_available(
+    progress: Option<FetchProgressTx>,
+) -> std::result::Result<bool, VersionFetchError> {
+    let current = cfg::current_version()
+        .await
+        .map_err(|e| VersionFetchError::new(VersionFetchFailureKind::Unknown, e.into()))?;
+    let remote_versions = fetch_remote_version(false, progress).await?;
     Ok(current < remote_versions.latest_version)
 }
 
 /// Return the latest version from the remote server.
-pub async fn latest_version() -> Result<String> {
-    let remote_versions = fetch_remote_version(false).await?;
+pub async fn latest_version() -> std::result::Result<String, VersionFetchError> {
+    let remote_versions = fetch_remote_version(false, None).await?;
     Ok(remote_versions.latest_version.to_string())
 }
 
 /// Return `Ok(true)` when the running build is **below** the distributor's
 /// minimum upgradeable version, meaning the device needs to be reflashed.
-pub async fn is_too_old_to_upgrade() -> Result<bool> {
-    let current = cfg::current_version().await?;
-    let remote_versions = fetch_remote_version(false).await?;
+pub async fn is_too_old_to_upgrade(
+    progress: Option<FetchProgressTx>,
+) -> std::result::Result<bool, VersionFetchError> {
+    let current = cfg::current_version()
+        .await
+        .map_err(|e| VersionFetchError::new(VersionFetchFailureKind::Unknown, e.into()))?;
+    let remote_versions = fetch_remote_version(false, progress).await?;
 
     if let Some(min_upgradeable) = &remote_versions.min_upgradeable_version {
         Ok(current < *min_upgradeable)
@@ -74,14 +192,14 @@ pub async fn is_too_old_to_upgrade() -> Result<bool> {
 }
 
 /// Return the flashing guide URL from the remote server, if available.
-pub async fn flashing_guide_url() -> Result<Option<String>> {
-    let remote_versions = fetch_remote_version(false).await?;
+pub async fn flashing_guide_url() -> std::result::Result<Option<String>, VersionFetchError> {
+    let remote_versions = fetch_remote_version(false, None).await?;
     Ok(remote_versions.flashing_guide.clone())
 }
 
 /// Return the minimum upgradeable version from the remote server, if available.
-pub async fn min_upgradeable_version() -> Result<Option<String>> {
-    let remote_versions = fetch_remote_version(false).await?;
+pub async fn min_upgradeable_version() -> std::result::Result<Option<String>, VersionFetchError> {
+    let remote_versions = fetch_remote_version(false, None).await?;
     Ok(remote_versions
         .min_upgradeable_version
         .as_ref()
@@ -248,7 +366,10 @@ struct UpstreamVersion {
     latest_version: Version,
 }
 
-async fn fetch_remote_version(refresh: bool) -> Result<UpstreamVersion> {
+async fn fetch_remote_version(
+    refresh: bool,
+    progress: Option<FetchProgressTx>,
+) -> std::result::Result<UpstreamVersion, VersionFetchError> {
     // Check if we have a cached version
     if !refresh {
         let cache = REMOTE_VERSIONS.read().unwrap();
@@ -257,19 +378,34 @@ async fn fetch_remote_version(refresh: bool) -> Result<UpstreamVersion> {
         }
     }
 
+    let endpoint = cfg::endpoint()
+        .await
+        .map_err(|e| VersionFetchError::new(VersionFetchFailureKind::Unknown, e.into()))?;
+    let branch = cfg::branch()
+        .await
+        .map_err(|e| VersionFetchError::new(VersionFetchFailureKind::Unknown, e.into()))?;
     let url = format!(
         "{}{}{}",
-        cfg::endpoint().await?,
+        endpoint,
         constant::UPDATER_UPSTREAM_CONFIG_URL_SUFFIX,
-        cfg::branch().await?
+        branch
     );
 
     // Retry logic: attempt up to UPDATER_VERSION_CHECK_RETRIES times
     let max_retries = constant::UPDATER_VERSION_CHECK_RETRIES;
     let retry_delay = Duration::from_millis(constant::UPDATER_VERSION_CHECK_RETRY_DELAY);
-    let mut last_error: Option<anyhow::Error> = None;
+    let mut last_error: Option<VersionFetchError> = None;
 
     for attempt in 1..=max_retries {
+        if let Some(tx) = &progress {
+            if tx.send((attempt, max_retries)).await.is_err() {
+                // Receiver dropped (setup finished); keep fetching without UI updates.
+                eprintln!(
+                    "UPDATER: progress channel closed; continuing version fetch without TV updates"
+                );
+            }
+        }
+
         println!("UPDATER: Fetching version info from {url} (attempt {attempt}/{max_retries})");
 
         match fetch_remote_version_once(&url).await {
@@ -283,7 +419,8 @@ async fn fetch_remote_version(refresh: bool) -> Result<UpstreamVersion> {
             }
             Err(e) => {
                 eprintln!("UPDATER: Version check attempt {attempt}/{max_retries} failed: {e:#}");
-                last_error = Some(e);
+                let kind = classify_version_fetch_error(&e);
+                last_error = Some(VersionFetchError::new(kind, e));
 
                 // Don't sleep after the last attempt
                 if attempt < max_retries {
@@ -293,8 +430,12 @@ async fn fetch_remote_version(refresh: bool) -> Result<UpstreamVersion> {
         }
     }
 
-    Err(last_error
-        .unwrap_or_else(|| anyhow::anyhow!("Version check failed after {max_retries} attempts")))
+    Err(last_error.unwrap_or_else(|| {
+        VersionFetchError::new(
+            VersionFetchFailureKind::Unknown,
+            anyhow::anyhow!("Version check failed after {max_retries} attempts"),
+        )
+    }))
 }
 
 /// Single attempt to fetch remote version (no retry logic).

--- a/components/feral-setupd/src/updater.rs
+++ b/components/feral-setupd/src/updater.rs
@@ -475,7 +475,7 @@ async fn fetch_remote_version_once(url: &str) -> Result<UpstreamVersion> {
 
 #[cfg(test)]
 mod classify_version_fetch_error_tests {
-    use super::{classify_version_fetch_error, VersionFetchFailureKind};
+    use super::{VersionFetchFailureKind, classify_version_fetch_error};
     use anyhow::Context;
 
     #[test]
@@ -491,9 +491,8 @@ mod classify_version_fetch_error_tests {
 
     #[test]
     fn http_status_line_4xx_is_client() {
-        let e = anyhow::anyhow!(
-            "HTTP 404 Not Found from distributor at https://example.invalid: body"
-        );
+        let e =
+            anyhow::anyhow!("HTTP 404 Not Found from distributor at https://example.invalid: body");
         assert_eq!(
             classify_version_fetch_error(&e),
             VersionFetchFailureKind::Client

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -253,7 +253,7 @@ The mobile app expects a BLE notification within a reasonable time after a write
 
 `feral-setupd` retries the remote version check up to `UPDATER_VERSION_CHECK_RETRIES` (3) times with a 2-second delay between retries before treating the check as failed.
 
-During `check_and_update_system`, each HTTP fetch attempt notifies a small progress channel so setup can navigate the TV to a short “checking for updates” line before the request runs. After retries are exhausted, the TV message is chosen from a coarse failure class (network vs HTTP 5xx vs HTTP 4xx vs parse/unexpected body vs unknown); BLE status code `6` (`BLE_ERR_CODE_VERSION_CHECK_FAILED`) is unchanged.
+During `check_and_update_system`, each HTTP fetch attempt notifies a small progress channel so setup can navigate the TV to a short “checking for updates” line before the request runs. When the subsequent required/available version comparison fails after those retries (the `is_update_required` / `is_update_available` error path), the TV message is chosen from a coarse failure class (network vs HTTP 5xx vs HTTP 4xx vs parse/unexpected body vs unknown); other branches may log and continue without that classified copy. BLE status code `6` (`BLE_ERR_CODE_VERSION_CHECK_FAILED`) is unchanged.
 
 ---
 

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -253,6 +253,8 @@ The mobile app expects a BLE notification within a reasonable time after a write
 
 `feral-setupd` retries the remote version check up to `UPDATER_VERSION_CHECK_RETRIES` (3) times with a 2-second delay between retries before treating the check as failed.
 
+During `check_and_update_system`, each HTTP fetch attempt notifies a small progress channel so setup can navigate the TV to a short “checking for updates” line before the request runs. After retries are exhausted, the TV message is chosen from a coarse failure class (network vs HTTP 5xx vs HTTP 4xx vs parse/unexpected body vs unknown); BLE status code `6` (`BLE_ERR_CODE_VERSION_CHECK_FAILED`) is unchanged.
+
 ---
 
 ## Protocol Invariants Agents Must Not Break


### PR DESCRIPTION
## Summary
- Show a short “checking for updates” line on the TV while distributor version metadata is fetched with HTTP retries during `check_and_update_system`, using an optional progress channel from `updater` (periodic refresh still passes `None` so background work does not touch the UI).
- Classify version-fetch failures (network, server, client, parse, unknown) and map them to dedicated TV copy; introduce `VersionFetchError` / `VersionFetchFailureKind` and URL-encode `show_message` query payloads.
- Document the behavior in `AGENTS.md` and `docs/api-design.md`, and add unit tests for `classify_version_fetch_error`.

## Test plan
- [ ] `make verify-setupd` (or equivalent: `cargo fmt`, `cargo clippy -D warnings`, `cargo test` in `components/feral-setupd` on Linux / project Docker image).
- [ ] Manual: unstable or blocked network during startup version check — confirm progress line appears between retries and final message matches failure class (or umbrella unknown).
- [ ] Manual: confirm hourly `spawn_remote_version_refresher` does not navigate the TV to the progress message.

Made with [Cursor](https://cursor.com)