### PR TITLE
feat(setupd): version-check TV progress and classified errors

### DIFF
--- a/components/feral-setupd/AGENTS.md
+++ b/components/feral-setupd/AGENTS.md
@@ -110,9 +110,12 @@ Runs/monitors the updater systemd unit, tails the updater log file, extracts
 progress/messages via regex, and streams progress/error lines back to callers.
 
 Distributor version metadata (`/api/latest/...`) is fetched with bounded retries;
-failures are classified (network vs HTTP class vs parse) for TV copy, and
-`check_and_update_system` can attach a progress channel so the launcher shows
-a short “checking for updates” line while those HTTP retries run.
+failures are classified (network vs HTTP class vs parse) for TV copy. For
+`UpdateExecution::Blocking` only, `check_and_update_system` attaches a progress
+channel so the launcher shows a short “checking for updates” line while those
+HTTP retries run; the channel is drained before final TV screens. For
+`UpdateExecution::NonBlocking` (BLE), updater calls pass `None` so CDP progress
+navigations are not on the mobile response path.
 Only `refresh_remote_version`, `is_too_old_to_upgrade`, `is_update_required`, and
 `is_update_available` accept that channel; helpers like `latest_version` read
 metadata without driving the progress UI.

--- a/components/feral-setupd/AGENTS.md
+++ b/components/feral-setupd/AGENTS.md
@@ -93,7 +93,7 @@ own bus. They arrive on:
 |---|---|
 | `show_pairing_qr_code` | Navigates CDP to the QR code page |
 | `factory_reset` | Starts the factory-reset flow |
-| `system_update` | Triggers a software update |
+| `system_update` | Optional version check (`UpdateMode::Available`); on `NoUpdateNeeded`, restores the TV page snapshot from before the check (`WebApp` → webapp, QR/message/recovery → prior surface, not unconditional webapp) |
 | `upload_logs` | Uploads device logs |
 | `upload_logs_with_bundle` | Uploads device logs with a `support_bundle_id` for support evidence unification |
 

--- a/components/feral-setupd/AGENTS.md
+++ b/components/feral-setupd/AGENTS.md
@@ -109,6 +109,14 @@ with an error.
 Runs/monitors the updater systemd unit, tails the updater log file, extracts
 progress/messages via regex, and streams progress/error lines back to callers.
 
+Distributor version metadata (`/api/latest/...`) is fetched with bounded retries;
+failures are classified (network vs HTTP class vs parse) for TV copy, and
+`check_and_update_system` can attach a progress channel so the launcher shows
+a short “checking for updates” line while those HTTP retries run.
+Only `refresh_remote_version`, `is_too_old_to_upgrade`, `is_update_required`, and
+`is_update_available` accept that channel; helpers like `latest_version` read
+metadata without driving the progress UI.
+
 Two enums control update behaviour:
 
 - `UpdateMode::Required` — check only against the distributor's minimum

--- a/components/feral-setupd/AGENTS.md
+++ b/components/feral-setupd/AGENTS.md
@@ -111,11 +111,10 @@ progress/messages via regex, and streams progress/error lines back to callers.
 
 Distributor version metadata (`/api/latest/...`) is fetched with bounded retries;
 failures are classified (network vs HTTP class vs parse) for TV copy, and
-`check_and_update_system` attaches a progress channel for **`UpdateExecution::Blocking`**
-only so the launcher shows a short “checking for updates” line while HTTP retries run;
-`NonBlocking` (BLE) passes `None` so CDP progress navigations are not on the mobile
-response path. Only `refresh_remote_version`, `is_too_old_to_upgrade`, `is_update_required`,
-and `is_update_available` accept that channel; helpers like `latest_version` read
+`check_and_update_system` can attach a progress channel so the launcher shows
+a short “checking for updates” line while those HTTP retries run.
+Only `refresh_remote_version`, `is_too_old_to_upgrade`, `is_update_required`, and
+`is_update_available` accept that channel; helpers like `latest_version` read
 metadata without driving the progress UI.
 
 Two enums control update behaviour:

--- a/components/feral-setupd/AGENTS.md
+++ b/components/feral-setupd/AGENTS.md
@@ -93,7 +93,7 @@ own bus. They arrive on:
 |---|---|
 | `show_pairing_qr_code` | Navigates CDP to the QR code page |
 | `factory_reset` | Starts the factory-reset flow |
-| `system_update` | Optional version check (`UpdateMode::Available`); on `NoUpdateNeeded`, restores the TV page snapshot from before the check (`WebApp` → webapp, QR/message/recovery → prior surface, not unconditional webapp) |
+| `system_update` | Optional version check (`UpdateMode::Available`); on `NoUpdateNeeded`, restores the pre-check TV page using `navigate_and_commit_if_still_progress`, which holds the `page` mutex across the entire navigate+commit sequence. All `show_*` functions that can race with this path also hold the same mutex during navigate+commit, so whichever path acquires the lock first wins atomically with no visual/state divergence. |
 | `upload_logs` | Uploads device logs |
 | `upload_logs_with_bundle` | Uploads device logs with a `support_bundle_id` for support evidence unification |
 

--- a/components/feral-setupd/AGENTS.md
+++ b/components/feral-setupd/AGENTS.md
@@ -111,10 +111,11 @@ progress/messages via regex, and streams progress/error lines back to callers.
 
 Distributor version metadata (`/api/latest/...`) is fetched with bounded retries;
 failures are classified (network vs HTTP class vs parse) for TV copy, and
-`check_and_update_system` can attach a progress channel so the launcher shows
-a short “checking for updates” line while those HTTP retries run.
-Only `refresh_remote_version`, `is_too_old_to_upgrade`, `is_update_required`, and
-`is_update_available` accept that channel; helpers like `latest_version` read
+`check_and_update_system` attaches a progress channel for **`UpdateExecution::Blocking`**
+only so the launcher shows a short “checking for updates” line while HTTP retries run;
+`NonBlocking` (BLE) passes `None` so CDP progress navigations are not on the mobile
+response path. Only `refresh_remote_version`, `is_too_old_to_upgrade`, `is_update_required`,
+and `is_update_available` accept that channel; helpers like `latest_version` read
 metadata without driving the progress UI.
 
 Two enums control update behaviour:

--- a/components/feral-setupd/AGENTS.md
+++ b/components/feral-setupd/AGENTS.md
@@ -93,7 +93,7 @@ own bus. They arrive on:
 |---|---|
 | `show_pairing_qr_code` | Navigates CDP to the QR code page |
 | `factory_reset` | Starts the factory-reset flow |
-| `system_update` | Optional version check (`UpdateMode::Available`); on `NoUpdateNeeded`, restores the pre-check TV page using `navigate_and_commit_if_still_progress`, which holds the `page` mutex across the entire navigate+commit sequence. All `show_*` functions that can race with this path also hold the same mutex during navigate+commit, so whichever path acquires the lock first wins atomically with no visual/state divergence. |
+| `system_update` | Optional version check (`UpdateMode::Available`); on `NoUpdateNeeded`, restores the TV page snapshot from before the check (`WebApp` → webapp, QR/message/recovery → prior surface, not unconditional webapp) |
 | `upload_logs` | Uploads device logs |
 | `upload_logs_with_bundle` | Uploads device logs with a `support_bundle_id` for support evidence unification |
 

--- a/components/feral-setupd/AGENTS.md
+++ b/components/feral-setupd/AGENTS.md
@@ -119,6 +119,12 @@ navigations are not on the mobile response path.
 Only `refresh_remote_version`, `is_too_old_to_upgrade`, `is_update_required`, and
 `is_update_available` accept that channel; helpers like `latest_version` read
 metadata without driving the progress UI.
+`UpdateMode::Available` no longer restores a stale TV surface blindly: the
+progress flow uses a dedicated `Page::VersionCheckProgress(session_id, …)`
+marker, and the no-update restore path only runs while the same session is
+still current. Version-check UI commits are serialized through the
+`ui_transition` mutex; keep any new version-check UI transitions aligned with
+that ownership rule.
 
 Two enums control update behaviour:
 

--- a/components/feral-setupd/src/constant.rs
+++ b/components/feral-setupd/src/constant.rs
@@ -22,7 +22,20 @@ pub const UPDATER_PROCESS_LOG_FILE: &str = "/var/log/updaterd.log";
 pub const UPDATER_VERSION_CHECK_RETRIES: u32 = 3;
 pub const UPDATER_VERSION_CHECK_RETRY_DELAY: u64 = 2 * 1000; // 2 seconds between retries
 pub const UPDATER_REMOTE_VERSION_REFRESH_INTERVAL: u64 = 60 * 60 * 1000; // 1 hour
-pub const UPDATER_FAILED_TO_CHECK_VERSION_MSG: &str = "FF1 needs to check for critical updates before playing art. If your network is stable and this persists, contact support@feralfile.com - your device may need hands-on help.";
+
+/// Shown on the TV between HTTP retry attempts while checking for updates.
+pub const VERSION_CHECK_PROGRESS_TV_MSG: &str = "Checking for updates...";
+
+/// Unclassified distributor/config failures; keep umbrella guidance for odd edge cases.
+pub const VERSION_CHECK_FAILED_UNKNOWN_MSG: &str = "FF1 needs to check for critical updates before playing art. If your network is stable and this persists, contact support@feralfile.com - your device may need hands-on help.";
+
+pub const VERSION_CHECK_FAILED_NETWORK_MSG: &str = "We could not reach the update server. Your Wi-Fi may be unstable—move closer to the router, wait a moment, then try again from the app.";
+
+pub const VERSION_CHECK_FAILED_SERVER_MSG: &str = "The update service is temporarily unavailable. Please wait a few minutes and try again from the app.";
+
+pub const VERSION_CHECK_FAILED_CLIENT_MSG: &str = "The update server rejected this request (configuration issue). If this keeps happening, contact support@feralfile.com.";
+
+pub const VERSION_CHECK_FAILED_PARSE_MSG: &str = "We received an unexpected response from the update server. Please try again later or contact support@feralfile.com.";
 
 // Bluetooth configuration
 pub const SERVICE_UUID: Uuid = Uuid::from_u128(0xf7826da64fa24e988024bc5b71e0893e_u128);

--- a/components/feral-setupd/src/main.rs
+++ b/components/feral-setupd/src/main.rs
@@ -1104,6 +1104,24 @@ fn available_system_update_follow_up(
     }
 }
 
+/// Whether `check_and_update_system` drives the transient “checking for updates” TV line.
+///
+/// `NonBlocking` callers (BLE) must not attach version-check progress to CDP navigation;
+/// that work stays on the HTTP fetch path only so mobile notifications are not delayed.
+#[must_use]
+fn version_check_progress_tv_enabled(execution: UpdateExecution) -> bool {
+    matches!(execution, UpdateExecution::Blocking)
+}
+
+/// After the progress sender is dropped, join the progress task when TV ordering matters.
+async fn finish_version_check_progress(progress_task: Option<tokio::task::JoinHandle<()>>) {
+    if let Some(task) = progress_task {
+        if let Err(join_err) = task.await {
+            eprintln!("MAIN: version-check progress task ended with: {join_err:#?}");
+        }
+    }
+}
+
 /// Shared system update logic that checks version status and optionally triggers an update.
 ///
 /// This function handles:
@@ -1126,13 +1144,13 @@ async fn check_and_update_system(
     mode: UpdateMode,
     execution: UpdateExecution,
 ) -> Result<UpdateCheckResult> {
-    // TV progress while HTTP retries run inside `fetch_remote_version` (sender dropped before
-    // the final classified failure copy so the last screen is stable).
-    let (prog_tx, mut prog_rx) = mpsc::channel::<(u32, u32)>(16);
-    let progress_task = {
+    // TV progress while HTTP retries run inside `fetch_remote_version` (Blocking only).
+    let progress_tv = version_check_progress_tv_enabled(execution);
+    let (mut prog_tx, progress_task) = if progress_tv {
+        let (prog_tx, mut prog_rx) = mpsc::channel::<(u32, u32)>(16);
         let chrome = chrome.clone();
         let app_state = app_state.clone();
-        tokio::spawn(async move {
+        let progress_task = tokio::spawn(async move {
             while let Some((_attempt, _max)) = prog_rx.recv().await {
                 if let Err(e) =
                     show_message(&chrome, &app_state, constant::VERSION_CHECK_PROGRESS_TV_MSG).await
@@ -1140,20 +1158,20 @@ async fn check_and_update_system(
                     eprintln!("MAIN: version-check progress UI failed: {e:#?}");
                 }
             }
-        })
+        });
+        (Some(prog_tx), Some(progress_task))
+    } else {
+        (None, None)
     };
-
     // Always fetch the remote version first to ensure we have the latest info
-    updater::refresh_remote_version(Some(prog_tx.clone())).await;
+    updater::refresh_remote_version(prog_tx.clone()).await;
     // First check if device is too old to auto-upgrade
-    match updater::is_too_old_to_upgrade(Some(prog_tx.clone())).await {
+    match updater::is_too_old_to_upgrade(prog_tx.clone()).await {
         Ok(true) => {
             // Finish progress UI before reflashing screens; otherwise queued progress
             // navigations can overwrite the QR/message we are about to show.
-            drop(prog_tx);
-            if let Err(join_err) = progress_task.await {
-                eprintln!("MAIN: version-check progress task ended with: {join_err:#?}");
-            }
+            prog_tx.take();
+            finish_version_check_progress(progress_task).await;
 
             // Device is too old, show reflashing QR code
             if let Ok(Some(flashing_guide)) = updater::flashing_guide_url().await {
@@ -1233,14 +1251,12 @@ async fn check_and_update_system(
 
     // Check if update is needed based on mode
     let needs_update = match mode {
-        UpdateMode::Required => updater::is_update_required(Some(prog_tx.clone())).await,
-        UpdateMode::Available => updater::is_update_available(Some(prog_tx.clone())).await,
+        UpdateMode::Required => updater::is_update_required(prog_tx.clone()).await,
+        UpdateMode::Available => updater::is_update_available(prog_tx.clone()).await,
     };
 
-    drop(prog_tx);
-    if let Err(join_err) = progress_task.await {
-        eprintln!("MAIN: version-check progress task ended with: {join_err:#?}");
-    }
+    prog_tx.take();
+    finish_version_check_progress(progress_task).await;
 
     match needs_update {
         Ok(true) => {
@@ -1383,9 +1399,11 @@ async fn wait_for_controld(timeout: Duration) -> Result<()> {
 #[cfg(test)]
 mod available_system_update_follow_up_tests {
     use super::{
-        AvailableSystemUpdateFollowUp, UpdateCheckResult, available_system_update_follow_up,
+        AvailableSystemUpdateFollowUp, UpdateCheckResult, UpdateExecution,
+        available_system_update_follow_up, version_check_progress_tv_enabled,
     };
     use anyhow::anyhow;
+    use tokio::sync::mpsc;
 
     #[test]
     fn no_update_needed_returns_to_webapp() {
@@ -1425,5 +1443,30 @@ mod available_system_update_follow_up_tests {
             available_system_update_follow_up(&Err(anyhow!("cdp navigate failed"))),
             AvailableSystemUpdateFollowUp::LogFailure,
         );
+    }
+
+    #[test]
+    fn ble_nonblocking_skips_version_check_progress_tv() {
+        assert!(!version_check_progress_tv_enabled(
+            UpdateExecution::NonBlocking
+        ));
+    }
+
+    #[test]
+    fn blocking_startup_and_dbus_enable_version_check_progress_tv() {
+        assert!(version_check_progress_tv_enabled(UpdateExecution::Blocking));
+    }
+
+    /// Guardrail: progress task must observe channel close once orchestration drops
+    /// its last `Sender` clone (see `prog_tx.take()` before `finish_version_check_progress`).
+    #[tokio::test]
+    async fn progress_task_joins_after_all_senders_dropped() {
+        let (tx, mut rx) = mpsc::channel::<(u32, u32)>(1);
+        let task = tokio::spawn(async move { while rx.recv().await.is_some() {} });
+        drop(tx);
+        tokio::time::timeout(std::time::Duration::from_secs(1), task)
+            .await
+            .expect("progress task should exit after senders dropped")
+            .expect("progress task join");
     }
 }

--- a/components/feral-setupd/src/main.rs
+++ b/components/feral-setupd/src/main.rs
@@ -1104,24 +1104,6 @@ fn available_system_update_follow_up(
     }
 }
 
-/// Whether `check_and_update_system` drives the transient “checking for updates” TV line.
-///
-/// `NonBlocking` callers (BLE) must not attach version-check progress to CDP navigation;
-/// that work stays on the HTTP fetch path only so mobile notifications are not delayed.
-#[must_use]
-fn version_check_progress_tv_enabled(execution: UpdateExecution) -> bool {
-    matches!(execution, UpdateExecution::Blocking)
-}
-
-/// After the progress sender is dropped, join the progress task when TV ordering matters.
-async fn finish_version_check_progress(progress_task: Option<tokio::task::JoinHandle<()>>) {
-    if let Some(task) = progress_task {
-        if let Err(join_err) = task.await {
-            eprintln!("MAIN: version-check progress task ended with: {join_err:#?}");
-        }
-    }
-}
-
 /// Shared system update logic that checks version status and optionally triggers an update.
 ///
 /// This function handles:
@@ -1144,13 +1126,13 @@ async fn check_and_update_system(
     mode: UpdateMode,
     execution: UpdateExecution,
 ) -> Result<UpdateCheckResult> {
-    // TV progress while HTTP retries run inside `fetch_remote_version` (Blocking only).
-    let progress_tv = version_check_progress_tv_enabled(execution);
-    let (mut prog_tx, progress_task) = if progress_tv {
-        let (prog_tx, mut prog_rx) = mpsc::channel::<(u32, u32)>(16);
+    // TV progress while HTTP retries run inside `fetch_remote_version` (sender dropped before
+    // the final classified failure copy so the last screen is stable).
+    let (prog_tx, mut prog_rx) = mpsc::channel::<(u32, u32)>(16);
+    let progress_task = {
         let chrome = chrome.clone();
         let app_state = app_state.clone();
-        let progress_task = tokio::spawn(async move {
+        tokio::spawn(async move {
             while let Some((_attempt, _max)) = prog_rx.recv().await {
                 if let Err(e) =
                     show_message(&chrome, &app_state, constant::VERSION_CHECK_PROGRESS_TV_MSG).await
@@ -1158,20 +1140,20 @@ async fn check_and_update_system(
                     eprintln!("MAIN: version-check progress UI failed: {e:#?}");
                 }
             }
-        });
-        (Some(prog_tx), Some(progress_task))
-    } else {
-        (None, None)
+        })
     };
+
     // Always fetch the remote version first to ensure we have the latest info
-    updater::refresh_remote_version(prog_tx.clone()).await;
+    updater::refresh_remote_version(Some(prog_tx.clone())).await;
     // First check if device is too old to auto-upgrade
-    match updater::is_too_old_to_upgrade(prog_tx.clone()).await {
+    match updater::is_too_old_to_upgrade(Some(prog_tx.clone())).await {
         Ok(true) => {
             // Finish progress UI before reflashing screens; otherwise queued progress
             // navigations can overwrite the QR/message we are about to show.
-            prog_tx.take();
-            finish_version_check_progress(progress_task).await;
+            drop(prog_tx);
+            if let Err(join_err) = progress_task.await {
+                eprintln!("MAIN: version-check progress task ended with: {join_err:#?}");
+            }
 
             // Device is too old, show reflashing QR code
             if let Ok(Some(flashing_guide)) = updater::flashing_guide_url().await {
@@ -1251,12 +1233,14 @@ async fn check_and_update_system(
 
     // Check if update is needed based on mode
     let needs_update = match mode {
-        UpdateMode::Required => updater::is_update_required(prog_tx.clone()).await,
-        UpdateMode::Available => updater::is_update_available(prog_tx.clone()).await,
+        UpdateMode::Required => updater::is_update_required(Some(prog_tx.clone())).await,
+        UpdateMode::Available => updater::is_update_available(Some(prog_tx.clone())).await,
     };
 
-    prog_tx.take();
-    finish_version_check_progress(progress_task).await;
+    drop(prog_tx);
+    if let Err(join_err) = progress_task.await {
+        eprintln!("MAIN: version-check progress task ended with: {join_err:#?}");
+    }
 
     match needs_update {
         Ok(true) => {
@@ -1399,11 +1383,9 @@ async fn wait_for_controld(timeout: Duration) -> Result<()> {
 #[cfg(test)]
 mod available_system_update_follow_up_tests {
     use super::{
-        AvailableSystemUpdateFollowUp, UpdateCheckResult, UpdateExecution,
-        available_system_update_follow_up, version_check_progress_tv_enabled,
+        AvailableSystemUpdateFollowUp, UpdateCheckResult, available_system_update_follow_up,
     };
     use anyhow::anyhow;
-    use tokio::sync::mpsc;
 
     #[test]
     fn no_update_needed_returns_to_webapp() {
@@ -1443,30 +1425,5 @@ mod available_system_update_follow_up_tests {
             available_system_update_follow_up(&Err(anyhow!("cdp navigate failed"))),
             AvailableSystemUpdateFollowUp::LogFailure,
         );
-    }
-
-    #[test]
-    fn ble_nonblocking_skips_version_check_progress_tv() {
-        assert!(!version_check_progress_tv_enabled(
-            UpdateExecution::NonBlocking
-        ));
-    }
-
-    #[test]
-    fn blocking_startup_and_dbus_enable_version_check_progress_tv() {
-        assert!(version_check_progress_tv_enabled(UpdateExecution::Blocking));
-    }
-
-    /// Guardrail: progress task must observe channel close once orchestration drops
-    /// its last `Sender` clone (see `prog_tx.take()` before `finish_version_check_progress`).
-    #[tokio::test]
-    async fn progress_task_joins_after_all_senders_dropped() {
-        let (tx, mut rx) = mpsc::channel::<(u32, u32)>(1);
-        let task = tokio::spawn(async move { while rx.recv().await.is_some() {} });
-        drop(tx);
-        tokio::time::timeout(std::time::Duration::from_secs(1), task)
-            .await
-            .expect("progress task should exit after senders dropped")
-            .expect("progress task join");
     }
 }

--- a/components/feral-setupd/src/main.rs
+++ b/components/feral-setupd/src/main.rs
@@ -696,17 +696,10 @@ mod callbacks {
         .await;
         match super::available_system_update_follow_up(&result, &prior_page) {
             super::AvailableSystemUpdateFollowUp::RestoreWebApp => {
-                if let Err(e) =
-                    super::restore_webapp_after_no_update_check(app_state, chromium).await
-                {
-                    eprintln!("MAIN: Failed to restore webapp after no-update check: {e:#?}");
-                }
+                let _ = show_webapp(app_state, chromium).await;
             }
             super::AvailableSystemUpdateFollowUp::RestorePriorPage => {
-                if let Err(e) =
-                    super::restore_prior_page_after_no_update_check(app_state, chromium, prior_page)
-                        .await
-                {
+                if let Err(e) = super::restore_prior_page(app_state, chromium, prior_page).await {
                     eprintln!("MAIN: Failed to restore TV page after no-update check: {e:#?}");
                 }
             }
@@ -1236,7 +1229,9 @@ async fn check_and_update_system(
     // Check if update is needed based on mode
     let needs_update = match mode {
         UpdateMode::Required => updater::is_update_required(progress.as_updater_progress()).await,
-        UpdateMode::Available => updater::is_update_available(progress.as_updater_progress()).await,
+        UpdateMode::Available => {
+            updater::is_update_available(progress.as_updater_progress()).await
+        }
     };
 
     progress.finish().await;
@@ -1341,168 +1336,26 @@ impl VersionCheckProgress {
     }
 }
 
-/// True when `page` is still the transient copy shown during distributor HTTP retries.
-fn is_version_check_progress_page(page: &Page) -> bool {
-    matches!(
-        page,
-        Page::Message(_, text) if text.as_str() == constant::VERSION_CHECK_PROGRESS_TV_MSG
-    )
-}
-
-/// Commit `new_page` only when the current page is still the transient version-check progress
-/// copy. Used for the "already on webapp" fast path where no navigation is needed.
-async fn try_commit_page_if_still_progress(page: &Mutex<Page>, new_page: Page) -> bool {
-    let mut current = page.lock().await;
-    if !is_version_check_progress_page(&current) {
-        return false;
-    }
-    *current = new_page;
-    true
-}
-
-/// Navigate to `url` and commit `new_page`, but only when the current page is still the
-/// transient version-check progress copy. The page lock is held across the entire
-/// navigate+commit sequence so that a concurrent `show_*` call that holds the same lock
-/// for its own navigate+commit will be seen atomically: whichever path acquires the lock
-/// first wins, and the loser either finds the page changed (restore → skip) or
-/// unconditionally commits its own state (show_* → overwrite).
-///
-/// Invariant: all `show_*` functions that can race with this path must also hold the page
-/// lock during navigate. Violating this allows a concurrent navigate to slip onto the screen
-/// between our lock check and our navigate, producing a visual/state divergence.
-async fn navigate_and_commit_if_still_progress(
-    page: &Mutex<Page>,
-    chrome: &Arc<Cdp>,
-    url: &str,
-    new_page: Page,
-) -> Result<bool> {
-    let mut current = page.lock().await;
-    if !is_version_check_progress_page(&current) {
-        return Ok(false);
-    }
-    chrome
-        .navigate(url)
-        .await
-        .with_context(|| format!("navigating to {url}"))?;
-    *current = new_page;
-    Ok(true)
-}
-
-async fn restore_webapp_after_no_update_check(
-    app_state: &Arc<AppState>,
-    chrome: &Arc<Cdp>,
-) -> Result<()> {
-    // Best-effort early exit to avoid unnecessary I/O. The real guard is inside
-    // `try_commit_page_if_still_progress` / `navigate_and_commit_if_still_progress`
-    // which hold the page lock for the entire check+write (or check+navigate+write).
-    if !is_version_check_progress_page(&app_state.page.lock().await) {
-        println!("MAIN: skip webapp restore after no-update check; page changed during check");
-        return Ok(());
-    }
-
-    let webapp_url = constant::WEBAPP_URL;
-    let current_url = chrome.get_current_url().await?;
-    if current_url.starts_with(webapp_url) {
-        // Already on webapp — just commit state, no navigate needed.
-        if !try_commit_page_if_still_progress(&app_state.page, Page::WebApp(unix_s())).await {
-            println!("MAIN: skip webapp restore after no-update check; page changed during check");
-        }
-        return Ok(());
-    }
-
-    // Sleep outside the lock so a concurrent show_* that already holds the lock
-    // for its own navigate+commit is not blocked by us sleeping.
-    time::sleep(Duration::from_millis(constant::WIFI_WEBAPP_DELAY)).await;
-
-    if !navigate_and_commit_if_still_progress(
-        &app_state.page,
-        chrome,
-        webapp_url,
-        Page::WebApp(unix_s()),
-    )
-    .await?
-    {
-        println!("MAIN: skip webapp restore after no-update check; page changed during check");
-    } else {
-        println!("MAIN: Navigated to {webapp_url}");
-    }
-    Ok(())
-}
-
-async fn restore_prior_page_after_no_update_check(
+/// Re-show the TV surface that was active before an optional version check replaced it
+/// with transient progress copy. Called from the D-Bus `system_update` no-update path only.
+async fn restore_prior_page(
     app_state: &Arc<AppState>,
     chrome: &Arc<Cdp>,
     prior: Page,
 ) -> Result<()> {
     match prior {
-        Page::WebApp(_) => restore_webapp_after_no_update_check(app_state, chrome).await,
-        Page::QRCode(_) => {
-            let qrcode_url = build_qrcode_url(app_state);
-            if !navigate_and_commit_if_still_progress(
-                &app_state.page,
-                chrome,
-                &qrcode_url,
-                Page::QRCode(unix_s()),
-            )
-            .await?
-            {
-                println!(
-                    "MAIN: skip prior-page restore after no-update check; page changed during check"
-                );
-            } else {
-                println!("MAIN: Navigated to {qrcode_url}");
-            }
-            Ok(())
-        }
-        Page::Message(_, text) => {
-            let encoded = urlencoding::encode(&text);
-            let message_url = format!("{}{}", constant::MSG_URL_PREFIX, encoded);
-            if !navigate_and_commit_if_still_progress(
-                &app_state.page,
-                chrome,
-                &message_url,
-                Page::Message(unix_s(), text),
-            )
-            .await?
-            {
-                println!(
-                    "MAIN: skip prior-page restore after no-update check; page changed during check"
-                );
-            } else {
-                println!("MAIN: Navigated to {message_url}");
-            }
-            Ok(())
-        }
-        Page::FactoryReset(_) => {
-            let message_url = format!(
-                "{}{}",
-                constant::MSG_URL_PREFIX,
-                constant::FACTORY_RESET_MSG
-            );
-            if !navigate_and_commit_if_still_progress(
-                &app_state.page,
-                chrome,
-                &message_url,
-                Page::FactoryReset(unix_s()),
-            )
-            .await?
-            {
-                println!(
-                    "MAIN: skip prior-page restore after no-update check; page changed during check"
-                );
-            } else {
-                println!("MAIN: Navigated to {message_url}");
-            }
-            Ok(())
-        }
+        Page::WebApp(_) => show_webapp(app_state, chrome).await,
+        Page::QRCode(_) => show_qrcode(app_state, chrome).await,
+        Page::Message(_, text) => show_message(chrome, app_state, &text).await,
+        Page::FactoryReset(_) => show_factory_reset(chrome, app_state).await,
         Page::ReflashingRequired(_, message) => {
-            restore_reflashing_page_after_no_update(app_state, chrome, &message).await
+            restore_reflashing_page(app_state, chrome, &message).await
         }
         Page::SystemUpgrade(_) | Page::None(_) => Ok(()),
     }
 }
 
-async fn restore_reflashing_page_after_no_update(
+async fn restore_reflashing_page(
     app_state: &Arc<AppState>,
     chrome: &Arc<Cdp>,
     fallback_message: &str,
@@ -1520,49 +1373,18 @@ async fn restore_reflashing_page_after_no_update(
                 None
             })
             .unwrap_or_else(|| "Unknown".to_string());
-
-        let message = format!(
-            "We've moved too far ahead for this version to catch up. Your FF1 is too far behind to auto-upgrade. Current version: {current_version} Latest version: {latest_version} Minimum upgradeable version: {min_upgradeable}. Scan the code above for step-by-step reflashing instructions, or contact us for help. support@feralfile.com"
-        );
-        let qrcode_url = format!(
-            "{}&qr_content={}&message={}",
-            constant::QRCODE_URL_PREFIX,
-            urlencoding::encode(&flashing_guide),
-            urlencoding::encode(&message)
-        );
-
-        if !navigate_and_commit_if_still_progress(
-            &app_state.page,
+        show_reflashing_qrcode(
+            app_state,
             chrome,
-            &qrcode_url,
-            Page::ReflashingRequired(unix_s(), message),
+            &flashing_guide,
+            &current_version,
+            &latest_version,
+            &min_upgradeable,
         )
-        .await?
-        {
-            println!(
-                "MAIN: skip prior-page restore after no-update check; page changed during check"
-            );
-        } else {
-            println!("MAIN: Navigated to reflashing QR code: {qrcode_url}");
-        }
-        return Ok(());
-    }
-
-    let encoded = urlencoding::encode(fallback_message);
-    let message_url = format!("{}{}", constant::MSG_URL_PREFIX, encoded);
-    if !navigate_and_commit_if_still_progress(
-        &app_state.page,
-        chrome,
-        &message_url,
-        Page::Message(unix_s(), fallback_message.to_string()),
-    )
-    .await?
-    {
-        println!("MAIN: skip prior-page restore after no-update check; page changed during check");
+        .await
     } else {
-        println!("MAIN: Navigated to {message_url}");
+        show_message(chrome, app_state, fallback_message).await
     }
-    Ok(())
 }
 
 async fn show_webapp(app_state: &Arc<AppState>, chrome: &Arc<Cdp>) -> Result<()> {
@@ -1593,15 +1415,13 @@ async fn show_webapp(app_state: &Arc<AppState>, chrome: &Arc<Cdp>) -> Result<()>
 async fn show_message(chrome: &Arc<Cdp>, app_state: &Arc<AppState>, message: &str) -> Result<()> {
     let encoded = urlencoding::encode(message);
     let message_url = format!("{}{}", constant::MSG_URL_PREFIX, encoded);
-    // Hold the page lock across navigate+commit so the no-update restore path, which also
-    // holds the lock for its navigate_and_commit_if_still_progress call, sees an atomic
-    // boundary: whichever path acquires the lock first wins, preventing visual/state divergence.
-    let mut page = app_state.page.lock().await;
     chrome
         .navigate(&message_url)
         .await
         .with_context(|| format!("navigating to {message_url}"))?;
     println!("MAIN: Navigated to {message_url}");
+
+    let mut page = app_state.page.lock().await;
     *page = Page::Message(unix_s(), message.to_string());
     Ok(())
 }
@@ -1612,12 +1432,13 @@ async fn show_system_upgrade(
     message: &str,
 ) -> Result<()> {
     let message_url = format!("{}{}", constant::MSG_URL_PREFIX, message);
-    let mut page = app_state.page.lock().await;
     chrome
         .navigate(&message_url)
         .await
         .with_context(|| format!("navigating to {message_url}"))?;
     println!("MAIN: Navigated to {message_url}");
+
+    let mut page = app_state.page.lock().await;
     *page = Page::SystemUpgrade(unix_s());
     Ok(())
 }
@@ -1628,12 +1449,13 @@ async fn show_factory_reset(chrome: &Arc<Cdp>, app_state: &Arc<AppState>) -> Res
         constant::MSG_URL_PREFIX,
         constant::FACTORY_RESET_MSG
     );
-    let mut page = app_state.page.lock().await;
     chrome
         .navigate(&message_url)
         .await
         .with_context(|| format!("navigating to {message_url}"))?;
     println!("MAIN: Navigated to {message_url}");
+
+    let mut page = app_state.page.lock().await;
     *page = Page::FactoryReset(unix_s());
     Ok(())
 }
@@ -1687,90 +1509,15 @@ mod version_check_progress_tests {
         let per_updater_call = tx.clone();
         drop(per_updater_call);
 
-        let receiver_task = tokio::spawn(async move { while rx.recv().await.is_some() {} });
+        let receiver_task = tokio::spawn(async move {
+            while rx.recv().await.is_some() {}
+        });
 
         drop(tx);
         timeout(Duration::from_secs(1), receiver_task)
             .await
             .expect("receiver should finish within 1s")
             .expect("receiver task join");
-    }
-}
-
-#[cfg(test)]
-mod version_check_progress_page_tests {
-    use super::{Page, is_version_check_progress_page, try_commit_page_if_still_progress};
-    use crate::constant;
-    use tokio::sync::Mutex;
-
-    #[test]
-    fn progress_page_matches_version_check_copy() {
-        assert!(is_version_check_progress_page(&Page::Message(
-            0,
-            constant::VERSION_CHECK_PROGRESS_TV_MSG.to_string(),
-        )));
-    }
-
-    #[test]
-    fn other_pages_are_not_version_check_progress() {
-        assert!(!is_version_check_progress_page(&Page::QRCode(0)));
-        assert!(!is_version_check_progress_page(&Page::WebApp(0)));
-        assert!(!is_version_check_progress_page(&Page::FactoryReset(0)));
-        assert!(!is_version_check_progress_page(&Page::Message(
-            0,
-            "Welcome".to_string(),
-        )));
-    }
-
-    /// If a concurrent show_* path (BLE, factory-reset) has already written a real page,
-    /// the restore commit is rejected. `navigate_and_commit_if_still_progress` contains
-    /// the same guard; this tests the underlying primitive it delegates to.
-    #[tokio::test]
-    async fn commit_skips_when_page_is_no_longer_progress() {
-        let page = Mutex::new(Page::FactoryReset(0));
-        assert!(
-            !try_commit_page_if_still_progress(&page, Page::QRCode(1)).await,
-            "must not overwrite a non-progress page"
-        );
-        assert!(matches!(*page.lock().await, Page::FactoryReset(0)));
-    }
-
-    #[tokio::test]
-    async fn commit_succeeds_when_still_on_progress() {
-        let page = Mutex::new(Page::Message(
-            0,
-            constant::VERSION_CHECK_PROGRESS_TV_MSG.to_string(),
-        ));
-        assert!(
-            try_commit_page_if_still_progress(&page, Page::QRCode(1)).await,
-            "must commit when page is still the progress copy"
-        );
-        assert!(matches!(*page.lock().await, Page::QRCode(1)));
-    }
-
-    /// Verifies the invariant that `navigate_and_commit_if_still_progress` requires: all
-    /// show_* functions that can race with the restore path also hold the page lock during
-    /// navigate+commit, so their page writes are visible to the restore's lock check.
-    /// (The full navigate race is integration-level and requires a mock CDP to test end-to-end.)
-    #[tokio::test]
-    async fn concurrent_commit_while_holding_lock_is_seen_by_restore_check() {
-        let page = Mutex::new(Page::Message(
-            0,
-            constant::VERSION_CHECK_PROGRESS_TV_MSG.to_string(),
-        ));
-
-        // Simulate a show_factory_reset that acquired the lock, navigated, and committed.
-        {
-            let mut guard = page.lock().await;
-            *guard = Page::FactoryReset(0);
-        }
-
-        // Restore path then tries to commit — must see FactoryReset and skip.
-        assert!(
-            !try_commit_page_if_still_progress(&page, Page::QRCode(1)).await,
-            "restore must not overwrite a page committed by a concurrent show_*"
-        );
-        assert!(matches!(*page.lock().await, Page::FactoryReset(0)));
     }
 }
 

--- a/components/feral-setupd/src/main.rs
+++ b/components/feral-setupd/src/main.rs
@@ -684,15 +684,23 @@ mod callbacks {
 
         // Use Available mode for user-triggered updates (check for any newer version)
         // Use Blocking execution since D-Bus callback runs in a spawned task anyway
-        if let Err(e) = super::check_and_update_system(
+        let result = super::check_and_update_system(
             app_state,
             chromium,
             super::UpdateMode::Available,
             super::UpdateExecution::Blocking,
         )
-        .await
-        {
-            eprintln!("MAIN: System update failed: {e:#?}");
+        .await;
+        match super::available_system_update_follow_up(&result) {
+            super::AvailableSystemUpdateFollowUp::ReturnToWebApp => {
+                // Already on the latest build: leave the transient progress screen without
+                // showing extra TV copy (user stays on / returns to the bundled web app).
+                let _ = show_webapp(app_state, chromium).await;
+            }
+            super::AvailableSystemUpdateFollowUp::LogFailure => {
+                eprintln!("MAIN: System update failed: {result:#?}");
+            }
+            super::AvailableSystemUpdateFollowUp::NoOp => {}
         }
     }
 
@@ -1075,6 +1083,27 @@ pub enum UpdateCheckResult {
     VersionCheckFailed,
 }
 
+/// Follow-up after `check_and_update_system(UpdateMode::Available, …)` in the D-Bus path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AvailableSystemUpdateFollowUp {
+    /// Optional check found no newer build; leave the transient progress route quietly.
+    ReturnToWebApp,
+    /// Blocking orchestration failed (CDP navigate, updater start, etc.).
+    LogFailure,
+    /// Core already drove TV/updater (update started, reflash, classified fetch error).
+    NoOp,
+}
+
+fn available_system_update_follow_up(
+    result: &Result<UpdateCheckResult>,
+) -> AvailableSystemUpdateFollowUp {
+    match result {
+        Ok(UpdateCheckResult::NoUpdateNeeded) => AvailableSystemUpdateFollowUp::ReturnToWebApp,
+        Err(_) => AvailableSystemUpdateFollowUp::LogFailure,
+        Ok(_) => AvailableSystemUpdateFollowUp::NoOp,
+    }
+}
+
 /// Shared system update logic that checks version status and optionally triggers an update.
 ///
 /// This function handles:
@@ -1348,5 +1377,53 @@ async fn wait_for_controld(timeout: Duration) -> Result<()> {
     match time::timeout(timeout, wait_future).await {
         Ok(_) => Ok(()),
         Err(_) => Err(anyhow::anyhow!("Timeout waiting for controld connection")),
+    }
+}
+
+#[cfg(test)]
+mod available_system_update_follow_up_tests {
+    use super::{
+        AvailableSystemUpdateFollowUp, UpdateCheckResult, available_system_update_follow_up,
+    };
+    use anyhow::anyhow;
+
+    #[test]
+    fn no_update_needed_returns_to_webapp() {
+        assert_eq!(
+            available_system_update_follow_up(&Ok(UpdateCheckResult::NoUpdateNeeded)),
+            AvailableSystemUpdateFollowUp::ReturnToWebApp,
+        );
+    }
+
+    #[test]
+    fn update_started_is_no_op_for_dbus_follow_up() {
+        assert_eq!(
+            available_system_update_follow_up(&Ok(UpdateCheckResult::UpdateStarted)),
+            AvailableSystemUpdateFollowUp::NoOp,
+        );
+    }
+
+    #[test]
+    fn too_old_to_upgrade_is_no_op_for_dbus_follow_up() {
+        assert_eq!(
+            available_system_update_follow_up(&Ok(UpdateCheckResult::TooOldToUpgrade)),
+            AvailableSystemUpdateFollowUp::NoOp,
+        );
+    }
+
+    #[test]
+    fn version_check_failed_is_no_op_for_dbus_follow_up() {
+        assert_eq!(
+            available_system_update_follow_up(&Ok(UpdateCheckResult::VersionCheckFailed)),
+            AvailableSystemUpdateFollowUp::NoOp,
+        );
+    }
+
+    #[test]
+    fn orchestration_error_is_logged_only() {
+        assert_eq!(
+            available_system_update_follow_up(&Err(anyhow!("cdp navigate failed"))),
+            AvailableSystemUpdateFollowUp::LogFailure,
+        );
     }
 }

--- a/components/feral-setupd/src/main.rs
+++ b/components/feral-setupd/src/main.rs
@@ -1126,34 +1126,16 @@ async fn check_and_update_system(
     mode: UpdateMode,
     execution: UpdateExecution,
 ) -> Result<UpdateCheckResult> {
-    // TV progress while HTTP retries run inside `fetch_remote_version` (sender dropped before
-    // the final classified failure copy so the last screen is stable).
-    let (prog_tx, mut prog_rx) = mpsc::channel::<(u32, u32)>(16);
-    let progress_task = {
-        let chrome = chrome.clone();
-        let app_state = app_state.clone();
-        tokio::spawn(async move {
-            while let Some((_attempt, _max)) = prog_rx.recv().await {
-                if let Err(e) =
-                    show_message(&chrome, &app_state, constant::VERSION_CHECK_PROGRESS_TV_MSG).await
-                {
-                    eprintln!("MAIN: version-check progress UI failed: {e:#?}");
-                }
-            }
-        })
-    };
+    let progress = VersionCheckProgress::start(execution, chrome.clone(), app_state.clone());
 
     // Always fetch the remote version first to ensure we have the latest info
-    updater::refresh_remote_version(Some(prog_tx.clone())).await;
+    updater::refresh_remote_version(progress.as_updater_progress()).await;
     // First check if device is too old to auto-upgrade
-    match updater::is_too_old_to_upgrade(Some(prog_tx.clone())).await {
+    match updater::is_too_old_to_upgrade(progress.as_updater_progress()).await {
         Ok(true) => {
             // Finish progress UI before reflashing screens; otherwise queued progress
             // navigations can overwrite the QR/message we are about to show.
-            drop(prog_tx);
-            if let Err(join_err) = progress_task.await {
-                eprintln!("MAIN: version-check progress task ended with: {join_err:#?}");
-            }
+            progress.finish().await;
 
             // Device is too old, show reflashing QR code
             if let Ok(Some(flashing_guide)) = updater::flashing_guide_url().await {
@@ -1233,14 +1215,13 @@ async fn check_and_update_system(
 
     // Check if update is needed based on mode
     let needs_update = match mode {
-        UpdateMode::Required => updater::is_update_required(Some(prog_tx.clone())).await,
-        UpdateMode::Available => updater::is_update_available(Some(prog_tx.clone())).await,
+        UpdateMode::Required => updater::is_update_required(progress.as_updater_progress()).await,
+        UpdateMode::Available => {
+            updater::is_update_available(progress.as_updater_progress()).await
+        }
     };
 
-    drop(prog_tx);
-    if let Err(join_err) = progress_task.await {
-        eprintln!("MAIN: version-check progress task ended with: {join_err:#?}");
-    }
+    progress.finish().await;
 
     match needs_update {
         Ok(true) => {
@@ -1279,6 +1260,65 @@ async fn check_and_update_system(
                 }
             }
             Ok(UpdateCheckResult::VersionCheckFailed)
+        }
+    }
+}
+
+/// Drives TV “checking for updates” copy during distributor HTTP retries.
+///
+/// Only [`UpdateExecution::Blocking`] attaches a channel: BLE uses [`UpdateExecution::NonBlocking`]
+/// and passes `None` into the updater so CDP navigations are not on the mobile response path.
+/// When active, the sender is dropped and the task drained before final TV screens so progress
+/// cannot overwrite reflash, failure, or update UI.
+struct VersionCheckProgress {
+    tx: Option<updater::FetchProgressTx>,
+    task: Option<task::JoinHandle<()>>,
+}
+
+impl VersionCheckProgress {
+    #[must_use]
+    fn uses_tv_progress(execution: UpdateExecution) -> bool {
+        matches!(execution, UpdateExecution::Blocking)
+    }
+
+    fn start(execution: UpdateExecution, chrome: Arc<Cdp>, app_state: Arc<AppState>) -> Self {
+        if !Self::uses_tv_progress(execution) {
+            return Self {
+                tx: None,
+                task: None,
+            };
+        }
+
+        let (prog_tx, mut prog_rx) = mpsc::channel::<(u32, u32)>(16);
+        let progress_task = tokio::spawn(async move {
+            while let Some((_attempt, _max)) = prog_rx.recv().await {
+                if let Err(e) =
+                    show_message(&chrome, &app_state, constant::VERSION_CHECK_PROGRESS_TV_MSG).await
+                {
+                    eprintln!("MAIN: version-check progress UI failed: {e:#?}");
+                }
+            }
+        });
+
+        Self {
+            tx: Some(prog_tx),
+            task: Some(progress_task),
+        }
+    }
+
+    fn as_updater_progress(&self) -> Option<updater::FetchProgressTx> {
+        self.tx.clone()
+    }
+
+    async fn finish(self) {
+        let Some(tx) = self.tx else {
+            return;
+        };
+        drop(tx);
+        if let Some(task) = self.task {
+            if let Err(join_err) = task.await {
+                eprintln!("MAIN: version-check progress task ended with: {join_err:#?}");
+            }
         }
     }
 }
@@ -1377,6 +1417,43 @@ async fn wait_for_controld(timeout: Duration) -> Result<()> {
     match time::timeout(timeout, wait_future).await {
         Ok(_) => Ok(()),
         Err(_) => Err(anyhow::anyhow!("Timeout waiting for controld connection")),
+    }
+}
+
+#[cfg(test)]
+mod version_check_progress_tests {
+    use super::{UpdateExecution, VersionCheckProgress};
+    use std::time::Duration;
+    use tokio::sync::mpsc;
+    use tokio::time::timeout;
+
+    #[test]
+    fn tv_progress_only_for_blocking_execution() {
+        assert!(VersionCheckProgress::uses_tv_progress(
+            UpdateExecution::Blocking
+        ));
+        assert!(!VersionCheckProgress::uses_tv_progress(
+            UpdateExecution::NonBlocking
+        ));
+    }
+
+    /// Mirrors `check_and_update_system`: ephemeral `Sender` clones must not outlive `finish`,
+    /// or the progress receiver task never sees the channel close.
+    #[tokio::test]
+    async fn progress_receiver_exits_after_all_senders_dropped() {
+        let (tx, mut rx) = mpsc::channel::<(u32, u32)>(16);
+        let per_updater_call = tx.clone();
+        drop(per_updater_call);
+
+        let receiver_task = tokio::spawn(async move {
+            while rx.recv().await.is_some() {}
+        });
+
+        drop(tx);
+        timeout(Duration::from_secs(1), receiver_task)
+            .await
+            .expect("receiver should finish within 1s")
+            .expect("receiver task join");
     }
 }
 

--- a/components/feral-setupd/src/main.rs
+++ b/components/feral-setupd/src/main.rs
@@ -682,6 +682,9 @@ mod callbacks {
             return;
         }
 
+        // Snapshot before the version check overwrites `page` with transient progress copy.
+        let prior_page = app_state.page.lock().await.clone();
+
         // Use Available mode for user-triggered updates (check for any newer version)
         // Use Blocking execution since D-Bus callback runs in a spawned task anyway
         let result = super::check_and_update_system(
@@ -691,11 +694,14 @@ mod callbacks {
             super::UpdateExecution::Blocking,
         )
         .await;
-        match super::available_system_update_follow_up(&result) {
-            super::AvailableSystemUpdateFollowUp::ReturnToWebApp => {
-                // Already on the latest build: leave the transient progress screen without
-                // showing extra TV copy (user stays on / returns to the bundled web app).
+        match super::available_system_update_follow_up(&result, &prior_page) {
+            super::AvailableSystemUpdateFollowUp::RestoreWebApp => {
                 let _ = show_webapp(app_state, chromium).await;
+            }
+            super::AvailableSystemUpdateFollowUp::RestorePriorPage => {
+                if let Err(e) = super::restore_prior_page(app_state, chromium, prior_page).await {
+                    eprintln!("MAIN: Failed to restore TV page after no-update check: {e:#?}");
+                }
             }
             super::AvailableSystemUpdateFollowUp::LogFailure => {
                 eprintln!("MAIN: System update failed: {result:#?}");
@@ -1086,8 +1092,10 @@ pub enum UpdateCheckResult {
 /// Follow-up after `check_and_update_system(UpdateMode::Available, …)` in the D-Bus path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AvailableSystemUpdateFollowUp {
-    /// Optional check found no newer build; leave the transient progress route quietly.
-    ReturnToWebApp,
+    /// No newer build while the user was already on the bundled web app.
+    RestoreWebApp,
+    /// No newer build; re-show the setup/recovery/message surface from before the check.
+    RestorePriorPage,
     /// Blocking orchestration failed (CDP navigate, updater start, etc.).
     LogFailure,
     /// Core already drove TV/updater (update started, reflash, classified fetch error).
@@ -1096,9 +1104,14 @@ enum AvailableSystemUpdateFollowUp {
 
 fn available_system_update_follow_up(
     result: &Result<UpdateCheckResult>,
+    prior_page: &Page,
 ) -> AvailableSystemUpdateFollowUp {
     match result {
-        Ok(UpdateCheckResult::NoUpdateNeeded) => AvailableSystemUpdateFollowUp::ReturnToWebApp,
+        Ok(UpdateCheckResult::NoUpdateNeeded) => match prior_page {
+            Page::WebApp(_) => AvailableSystemUpdateFollowUp::RestoreWebApp,
+            Page::None(_) | Page::SystemUpgrade(_) => AvailableSystemUpdateFollowUp::NoOp,
+            _ => AvailableSystemUpdateFollowUp::RestorePriorPage,
+        },
         Err(_) => AvailableSystemUpdateFollowUp::LogFailure,
         Ok(_) => AvailableSystemUpdateFollowUp::NoOp,
     }
@@ -1323,6 +1336,57 @@ impl VersionCheckProgress {
     }
 }
 
+/// Re-show the TV surface that was active before an optional version check replaced it
+/// with transient progress copy. Called from the D-Bus `system_update` no-update path only.
+async fn restore_prior_page(
+    app_state: &Arc<AppState>,
+    chrome: &Arc<Cdp>,
+    prior: Page,
+) -> Result<()> {
+    match prior {
+        Page::WebApp(_) => show_webapp(app_state, chrome).await,
+        Page::QRCode(_) => show_qrcode(app_state, chrome).await,
+        Page::Message(_, text) => show_message(chrome, app_state, &text).await,
+        Page::FactoryReset(_) => show_factory_reset(chrome, app_state).await,
+        Page::ReflashingRequired(_, message) => {
+            restore_reflashing_page(app_state, chrome, &message).await
+        }
+        Page::SystemUpgrade(_) | Page::None(_) => Ok(()),
+    }
+}
+
+async fn restore_reflashing_page(
+    app_state: &Arc<AppState>,
+    chrome: &Arc<Cdp>,
+    fallback_message: &str,
+) -> Result<()> {
+    if let Ok(Some(flashing_guide)) = updater::flashing_guide_url().await {
+        let current_version = app_state.current_version.clone();
+        let latest_version = updater::latest_version().await.unwrap_or_else(|e| {
+            eprintln!("MAIN: latest_version for reflashing restore: {e:#?}");
+            "Unknown".to_string()
+        });
+        let min_upgradeable = updater::min_upgradeable_version()
+            .await
+            .unwrap_or_else(|e| {
+                eprintln!("MAIN: min_upgradeable_version for reflashing restore: {e:#?}");
+                None
+            })
+            .unwrap_or_else(|| "Unknown".to_string());
+        show_reflashing_qrcode(
+            app_state,
+            chrome,
+            &flashing_guide,
+            &current_version,
+            &latest_version,
+            &min_upgradeable,
+        )
+        .await
+    } else {
+        show_message(chrome, app_state, fallback_message).await
+    }
+}
+
 async fn show_webapp(app_state: &Arc<AppState>, chrome: &Arc<Cdp>) -> Result<()> {
     let mut page = app_state.page.lock().await;
 
@@ -1460,22 +1524,61 @@ mod version_check_progress_tests {
 #[cfg(test)]
 mod available_system_update_follow_up_tests {
     use super::{
-        AvailableSystemUpdateFollowUp, UpdateCheckResult, available_system_update_follow_up,
+        AvailableSystemUpdateFollowUp, Page, UpdateCheckResult, available_system_update_follow_up,
     };
     use anyhow::anyhow;
 
     #[test]
-    fn no_update_needed_returns_to_webapp() {
+    fn no_update_needed_after_webapp_restores_webapp() {
         assert_eq!(
-            available_system_update_follow_up(&Ok(UpdateCheckResult::NoUpdateNeeded)),
-            AvailableSystemUpdateFollowUp::ReturnToWebApp,
+            available_system_update_follow_up(
+                &Ok(UpdateCheckResult::NoUpdateNeeded),
+                &Page::WebApp(0),
+            ),
+            AvailableSystemUpdateFollowUp::RestoreWebApp,
+        );
+    }
+
+    #[test]
+    fn no_update_needed_after_qrcode_restores_prior_page() {
+        assert_eq!(
+            available_system_update_follow_up(
+                &Ok(UpdateCheckResult::NoUpdateNeeded),
+                &Page::QRCode(0),
+            ),
+            AvailableSystemUpdateFollowUp::RestorePriorPage,
+        );
+    }
+
+    #[test]
+    fn no_update_needed_after_message_restores_prior_page() {
+        assert_eq!(
+            available_system_update_follow_up(
+                &Ok(UpdateCheckResult::NoUpdateNeeded),
+                &Page::Message(0, "Welcome".to_string()),
+            ),
+            AvailableSystemUpdateFollowUp::RestorePriorPage,
+        );
+    }
+
+    #[test]
+    fn no_update_needed_with_unknown_prior_page_is_no_op() {
+        assert_eq!(
+            available_system_update_follow_up(
+                &Ok(UpdateCheckResult::NoUpdateNeeded),
+                &Page::None(0),
+            ),
+            AvailableSystemUpdateFollowUp::NoOp,
         );
     }
 
     #[test]
     fn update_started_is_no_op_for_dbus_follow_up() {
         assert_eq!(
-            available_system_update_follow_up(&Ok(UpdateCheckResult::UpdateStarted)),
+            available_system_update_follow_up(
+                &Ok(UpdateCheckResult::UpdateStarted),
+                &Page::WebApp(0),
+            ),
             AvailableSystemUpdateFollowUp::NoOp,
         );
     }
@@ -1483,7 +1586,10 @@ mod available_system_update_follow_up_tests {
     #[test]
     fn too_old_to_upgrade_is_no_op_for_dbus_follow_up() {
         assert_eq!(
-            available_system_update_follow_up(&Ok(UpdateCheckResult::TooOldToUpgrade)),
+            available_system_update_follow_up(
+                &Ok(UpdateCheckResult::TooOldToUpgrade),
+                &Page::WebApp(0),
+            ),
             AvailableSystemUpdateFollowUp::NoOp,
         );
     }
@@ -1491,7 +1597,10 @@ mod available_system_update_follow_up_tests {
     #[test]
     fn version_check_failed_is_no_op_for_dbus_follow_up() {
         assert_eq!(
-            available_system_update_follow_up(&Ok(UpdateCheckResult::VersionCheckFailed)),
+            available_system_update_follow_up(
+                &Ok(UpdateCheckResult::VersionCheckFailed),
+                &Page::WebApp(0),
+            ),
             AvailableSystemUpdateFollowUp::NoOp,
         );
     }
@@ -1499,7 +1608,10 @@ mod available_system_update_follow_up_tests {
     #[test]
     fn orchestration_error_is_logged_only() {
         assert_eq!(
-            available_system_update_follow_up(&Err(anyhow!("cdp navigate failed"))),
+            available_system_update_follow_up(
+                &Err(anyhow!("cdp navigate failed")),
+                &Page::WebApp(0),
+            ),
             AvailableSystemUpdateFollowUp::LogFailure,
         );
     }

--- a/components/feral-setupd/src/main.rs
+++ b/components/feral-setupd/src/main.rs
@@ -696,10 +696,17 @@ mod callbacks {
         .await;
         match super::available_system_update_follow_up(&result, &prior_page) {
             super::AvailableSystemUpdateFollowUp::RestoreWebApp => {
-                let _ = show_webapp(app_state, chromium).await;
+                if let Err(e) =
+                    super::restore_webapp_after_no_update_check(app_state, chromium).await
+                {
+                    eprintln!("MAIN: Failed to restore webapp after no-update check: {e:#?}");
+                }
             }
             super::AvailableSystemUpdateFollowUp::RestorePriorPage => {
-                if let Err(e) = super::restore_prior_page(app_state, chromium, prior_page).await {
+                if let Err(e) =
+                    super::restore_prior_page_after_no_update_check(app_state, chromium, prior_page)
+                        .await
+                {
                     eprintln!("MAIN: Failed to restore TV page after no-update check: {e:#?}");
                 }
             }
@@ -1229,9 +1236,7 @@ async fn check_and_update_system(
     // Check if update is needed based on mode
     let needs_update = match mode {
         UpdateMode::Required => updater::is_update_required(progress.as_updater_progress()).await,
-        UpdateMode::Available => {
-            updater::is_update_available(progress.as_updater_progress()).await
-        }
+        UpdateMode::Available => updater::is_update_available(progress.as_updater_progress()).await,
     };
 
     progress.finish().await;
@@ -1336,26 +1341,168 @@ impl VersionCheckProgress {
     }
 }
 
-/// Re-show the TV surface that was active before an optional version check replaced it
-/// with transient progress copy. Called from the D-Bus `system_update` no-update path only.
-async fn restore_prior_page(
+/// True when `page` is still the transient copy shown during distributor HTTP retries.
+fn is_version_check_progress_page(page: &Page) -> bool {
+    matches!(
+        page,
+        Page::Message(_, text) if text.as_str() == constant::VERSION_CHECK_PROGRESS_TV_MSG
+    )
+}
+
+/// Commit `new_page` only when the current page is still the transient version-check progress
+/// copy. Used for the "already on webapp" fast path where no navigation is needed.
+async fn try_commit_page_if_still_progress(page: &Mutex<Page>, new_page: Page) -> bool {
+    let mut current = page.lock().await;
+    if !is_version_check_progress_page(&current) {
+        return false;
+    }
+    *current = new_page;
+    true
+}
+
+/// Navigate to `url` and commit `new_page`, but only when the current page is still the
+/// transient version-check progress copy. The page lock is held across the entire
+/// navigate+commit sequence so that a concurrent `show_*` call that holds the same lock
+/// for its own navigate+commit will be seen atomically: whichever path acquires the lock
+/// first wins, and the loser either finds the page changed (restore → skip) or
+/// unconditionally commits its own state (show_* → overwrite).
+///
+/// Invariant: all `show_*` functions that can race with this path must also hold the page
+/// lock during navigate. Violating this allows a concurrent navigate to slip onto the screen
+/// between our lock check and our navigate, producing a visual/state divergence.
+async fn navigate_and_commit_if_still_progress(
+    page: &Mutex<Page>,
+    chrome: &Arc<Cdp>,
+    url: &str,
+    new_page: Page,
+) -> Result<bool> {
+    let mut current = page.lock().await;
+    if !is_version_check_progress_page(&current) {
+        return Ok(false);
+    }
+    chrome
+        .navigate(url)
+        .await
+        .with_context(|| format!("navigating to {url}"))?;
+    *current = new_page;
+    Ok(true)
+}
+
+async fn restore_webapp_after_no_update_check(
+    app_state: &Arc<AppState>,
+    chrome: &Arc<Cdp>,
+) -> Result<()> {
+    // Best-effort early exit to avoid unnecessary I/O. The real guard is inside
+    // `try_commit_page_if_still_progress` / `navigate_and_commit_if_still_progress`
+    // which hold the page lock for the entire check+write (or check+navigate+write).
+    if !is_version_check_progress_page(&app_state.page.lock().await) {
+        println!("MAIN: skip webapp restore after no-update check; page changed during check");
+        return Ok(());
+    }
+
+    let webapp_url = constant::WEBAPP_URL;
+    let current_url = chrome.get_current_url().await?;
+    if current_url.starts_with(webapp_url) {
+        // Already on webapp — just commit state, no navigate needed.
+        if !try_commit_page_if_still_progress(&app_state.page, Page::WebApp(unix_s())).await {
+            println!("MAIN: skip webapp restore after no-update check; page changed during check");
+        }
+        return Ok(());
+    }
+
+    // Sleep outside the lock so a concurrent show_* that already holds the lock
+    // for its own navigate+commit is not blocked by us sleeping.
+    time::sleep(Duration::from_millis(constant::WIFI_WEBAPP_DELAY)).await;
+
+    if !navigate_and_commit_if_still_progress(
+        &app_state.page,
+        chrome,
+        webapp_url,
+        Page::WebApp(unix_s()),
+    )
+    .await?
+    {
+        println!("MAIN: skip webapp restore after no-update check; page changed during check");
+    } else {
+        println!("MAIN: Navigated to {webapp_url}");
+    }
+    Ok(())
+}
+
+async fn restore_prior_page_after_no_update_check(
     app_state: &Arc<AppState>,
     chrome: &Arc<Cdp>,
     prior: Page,
 ) -> Result<()> {
     match prior {
-        Page::WebApp(_) => show_webapp(app_state, chrome).await,
-        Page::QRCode(_) => show_qrcode(app_state, chrome).await,
-        Page::Message(_, text) => show_message(chrome, app_state, &text).await,
-        Page::FactoryReset(_) => show_factory_reset(chrome, app_state).await,
+        Page::WebApp(_) => restore_webapp_after_no_update_check(app_state, chrome).await,
+        Page::QRCode(_) => {
+            let qrcode_url = build_qrcode_url(app_state);
+            if !navigate_and_commit_if_still_progress(
+                &app_state.page,
+                chrome,
+                &qrcode_url,
+                Page::QRCode(unix_s()),
+            )
+            .await?
+            {
+                println!(
+                    "MAIN: skip prior-page restore after no-update check; page changed during check"
+                );
+            } else {
+                println!("MAIN: Navigated to {qrcode_url}");
+            }
+            Ok(())
+        }
+        Page::Message(_, text) => {
+            let encoded = urlencoding::encode(&text);
+            let message_url = format!("{}{}", constant::MSG_URL_PREFIX, encoded);
+            if !navigate_and_commit_if_still_progress(
+                &app_state.page,
+                chrome,
+                &message_url,
+                Page::Message(unix_s(), text),
+            )
+            .await?
+            {
+                println!(
+                    "MAIN: skip prior-page restore after no-update check; page changed during check"
+                );
+            } else {
+                println!("MAIN: Navigated to {message_url}");
+            }
+            Ok(())
+        }
+        Page::FactoryReset(_) => {
+            let message_url = format!(
+                "{}{}",
+                constant::MSG_URL_PREFIX,
+                constant::FACTORY_RESET_MSG
+            );
+            if !navigate_and_commit_if_still_progress(
+                &app_state.page,
+                chrome,
+                &message_url,
+                Page::FactoryReset(unix_s()),
+            )
+            .await?
+            {
+                println!(
+                    "MAIN: skip prior-page restore after no-update check; page changed during check"
+                );
+            } else {
+                println!("MAIN: Navigated to {message_url}");
+            }
+            Ok(())
+        }
         Page::ReflashingRequired(_, message) => {
-            restore_reflashing_page(app_state, chrome, &message).await
+            restore_reflashing_page_after_no_update(app_state, chrome, &message).await
         }
         Page::SystemUpgrade(_) | Page::None(_) => Ok(()),
     }
 }
 
-async fn restore_reflashing_page(
+async fn restore_reflashing_page_after_no_update(
     app_state: &Arc<AppState>,
     chrome: &Arc<Cdp>,
     fallback_message: &str,
@@ -1373,18 +1520,49 @@ async fn restore_reflashing_page(
                 None
             })
             .unwrap_or_else(|| "Unknown".to_string());
-        show_reflashing_qrcode(
-            app_state,
+
+        let message = format!(
+            "We've moved too far ahead for this version to catch up. Your FF1 is too far behind to auto-upgrade. Current version: {current_version} Latest version: {latest_version} Minimum upgradeable version: {min_upgradeable}. Scan the code above for step-by-step reflashing instructions, or contact us for help. support@feralfile.com"
+        );
+        let qrcode_url = format!(
+            "{}&qr_content={}&message={}",
+            constant::QRCODE_URL_PREFIX,
+            urlencoding::encode(&flashing_guide),
+            urlencoding::encode(&message)
+        );
+
+        if !navigate_and_commit_if_still_progress(
+            &app_state.page,
             chrome,
-            &flashing_guide,
-            &current_version,
-            &latest_version,
-            &min_upgradeable,
+            &qrcode_url,
+            Page::ReflashingRequired(unix_s(), message),
         )
-        .await
-    } else {
-        show_message(chrome, app_state, fallback_message).await
+        .await?
+        {
+            println!(
+                "MAIN: skip prior-page restore after no-update check; page changed during check"
+            );
+        } else {
+            println!("MAIN: Navigated to reflashing QR code: {qrcode_url}");
+        }
+        return Ok(());
     }
+
+    let encoded = urlencoding::encode(fallback_message);
+    let message_url = format!("{}{}", constant::MSG_URL_PREFIX, encoded);
+    if !navigate_and_commit_if_still_progress(
+        &app_state.page,
+        chrome,
+        &message_url,
+        Page::Message(unix_s(), fallback_message.to_string()),
+    )
+    .await?
+    {
+        println!("MAIN: skip prior-page restore after no-update check; page changed during check");
+    } else {
+        println!("MAIN: Navigated to {message_url}");
+    }
+    Ok(())
 }
 
 async fn show_webapp(app_state: &Arc<AppState>, chrome: &Arc<Cdp>) -> Result<()> {
@@ -1415,13 +1593,15 @@ async fn show_webapp(app_state: &Arc<AppState>, chrome: &Arc<Cdp>) -> Result<()>
 async fn show_message(chrome: &Arc<Cdp>, app_state: &Arc<AppState>, message: &str) -> Result<()> {
     let encoded = urlencoding::encode(message);
     let message_url = format!("{}{}", constant::MSG_URL_PREFIX, encoded);
+    // Hold the page lock across navigate+commit so the no-update restore path, which also
+    // holds the lock for its navigate_and_commit_if_still_progress call, sees an atomic
+    // boundary: whichever path acquires the lock first wins, preventing visual/state divergence.
+    let mut page = app_state.page.lock().await;
     chrome
         .navigate(&message_url)
         .await
         .with_context(|| format!("navigating to {message_url}"))?;
     println!("MAIN: Navigated to {message_url}");
-
-    let mut page = app_state.page.lock().await;
     *page = Page::Message(unix_s(), message.to_string());
     Ok(())
 }
@@ -1432,13 +1612,12 @@ async fn show_system_upgrade(
     message: &str,
 ) -> Result<()> {
     let message_url = format!("{}{}", constant::MSG_URL_PREFIX, message);
+    let mut page = app_state.page.lock().await;
     chrome
         .navigate(&message_url)
         .await
         .with_context(|| format!("navigating to {message_url}"))?;
     println!("MAIN: Navigated to {message_url}");
-
-    let mut page = app_state.page.lock().await;
     *page = Page::SystemUpgrade(unix_s());
     Ok(())
 }
@@ -1449,13 +1628,12 @@ async fn show_factory_reset(chrome: &Arc<Cdp>, app_state: &Arc<AppState>) -> Res
         constant::MSG_URL_PREFIX,
         constant::FACTORY_RESET_MSG
     );
+    let mut page = app_state.page.lock().await;
     chrome
         .navigate(&message_url)
         .await
         .with_context(|| format!("navigating to {message_url}"))?;
     println!("MAIN: Navigated to {message_url}");
-
-    let mut page = app_state.page.lock().await;
     *page = Page::FactoryReset(unix_s());
     Ok(())
 }
@@ -1509,15 +1687,90 @@ mod version_check_progress_tests {
         let per_updater_call = tx.clone();
         drop(per_updater_call);
 
-        let receiver_task = tokio::spawn(async move {
-            while rx.recv().await.is_some() {}
-        });
+        let receiver_task = tokio::spawn(async move { while rx.recv().await.is_some() {} });
 
         drop(tx);
         timeout(Duration::from_secs(1), receiver_task)
             .await
             .expect("receiver should finish within 1s")
             .expect("receiver task join");
+    }
+}
+
+#[cfg(test)]
+mod version_check_progress_page_tests {
+    use super::{Page, is_version_check_progress_page, try_commit_page_if_still_progress};
+    use crate::constant;
+    use tokio::sync::Mutex;
+
+    #[test]
+    fn progress_page_matches_version_check_copy() {
+        assert!(is_version_check_progress_page(&Page::Message(
+            0,
+            constant::VERSION_CHECK_PROGRESS_TV_MSG.to_string(),
+        )));
+    }
+
+    #[test]
+    fn other_pages_are_not_version_check_progress() {
+        assert!(!is_version_check_progress_page(&Page::QRCode(0)));
+        assert!(!is_version_check_progress_page(&Page::WebApp(0)));
+        assert!(!is_version_check_progress_page(&Page::FactoryReset(0)));
+        assert!(!is_version_check_progress_page(&Page::Message(
+            0,
+            "Welcome".to_string(),
+        )));
+    }
+
+    /// If a concurrent show_* path (BLE, factory-reset) has already written a real page,
+    /// the restore commit is rejected. `navigate_and_commit_if_still_progress` contains
+    /// the same guard; this tests the underlying primitive it delegates to.
+    #[tokio::test]
+    async fn commit_skips_when_page_is_no_longer_progress() {
+        let page = Mutex::new(Page::FactoryReset(0));
+        assert!(
+            !try_commit_page_if_still_progress(&page, Page::QRCode(1)).await,
+            "must not overwrite a non-progress page"
+        );
+        assert!(matches!(*page.lock().await, Page::FactoryReset(0)));
+    }
+
+    #[tokio::test]
+    async fn commit_succeeds_when_still_on_progress() {
+        let page = Mutex::new(Page::Message(
+            0,
+            constant::VERSION_CHECK_PROGRESS_TV_MSG.to_string(),
+        ));
+        assert!(
+            try_commit_page_if_still_progress(&page, Page::QRCode(1)).await,
+            "must commit when page is still the progress copy"
+        );
+        assert!(matches!(*page.lock().await, Page::QRCode(1)));
+    }
+
+    /// Verifies the invariant that `navigate_and_commit_if_still_progress` requires: all
+    /// show_* functions that can race with the restore path also hold the page lock during
+    /// navigate+commit, so their page writes are visible to the restore's lock check.
+    /// (The full navigate race is integration-level and requires a mock CDP to test end-to-end.)
+    #[tokio::test]
+    async fn concurrent_commit_while_holding_lock_is_seen_by_restore_check() {
+        let page = Mutex::new(Page::Message(
+            0,
+            constant::VERSION_CHECK_PROGRESS_TV_MSG.to_string(),
+        ));
+
+        // Simulate a show_factory_reset that acquired the lock, navigated, and committed.
+        {
+            let mut guard = page.lock().await;
+            *guard = Page::FactoryReset(0);
+        }
+
+        // Restore path then tries to commit — must see FactoryReset and skip.
+        assert!(
+            !try_commit_page_if_still_progress(&page, Page::QRCode(1)).await,
+            "restore must not overwrite a page committed by a concurrent show_*"
+        );
+        assert!(matches!(*page.lock().await, Page::FactoryReset(0)));
     }
 }
 

--- a/components/feral-setupd/src/main.rs
+++ b/components/feral-setupd/src/main.rs
@@ -1099,7 +1099,7 @@ async fn check_and_update_system(
 ) -> Result<UpdateCheckResult> {
     // TV progress while HTTP retries run inside `fetch_remote_version` (sender dropped before
     // the final classified failure copy so the last screen is stable).
-    let (prog_tx, prog_rx) = mpsc::channel::<(u32, u32)>(16);
+    let (prog_tx, mut prog_rx) = mpsc::channel::<(u32, u32)>(16);
     let progress_task = {
         let chrome = chrome.clone();
         let app_state = app_state.clone();

--- a/components/feral-setupd/src/main.rs
+++ b/components/feral-setupd/src/main.rs
@@ -24,7 +24,7 @@ use std::time::Instant;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::signal::unix::{SignalKind, signal as unix_signal};
 use tokio::{
-    sync::Mutex,
+    sync::{Mutex, mpsc},
     task,
     time::{self, Duration},
 };
@@ -1031,7 +1031,10 @@ async fn on_startup_with_internet(app_state: Arc<AppState>, chrome: Arc<Cdp>) ->
 }
 
 async fn update(app_state: Arc<AppState>, chrome: Arc<Cdp>) -> Result<()> {
-    let latest_version = updater::latest_version().await.unwrap_or_default();
+    let latest_version = updater::latest_version().await.unwrap_or_else(|e| {
+        eprintln!("MAIN: latest_version for update banner: {e:#?}");
+        "Unknown".to_string()
+    });
     let base_msg = format!("{} {}", &constant::UPDATING_MSG_PREFIX, latest_version);
     let default_subtext = constant::UPDATING_MSG_SUBTEXT;
     let _ = show_system_upgrade(
@@ -1094,20 +1097,48 @@ async fn check_and_update_system(
     mode: UpdateMode,
     execution: UpdateExecution,
 ) -> Result<UpdateCheckResult> {
+    // TV progress while HTTP retries run inside `fetch_remote_version` (sender dropped before
+    // the final classified failure copy so the last screen is stable).
+    let (prog_tx, prog_rx) = mpsc::channel::<(u32, u32)>(16);
+    let progress_task = {
+        let chrome = chrome.clone();
+        let app_state = app_state.clone();
+        tokio::spawn(async move {
+            while let Some((_attempt, _max)) = prog_rx.recv().await {
+                if let Err(e) =
+                    show_message(&chrome, &app_state, constant::VERSION_CHECK_PROGRESS_TV_MSG).await
+                {
+                    eprintln!("MAIN: version-check progress UI failed: {e:#?}");
+                }
+            }
+        })
+    };
+
     // Always fetch the remote version first to ensure we have the latest info
-    updater::refresh_remote_version().await;
+    updater::refresh_remote_version(Some(prog_tx.clone())).await;
     // First check if device is too old to auto-upgrade
-    match updater::is_too_old_to_upgrade().await {
+    match updater::is_too_old_to_upgrade(Some(prog_tx.clone())).await {
         Ok(true) => {
+            // Finish progress UI before reflashing screens; otherwise queued progress
+            // navigations can overwrite the QR/message we are about to show.
+            drop(prog_tx);
+            if let Err(join_err) = progress_task.await {
+                eprintln!("MAIN: version-check progress task ended with: {join_err:#?}");
+            }
+
             // Device is too old, show reflashing QR code
             if let Ok(Some(flashing_guide)) = updater::flashing_guide_url().await {
                 let current_version = app_state.current_version.clone();
-                let latest_version = updater::latest_version()
-                    .await
-                    .unwrap_or_else(|_| "Unknown".to_string());
+                let latest_version = updater::latest_version().await.unwrap_or_else(|e| {
+                    eprintln!("MAIN: latest_version for reflashing banner: {e:#?}");
+                    "Unknown".to_string()
+                });
                 let min_upgradeable = updater::min_upgradeable_version()
                     .await
-                    .unwrap_or(None)
+                    .unwrap_or_else(|e| {
+                        eprintln!("MAIN: min_upgradeable_version for reflashing banner: {e:#?}");
+                        None
+                    })
                     .unwrap_or_else(|| "Unknown".to_string());
 
                 match execution {
@@ -1173,9 +1204,14 @@ async fn check_and_update_system(
 
     // Check if update is needed based on mode
     let needs_update = match mode {
-        UpdateMode::Required => updater::is_update_required().await,
-        UpdateMode::Available => updater::is_update_available().await,
+        UpdateMode::Required => updater::is_update_required(Some(prog_tx.clone())).await,
+        UpdateMode::Available => updater::is_update_available(Some(prog_tx.clone())).await,
     };
+
+    drop(prog_tx);
+    if let Err(join_err) = progress_task.await {
+        eprintln!("MAIN: version-check progress task ended with: {join_err:#?}");
+    }
 
     match needs_update {
         Ok(true) => {
@@ -1195,28 +1231,20 @@ async fn check_and_update_system(
             }
             Ok(UpdateCheckResult::NoUpdateNeeded)
         }
-        Err(e) => {
-            eprintln!("MAIN: Error checking for update: {e:#?}");
+        Err(ve) => {
+            eprintln!("MAIN: Error checking for update: {ve:#?}");
+            let tv_msg = ve.kind().tv_message();
             match execution {
                 UpdateExecution::Blocking => {
-                    show_message(
-                        chrome,
-                        app_state,
-                        constant::UPDATER_FAILED_TO_CHECK_VERSION_MSG,
-                    )
-                    .await?;
+                    show_message(chrome, app_state, tv_msg).await?;
                 }
                 UpdateExecution::NonBlocking => {
+                    let tv_msg = tv_msg.to_string();
                     task::spawn({
                         let app_state = app_state.clone();
                         let chrome = chrome.clone();
                         async move {
-                            let _ = show_message(
-                                &chrome,
-                                &app_state,
-                                constant::UPDATER_FAILED_TO_CHECK_VERSION_MSG,
-                            )
-                            .await;
+                            let _ = show_message(&chrome, &app_state, &tv_msg).await;
                         }
                     });
                 }
@@ -1252,7 +1280,8 @@ async fn show_webapp(app_state: &Arc<AppState>, chrome: &Arc<Cdp>) -> Result<()>
 }
 
 async fn show_message(chrome: &Arc<Cdp>, app_state: &Arc<AppState>, message: &str) -> Result<()> {
-    let message_url = format!("{}{}", constant::MSG_URL_PREFIX, message);
+    let encoded = urlencoding::encode(message);
+    let message_url = format!("{}{}", constant::MSG_URL_PREFIX, encoded);
     chrome
         .navigate(&message_url)
         .await

--- a/components/feral-setupd/src/main.rs
+++ b/components/feral-setupd/src/main.rs
@@ -19,7 +19,7 @@ use ble::{Ble, BleCallbacks};
 use cdp::Cdp;
 use connectivity::Connectivity;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Instant;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::signal::unix::{SignalKind, signal as unix_signal};
@@ -69,6 +69,7 @@ enum Page {
     FactoryReset(i64),
     WebApp(i64),
     ReflashingRequired(i64, String),
+    VersionCheckProgress(u64, i64),
 }
 
 impl Page {
@@ -92,6 +93,11 @@ struct AppState {
     state_store: PersistentState,
     internet: Connectivity,
     page: Mutex<Page>,
+    // Serializes CDP-driven UI commits so a newer transition can finish before
+    // version-check progress or restore logic tries to write the screen again.
+    ui_transition: Mutex<()>,
+    // Monotonically increasing owner for version-check UI sessions.
+    version_check_session: AtomicU64,
 
     // This is the flag to indicate whether we should automatically redirect to webapp
     // when internet is available.
@@ -206,6 +212,8 @@ async fn init_app_state(ble_service: &Arc<Ble>) -> Result<Arc<AppState>> {
         state_store: PersistentState::new(constant::CACHE_FILEPATH)?,
         internet: Connectivity::spawn().await,
         page: Mutex::new(Page::None(unix_s())),
+        ui_transition: Mutex::new(()),
+        version_check_session: AtomicU64::new(0),
         auto_proceed: AtomicBool::new(false),
     });
     sentry::configure_scope(|scope| {
@@ -420,16 +428,28 @@ async fn internet_setup_successfully_cb(
     )
     .await
     {
-        Ok(UpdateCheckResult::TooOldToUpgrade) => {
+        Ok(UpdateCheckOutcome {
+            result: UpdateCheckResult::TooOldToUpgrade,
+            ..
+        }) => {
             return Err(ble::BleStatus::VersionTooOld);
         }
-        Ok(UpdateCheckResult::UpdateStarted) => {
+        Ok(UpdateCheckOutcome {
+            result: UpdateCheckResult::UpdateStarted,
+            ..
+        }) => {
             return Err(ble::BleStatus::DeviceUpdating);
         }
-        Ok(UpdateCheckResult::VersionCheckFailed) => {
+        Ok(UpdateCheckOutcome {
+            result: UpdateCheckResult::VersionCheckFailed,
+            ..
+        }) => {
             return Err(ble::BleStatus::VersionCheckFailed);
         }
-        Ok(UpdateCheckResult::NoUpdateNeeded) => {} // Continue with normal flow
+        Ok(UpdateCheckOutcome {
+            result: UpdateCheckResult::NoUpdateNeeded,
+            ..
+        }) => {} // Continue with normal flow
         Err(e) => {
             // This shouldn't happen with NonBlocking, but handle it anyway
             eprintln!("MAIN: Error during update check: {e:#?}");
@@ -694,12 +714,35 @@ mod callbacks {
             super::UpdateExecution::Blocking,
         )
         .await;
-        match super::available_system_update_follow_up(&result, &prior_page) {
+        let current_page = app_state.page.lock().await.clone();
+        match super::available_system_update_follow_up(&result, &prior_page, &current_page) {
             super::AvailableSystemUpdateFollowUp::RestoreWebApp => {
-                let _ = show_webapp(app_state, chromium).await;
+                if let Err(e) = super::restore_prior_page(
+                    app_state,
+                    chromium,
+                    prior_page,
+                    match &result {
+                        Ok(outcome) => outcome.session_id,
+                        Err(_) => 0,
+                    },
+                )
+                .await
+                {
+                    eprintln!("MAIN: Failed to restore webapp after no-update check: {e:#?}");
+                }
             }
             super::AvailableSystemUpdateFollowUp::RestorePriorPage => {
-                if let Err(e) = super::restore_prior_page(app_state, chromium, prior_page).await {
+                if let Err(e) = super::restore_prior_page(
+                    app_state,
+                    chromium,
+                    prior_page,
+                    match &result {
+                        Ok(outcome) => outcome.session_id,
+                        Err(_) => 0,
+                    },
+                )
+                .await
+                {
                     eprintln!("MAIN: Failed to restore TV page after no-update check: {e:#?}");
                 }
             }
@@ -926,6 +969,11 @@ async fn wait_for_shutdown() {
 }
 
 async fn show_qrcode(app_state: &Arc<AppState>, chrome: &Arc<Cdp>) -> Result<()> {
+    let _transition = app_state.ui_transition.lock().await;
+    show_qrcode_locked(app_state, chrome).await
+}
+
+async fn show_qrcode_locked(app_state: &Arc<AppState>, chrome: &Arc<Cdp>) -> Result<()> {
     let qrcode_url = build_qrcode_url(app_state);
     // QRCode url is dynamically built
     // So we always navigate to make sure the url is correct
@@ -940,6 +988,26 @@ async fn show_qrcode(app_state: &Arc<AppState>, chrome: &Arc<Cdp>) -> Result<()>
 }
 
 async fn show_reflashing_qrcode(
+    app_state: &Arc<AppState>,
+    chrome: &Arc<Cdp>,
+    flashing_guide_url: &str,
+    current_version: &str,
+    latest_version: &str,
+    min_upgradeable_version: &str,
+) -> Result<()> {
+    let _transition = app_state.ui_transition.lock().await;
+    show_reflashing_qrcode_locked(
+        app_state,
+        chrome,
+        flashing_guide_url,
+        current_version,
+        latest_version,
+        min_upgradeable_version,
+    )
+    .await
+}
+
+async fn show_reflashing_qrcode_locked(
     app_state: &Arc<AppState>,
     chrome: &Arc<Cdp>,
     flashing_guide_url: &str,
@@ -1000,15 +1068,24 @@ async fn on_startup_with_internet(app_state: Arc<AppState>, chrome: Arc<Cdp>) ->
     )
     .await?
     {
-        UpdateCheckResult::TooOldToUpgrade | UpdateCheckResult::UpdateStarted => {
+        UpdateCheckOutcome {
+            result: UpdateCheckResult::TooOldToUpgrade | UpdateCheckResult::UpdateStarted,
+            ..
+        } => {
             // Device is either too old or updating; don't proceed with normal flow
             return Ok(());
         }
-        UpdateCheckResult::VersionCheckFailed => {
+        UpdateCheckOutcome {
+            result: UpdateCheckResult::VersionCheckFailed,
+            ..
+        } => {
             // Error was already shown to user, but we treat this as a hard failure
             return Err(anyhow::anyhow!("Failed to check version information"));
         }
-        UpdateCheckResult::NoUpdateNeeded => {} // Continue with normal flow
+        UpdateCheckOutcome {
+            result: UpdateCheckResult::NoUpdateNeeded,
+            ..
+        } => {} // Continue with normal flow
     }
 
     // No update, ensure we have a topic ID if possible and then
@@ -1089,6 +1166,12 @@ pub enum UpdateCheckResult {
     VersionCheckFailed,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct UpdateCheckOutcome {
+    result: UpdateCheckResult,
+    session_id: u64,
+}
+
 /// Follow-up after `check_and_update_system(UpdateMode::Available, …)` in the D-Bus path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AvailableSystemUpdateFollowUp {
@@ -1103,18 +1186,36 @@ enum AvailableSystemUpdateFollowUp {
 }
 
 fn available_system_update_follow_up(
-    result: &Result<UpdateCheckResult>,
+    result: &Result<UpdateCheckOutcome>,
     prior_page: &Page,
+    current_page: &Page,
 ) -> AvailableSystemUpdateFollowUp {
     match result {
-        Ok(UpdateCheckResult::NoUpdateNeeded) => match prior_page {
-            Page::WebApp(_) => AvailableSystemUpdateFollowUp::RestoreWebApp,
-            Page::None(_) | Page::SystemUpgrade(_) => AvailableSystemUpdateFollowUp::NoOp,
-            _ => AvailableSystemUpdateFollowUp::RestorePriorPage,
-        },
+        Ok(outcome) if outcome.result == UpdateCheckResult::NoUpdateNeeded => {
+            if !is_version_check_progress_page_for(current_page, outcome.session_id) {
+                return AvailableSystemUpdateFollowUp::NoOp;
+            }
+
+            match prior_page {
+                Page::WebApp(_) => AvailableSystemUpdateFollowUp::RestoreWebApp,
+                Page::None(_) | Page::SystemUpgrade(_) => AvailableSystemUpdateFollowUp::NoOp,
+                _ => AvailableSystemUpdateFollowUp::RestorePriorPage,
+            }
+        }
         Err(_) => AvailableSystemUpdateFollowUp::LogFailure,
         Ok(_) => AvailableSystemUpdateFollowUp::NoOp,
     }
+}
+
+fn is_version_check_progress_page_for(page: &Page, session_id: u64) -> bool {
+    matches!(page, Page::VersionCheckProgress(current_session, _) if *current_session == session_id)
+}
+
+fn next_version_check_session(app_state: &Arc<AppState>) -> u64 {
+    app_state
+        .version_check_session
+        .fetch_add(1, Ordering::Relaxed)
+        + 1
 }
 
 /// Shared system update logic that checks version status and optionally triggers an update.
@@ -1138,8 +1239,13 @@ async fn check_and_update_system(
     chrome: &Arc<Cdp>,
     mode: UpdateMode,
     execution: UpdateExecution,
-) -> Result<UpdateCheckResult> {
-    let progress = VersionCheckProgress::start(execution, chrome.clone(), app_state.clone());
+) -> Result<UpdateCheckOutcome> {
+    let session_id = next_version_check_session(app_state);
+    let progress =
+        VersionCheckProgress::start(execution, chrome.clone(), app_state.clone(), session_id);
+    if VersionCheckProgress::uses_tv_progress(execution) {
+        set_version_check_progress_page(app_state, session_id).await;
+    }
 
     // Always fetch the remote version first to ensure we have the latest info
     updater::refresh_remote_version(progress.as_updater_progress()).await;
@@ -1217,7 +1323,10 @@ async fn check_and_update_system(
                     }
                 }
             }
-            return Ok(UpdateCheckResult::TooOldToUpgrade);
+            return Ok(UpdateCheckOutcome {
+                result: UpdateCheckResult::TooOldToUpgrade,
+                session_id,
+            });
         }
         Ok(false) => {} // Device can be upgraded, continue
         Err(e) => {
@@ -1229,9 +1338,7 @@ async fn check_and_update_system(
     // Check if update is needed based on mode
     let needs_update = match mode {
         UpdateMode::Required => updater::is_update_required(progress.as_updater_progress()).await,
-        UpdateMode::Available => {
-            updater::is_update_available(progress.as_updater_progress()).await
-        }
+        UpdateMode::Available => updater::is_update_available(progress.as_updater_progress()).await,
     };
 
     progress.finish().await;
@@ -1246,13 +1353,19 @@ async fn check_and_update_system(
                     task::spawn(update(app_state.clone(), chrome.clone()));
                 }
             }
-            Ok(UpdateCheckResult::UpdateStarted)
+            Ok(UpdateCheckOutcome {
+                result: UpdateCheckResult::UpdateStarted,
+                session_id,
+            })
         }
         Ok(false) => {
             if mode == UpdateMode::Available {
                 println!("MAIN: System update requested but no update available");
             }
-            Ok(UpdateCheckResult::NoUpdateNeeded)
+            Ok(UpdateCheckOutcome {
+                result: UpdateCheckResult::NoUpdateNeeded,
+                session_id,
+            })
         }
         Err(ve) => {
             eprintln!("MAIN: Error checking for update: {ve:#?}");
@@ -1272,7 +1385,10 @@ async fn check_and_update_system(
                     });
                 }
             }
-            Ok(UpdateCheckResult::VersionCheckFailed)
+            Ok(UpdateCheckOutcome {
+                result: UpdateCheckResult::VersionCheckFailed,
+                session_id,
+            })
         }
     }
 }
@@ -1294,7 +1410,12 @@ impl VersionCheckProgress {
         matches!(execution, UpdateExecution::Blocking)
     }
 
-    fn start(execution: UpdateExecution, chrome: Arc<Cdp>, app_state: Arc<AppState>) -> Self {
+    fn start(
+        execution: UpdateExecution,
+        chrome: Arc<Cdp>,
+        app_state: Arc<AppState>,
+        session_id: u64,
+    ) -> Self {
         if !Self::uses_tv_progress(execution) {
             return Self {
                 tx: None,
@@ -1305,9 +1426,7 @@ impl VersionCheckProgress {
         let (prog_tx, mut prog_rx) = mpsc::channel::<(u32, u32)>(16);
         let progress_task = tokio::spawn(async move {
             while let Some((_attempt, _max)) = prog_rx.recv().await {
-                if let Err(e) =
-                    show_message(&chrome, &app_state, constant::VERSION_CHECK_PROGRESS_TV_MSG).await
-                {
+                if let Err(e) = show_version_check_progress(&chrome, &app_state, session_id).await {
                     eprintln!("MAIN: version-check progress UI failed: {e:#?}");
                 }
             }
@@ -1342,20 +1461,37 @@ async fn restore_prior_page(
     app_state: &Arc<AppState>,
     chrome: &Arc<Cdp>,
     prior: Page,
+    session_id: u64,
 ) -> Result<()> {
+    let _transition = app_state.ui_transition.lock().await;
+    let current_page = app_state.page.lock().await.clone();
+    if !is_version_check_progress_page_for(&current_page, session_id) {
+        return Ok(());
+    }
+
     match prior {
-        Page::WebApp(_) => show_webapp(app_state, chrome).await,
-        Page::QRCode(_) => show_qrcode(app_state, chrome).await,
-        Page::Message(_, text) => show_message(chrome, app_state, &text).await,
-        Page::FactoryReset(_) => show_factory_reset(chrome, app_state).await,
+        Page::WebApp(_) => show_webapp_locked(app_state, chrome).await,
+        Page::QRCode(_) => show_qrcode_locked(app_state, chrome).await,
+        Page::Message(_, text) => show_message_locked(chrome, app_state, &text).await,
+        Page::FactoryReset(_) => show_factory_reset_locked(chrome, app_state).await,
         Page::ReflashingRequired(_, message) => {
-            restore_reflashing_page(app_state, chrome, &message).await
+            restore_reflashing_page_locked(app_state, chrome, &message).await
         }
+        Page::VersionCheckProgress(_, _) => Ok(()),
         Page::SystemUpgrade(_) | Page::None(_) => Ok(()),
     }
 }
 
 async fn restore_reflashing_page(
+    app_state: &Arc<AppState>,
+    chrome: &Arc<Cdp>,
+    fallback_message: &str,
+) -> Result<()> {
+    let _transition = app_state.ui_transition.lock().await;
+    restore_reflashing_page_locked(app_state, chrome, fallback_message).await
+}
+
+async fn restore_reflashing_page_locked(
     app_state: &Arc<AppState>,
     chrome: &Arc<Cdp>,
     fallback_message: &str,
@@ -1373,7 +1509,7 @@ async fn restore_reflashing_page(
                 None
             })
             .unwrap_or_else(|| "Unknown".to_string());
-        show_reflashing_qrcode(
+        show_reflashing_qrcode_locked(
             app_state,
             chrome,
             &flashing_guide,
@@ -1383,11 +1519,16 @@ async fn restore_reflashing_page(
         )
         .await
     } else {
-        show_message(chrome, app_state, fallback_message).await
+        show_message_locked(chrome, app_state, fallback_message).await
     }
 }
 
 async fn show_webapp(app_state: &Arc<AppState>, chrome: &Arc<Cdp>) -> Result<()> {
+    let _transition = app_state.ui_transition.lock().await;
+    show_webapp_locked(app_state, chrome).await
+}
+
+async fn show_webapp_locked(app_state: &Arc<AppState>, chrome: &Arc<Cdp>) -> Result<()> {
     let mut page = app_state.page.lock().await;
 
     let webapp_url = constant::WEBAPP_URL;
@@ -1413,6 +1554,15 @@ async fn show_webapp(app_state: &Arc<AppState>, chrome: &Arc<Cdp>) -> Result<()>
 }
 
 async fn show_message(chrome: &Arc<Cdp>, app_state: &Arc<AppState>, message: &str) -> Result<()> {
+    let _transition = app_state.ui_transition.lock().await;
+    show_message_locked(chrome, app_state, message).await
+}
+
+async fn show_message_locked(
+    chrome: &Arc<Cdp>,
+    app_state: &Arc<AppState>,
+    message: &str,
+) -> Result<()> {
     let encoded = urlencoding::encode(message);
     let message_url = format!("{}{}", constant::MSG_URL_PREFIX, encoded);
     chrome
@@ -1426,7 +1576,61 @@ async fn show_message(chrome: &Arc<Cdp>, app_state: &Arc<AppState>, message: &st
     Ok(())
 }
 
+async fn set_version_check_progress_page(app_state: &Arc<AppState>, session_id: u64) {
+    let _transition = app_state.ui_transition.lock().await;
+    set_version_check_progress_page_locked(app_state, session_id).await;
+}
+
+async fn set_version_check_progress_page_locked(app_state: &Arc<AppState>, session_id: u64) {
+    let mut page = app_state.page.lock().await;
+    *page = Page::VersionCheckProgress(session_id, unix_s());
+}
+
+async fn show_version_check_progress(
+    chrome: &Arc<Cdp>,
+    app_state: &Arc<AppState>,
+    session_id: u64,
+) -> Result<()> {
+    let _transition = app_state.ui_transition.lock().await;
+    show_version_check_progress_locked(chrome, app_state, session_id).await
+}
+
+async fn show_version_check_progress_locked(
+    chrome: &Arc<Cdp>,
+    app_state: &Arc<AppState>,
+    session_id: u64,
+) -> Result<()> {
+    let current_page = app_state.page.lock().await.clone();
+    if !is_version_check_progress_page_for(&current_page, session_id) {
+        return Ok(());
+    }
+
+    let encoded = urlencoding::encode(constant::VERSION_CHECK_PROGRESS_TV_MSG);
+    let message_url = format!("{}{}", constant::MSG_URL_PREFIX, encoded);
+    chrome
+        .navigate(&message_url)
+        .await
+        .with_context(|| format!("navigating to {message_url}"))?;
+    println!("MAIN: Navigated to {message_url}");
+
+    let mut page = app_state.page.lock().await;
+    if matches!(*page, Page::VersionCheckProgress(current_session, _) if current_session == session_id)
+    {
+        *page = Page::VersionCheckProgress(session_id, unix_s());
+    }
+    Ok(())
+}
+
 async fn show_system_upgrade(
+    chrome: &Arc<Cdp>,
+    app_state: &Arc<AppState>,
+    message: &str,
+) -> Result<()> {
+    let _transition = app_state.ui_transition.lock().await;
+    show_system_upgrade_locked(chrome, app_state, message).await
+}
+
+async fn show_system_upgrade_locked(
     chrome: &Arc<Cdp>,
     app_state: &Arc<AppState>,
     message: &str,
@@ -1444,6 +1648,11 @@ async fn show_system_upgrade(
 }
 
 async fn show_factory_reset(chrome: &Arc<Cdp>, app_state: &Arc<AppState>) -> Result<()> {
+    let _transition = app_state.ui_transition.lock().await;
+    show_factory_reset_locked(chrome, app_state).await
+}
+
+async fn show_factory_reset_locked(chrome: &Arc<Cdp>, app_state: &Arc<AppState>) -> Result<()> {
     let message_url = format!(
         "{}{}",
         constant::MSG_URL_PREFIX,
@@ -1509,9 +1718,7 @@ mod version_check_progress_tests {
         let per_updater_call = tx.clone();
         drop(per_updater_call);
 
-        let receiver_task = tokio::spawn(async move {
-            while rx.recv().await.is_some() {}
-        });
+        let receiver_task = tokio::spawn(async move { while rx.recv().await.is_some() {} });
 
         drop(tx);
         timeout(Duration::from_secs(1), receiver_task)
@@ -1524,7 +1731,8 @@ mod version_check_progress_tests {
 #[cfg(test)]
 mod available_system_update_follow_up_tests {
     use super::{
-        AvailableSystemUpdateFollowUp, Page, UpdateCheckResult, available_system_update_follow_up,
+        AvailableSystemUpdateFollowUp, Page, UpdateCheckOutcome, UpdateCheckResult,
+        available_system_update_follow_up,
     };
     use anyhow::anyhow;
 
@@ -1532,8 +1740,12 @@ mod available_system_update_follow_up_tests {
     fn no_update_needed_after_webapp_restores_webapp() {
         assert_eq!(
             available_system_update_follow_up(
-                &Ok(UpdateCheckResult::NoUpdateNeeded),
+                &Ok(UpdateCheckOutcome {
+                    result: UpdateCheckResult::NoUpdateNeeded,
+                    session_id: 1,
+                }),
                 &Page::WebApp(0),
+                &Page::VersionCheckProgress(1, 1),
             ),
             AvailableSystemUpdateFollowUp::RestoreWebApp,
         );
@@ -1543,8 +1755,12 @@ mod available_system_update_follow_up_tests {
     fn no_update_needed_after_qrcode_restores_prior_page() {
         assert_eq!(
             available_system_update_follow_up(
-                &Ok(UpdateCheckResult::NoUpdateNeeded),
+                &Ok(UpdateCheckOutcome {
+                    result: UpdateCheckResult::NoUpdateNeeded,
+                    session_id: 1,
+                }),
                 &Page::QRCode(0),
+                &Page::VersionCheckProgress(1, 1),
             ),
             AvailableSystemUpdateFollowUp::RestorePriorPage,
         );
@@ -1554,8 +1770,12 @@ mod available_system_update_follow_up_tests {
     fn no_update_needed_after_message_restores_prior_page() {
         assert_eq!(
             available_system_update_follow_up(
-                &Ok(UpdateCheckResult::NoUpdateNeeded),
+                &Ok(UpdateCheckOutcome {
+                    result: UpdateCheckResult::NoUpdateNeeded,
+                    session_id: 1,
+                }),
                 &Page::Message(0, "Welcome".to_string()),
+                &Page::VersionCheckProgress(1, 1),
             ),
             AvailableSystemUpdateFollowUp::RestorePriorPage,
         );
@@ -1565,8 +1785,27 @@ mod available_system_update_follow_up_tests {
     fn no_update_needed_with_unknown_prior_page_is_no_op() {
         assert_eq!(
             available_system_update_follow_up(
-                &Ok(UpdateCheckResult::NoUpdateNeeded),
+                &Ok(UpdateCheckOutcome {
+                    result: UpdateCheckResult::NoUpdateNeeded,
+                    session_id: 1,
+                }),
                 &Page::None(0),
+                &Page::VersionCheckProgress(1, 1),
+            ),
+            AvailableSystemUpdateFollowUp::NoOp,
+        );
+    }
+
+    #[test]
+    fn no_update_needed_skips_restore_when_current_page_changed() {
+        assert_eq!(
+            available_system_update_follow_up(
+                &Ok(UpdateCheckOutcome {
+                    result: UpdateCheckResult::NoUpdateNeeded,
+                    session_id: 1,
+                }),
+                &Page::WebApp(0),
+                &Page::VersionCheckProgress(2, 1),
             ),
             AvailableSystemUpdateFollowUp::NoOp,
         );
@@ -1576,8 +1815,12 @@ mod available_system_update_follow_up_tests {
     fn update_started_is_no_op_for_dbus_follow_up() {
         assert_eq!(
             available_system_update_follow_up(
-                &Ok(UpdateCheckResult::UpdateStarted),
+                &Ok(UpdateCheckOutcome {
+                    result: UpdateCheckResult::UpdateStarted,
+                    session_id: 1,
+                }),
                 &Page::WebApp(0),
+                &Page::VersionCheckProgress(1, 1),
             ),
             AvailableSystemUpdateFollowUp::NoOp,
         );
@@ -1587,8 +1830,12 @@ mod available_system_update_follow_up_tests {
     fn too_old_to_upgrade_is_no_op_for_dbus_follow_up() {
         assert_eq!(
             available_system_update_follow_up(
-                &Ok(UpdateCheckResult::TooOldToUpgrade),
+                &Ok(UpdateCheckOutcome {
+                    result: UpdateCheckResult::TooOldToUpgrade,
+                    session_id: 1,
+                }),
                 &Page::WebApp(0),
+                &Page::VersionCheckProgress(1, 1),
             ),
             AvailableSystemUpdateFollowUp::NoOp,
         );
@@ -1598,8 +1845,12 @@ mod available_system_update_follow_up_tests {
     fn version_check_failed_is_no_op_for_dbus_follow_up() {
         assert_eq!(
             available_system_update_follow_up(
-                &Ok(UpdateCheckResult::VersionCheckFailed),
+                &Ok(UpdateCheckOutcome {
+                    result: UpdateCheckResult::VersionCheckFailed,
+                    session_id: 1,
+                }),
                 &Page::WebApp(0),
+                &Page::VersionCheckProgress(1, 1),
             ),
             AvailableSystemUpdateFollowUp::NoOp,
         );
@@ -1611,6 +1862,7 @@ mod available_system_update_follow_up_tests {
             available_system_update_follow_up(
                 &Err(anyhow!("cdp navigate failed")),
                 &Page::WebApp(0),
+                &Page::VersionCheckProgress(1, 1),
             ),
             AvailableSystemUpdateFollowUp::LogFailure,
         );

--- a/components/feral-setupd/src/updater.rs
+++ b/components/feral-setupd/src/updater.rs
@@ -472,3 +472,73 @@ async fn fetch_remote_version_once(url: &str) -> Result<UpstreamVersion> {
 
     Ok(versions)
 }
+
+#[cfg(test)]
+mod classify_version_fetch_error_tests {
+    use super::{classify_version_fetch_error, VersionFetchFailureKind};
+    use anyhow::Context;
+
+    #[test]
+    fn http_status_line_5xx_is_server() {
+        let e = anyhow::anyhow!(
+            "HTTP 503 Service Unavailable from distributor at https://example.invalid: body"
+        );
+        assert_eq!(
+            classify_version_fetch_error(&e),
+            VersionFetchFailureKind::Server
+        );
+    }
+
+    #[test]
+    fn http_status_line_4xx_is_client() {
+        let e = anyhow::anyhow!(
+            "HTTP 404 Not Found from distributor at https://example.invalid: body"
+        );
+        assert_eq!(
+            classify_version_fetch_error(&e),
+            VersionFetchFailureKind::Client
+        );
+    }
+
+    #[test]
+    fn decoding_distributor_json_context_is_parse() {
+        let e = Err::<(), _>(anyhow::anyhow!("invalid JSON"))
+            .context("decoding distributor JSON")
+            .unwrap_err();
+        assert_eq!(
+            classify_version_fetch_error(&e),
+            VersionFetchFailureKind::Parse
+        );
+    }
+
+    #[test]
+    fn parsing_upstream_semver_context_is_parse() {
+        let e = Err::<(), _>(anyhow::anyhow!("not a semver"))
+            .context("parsing upstream semver")
+            .unwrap_err();
+        assert_eq!(
+            classify_version_fetch_error(&e),
+            VersionFetchFailureKind::Parse
+        );
+    }
+
+    #[test]
+    fn parsing_min_upgradeable_semver_context_is_parse() {
+        let e = Err::<(), _>(anyhow::anyhow!("bad"))
+            .context("parsing min_upgradeable_version semver")
+            .unwrap_err();
+        assert_eq!(
+            classify_version_fetch_error(&e),
+            VersionFetchFailureKind::Parse
+        );
+    }
+
+    #[test]
+    fn unrelated_message_is_unknown() {
+        let e = anyhow::anyhow!("something else entirely");
+        assert_eq!(
+            classify_version_fetch_error(&e),
+            VersionFetchFailureKind::Unknown
+        );
+    }
+}

--- a/components/feral-setupd/src/updater.rs
+++ b/components/feral-setupd/src/updater.rs
@@ -5,6 +5,7 @@ use rand::Rng;
 use regex::Regex;
 use semver::Version;
 use serde::Deserialize;
+use std::fmt;
 use std::{process::Stdio, sync::RwLock, time::Duration};
 use tokio::{
     fs,
@@ -19,11 +20,116 @@ use tokio::{
 // ---------- Cache ----------
 static REMOTE_VERSIONS: RwLock<Option<UpstreamVersion>> = RwLock::new(None);
 
+// ---------- Version fetch errors / progress ----------
+
+/// Notifies `(current_attempt, max_attempts)` **before** each HTTP attempt (1-based),
+/// so setup UI can refresh a generic “checking for updates” line while `fetch_remote_version` retries.
+pub type FetchProgressTx = mpsc::Sender<(u32, u32)>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VersionFetchFailureKind {
+    Network,
+    Server,
+    Client,
+    Parse,
+    Unknown,
+}
+
+impl VersionFetchFailureKind {
+    #[must_use]
+    pub fn tv_message(self) -> &'static str {
+        match self {
+            Self::Network => constant::VERSION_CHECK_FAILED_NETWORK_MSG,
+            Self::Server => constant::VERSION_CHECK_FAILED_SERVER_MSG,
+            Self::Client => constant::VERSION_CHECK_FAILED_CLIENT_MSG,
+            Self::Parse => constant::VERSION_CHECK_FAILED_PARSE_MSG,
+            Self::Unknown => constant::VERSION_CHECK_FAILED_UNKNOWN_MSG,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct VersionFetchError {
+    kind: VersionFetchFailureKind,
+    source: anyhow::Error,
+}
+
+impl VersionFetchError {
+    pub fn new(kind: VersionFetchFailureKind, source: anyhow::Error) -> Self {
+        Self { kind, source }
+    }
+
+    #[must_use]
+    pub fn kind(&self) -> VersionFetchFailureKind {
+        self.kind
+    }
+}
+
+impl fmt::Display for VersionFetchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}: {}", self.kind, self.source)
+    }
+}
+
+impl std::error::Error for VersionFetchError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.source.as_ref())
+    }
+}
+
+fn classify_version_fetch_error(err: &anyhow::Error) -> VersionFetchFailureKind {
+    let full = err.to_string();
+    const HTTP_PREFIX: &str = "HTTP ";
+    if full.starts_with(HTTP_PREFIX) {
+        if let Some(rest) = full.strip_prefix(HTTP_PREFIX) {
+            if let Some(c) = rest.chars().next() {
+                if c == '4' {
+                    return VersionFetchFailureKind::Client;
+                }
+                if c == '5' {
+                    return VersionFetchFailureKind::Server;
+                }
+            }
+        }
+    }
+
+    for cause in err.chain() {
+        if let Some(re) = cause.downcast_ref::<reqwest::Error>() {
+            if re.is_decode() {
+                return VersionFetchFailureKind::Parse;
+            }
+            if let Some(status) = re.status() {
+                if status.is_server_error() {
+                    return VersionFetchFailureKind::Server;
+                }
+                if status.is_client_error() {
+                    return VersionFetchFailureKind::Client;
+                }
+            }
+            if re.is_timeout() || re.is_connect() {
+                return VersionFetchFailureKind::Network;
+            }
+        }
+    }
+
+    if full.contains("decoding distributor JSON")
+        || full.contains("parsing upstream semver")
+        || full.contains("parsing min_upgradeable_version semver")
+    {
+        return VersionFetchFailureKind::Parse;
+    }
+
+    VersionFetchFailureKind::Unknown
+}
+
 // ---------- Public API ----------
 
 /// Force refresh the cached remote version information.
-pub async fn refresh_remote_version() {
-    let _ = fetch_remote_version(true).await;
+///
+/// `progress` is used during setup to drive TV copy between HTTP attempts; periodic
+/// refresh passes `None` so we never spam the UI from the background task.
+pub async fn refresh_remote_version(progress: Option<FetchProgressTx>) {
+    let _ = fetch_remote_version(true, progress).await;
 }
 
 /// Spawn a background task that periodically refreshes the cached remote version.
@@ -34,37 +140,49 @@ pub fn spawn_remote_version_refresher() {
         loop {
             time::sleep(interval).await;
             println!("UPDATER: Periodic remote version refresh triggered");
-            refresh_remote_version().await;
+            refresh_remote_version(None).await;
         }
     });
 }
 
 /// Return `Ok(true)` when the running build is **below** the distributor's
 /// minimum supported version and an update is therefore required.
-pub async fn is_update_required() -> Result<bool> {
-    let current = cfg::current_version().await?;
-    let remote_versions = fetch_remote_version(false).await?;
+pub async fn is_update_required(
+    progress: Option<FetchProgressTx>,
+) -> std::result::Result<bool, VersionFetchError> {
+    let current = cfg::current_version()
+        .await
+        .map_err(|e| VersionFetchError::new(VersionFetchFailureKind::Unknown, e.into()))?;
+    let remote_versions = fetch_remote_version(false, progress).await?;
     Ok(current < remote_versions.min_runtime_version)
 }
 
 /// Return `Ok(true)` when a newer version is available from the distributor.
-pub async fn is_update_available() -> Result<bool> {
-    let current = cfg::current_version().await?;
-    let remote_versions = fetch_remote_version(false).await?;
+pub async fn is_update_available(
+    progress: Option<FetchProgressTx>,
+) -> std::result::Result<bool, VersionFetchError> {
+    let current = cfg::current_version()
+        .await
+        .map_err(|e| VersionFetchError::new(VersionFetchFailureKind::Unknown, e.into()))?;
+    let remote_versions = fetch_remote_version(false, progress).await?;
     Ok(current < remote_versions.latest_version)
 }
 
 /// Return the latest version from the remote server.
-pub async fn latest_version() -> Result<String> {
-    let remote_versions = fetch_remote_version(false).await?;
+pub async fn latest_version() -> std::result::Result<String, VersionFetchError> {
+    let remote_versions = fetch_remote_version(false, None).await?;
     Ok(remote_versions.latest_version.to_string())
 }
 
 /// Return `Ok(true)` when the running build is **below** the distributor's
 /// minimum upgradeable version, meaning the device needs to be reflashed.
-pub async fn is_too_old_to_upgrade() -> Result<bool> {
-    let current = cfg::current_version().await?;
-    let remote_versions = fetch_remote_version(false).await?;
+pub async fn is_too_old_to_upgrade(
+    progress: Option<FetchProgressTx>,
+) -> std::result::Result<bool, VersionFetchError> {
+    let current = cfg::current_version()
+        .await
+        .map_err(|e| VersionFetchError::new(VersionFetchFailureKind::Unknown, e.into()))?;
+    let remote_versions = fetch_remote_version(false, progress).await?;
 
     if let Some(min_upgradeable) = &remote_versions.min_upgradeable_version {
         Ok(current < *min_upgradeable)
@@ -74,14 +192,14 @@ pub async fn is_too_old_to_upgrade() -> Result<bool> {
 }
 
 /// Return the flashing guide URL from the remote server, if available.
-pub async fn flashing_guide_url() -> Result<Option<String>> {
-    let remote_versions = fetch_remote_version(false).await?;
+pub async fn flashing_guide_url() -> std::result::Result<Option<String>, VersionFetchError> {
+    let remote_versions = fetch_remote_version(false, None).await?;
     Ok(remote_versions.flashing_guide.clone())
 }
 
 /// Return the minimum upgradeable version from the remote server, if available.
-pub async fn min_upgradeable_version() -> Result<Option<String>> {
-    let remote_versions = fetch_remote_version(false).await?;
+pub async fn min_upgradeable_version() -> std::result::Result<Option<String>, VersionFetchError> {
+    let remote_versions = fetch_remote_version(false, None).await?;
     Ok(remote_versions
         .min_upgradeable_version
         .as_ref()
@@ -248,7 +366,10 @@ struct UpstreamVersion {
     latest_version: Version,
 }
 
-async fn fetch_remote_version(refresh: bool) -> Result<UpstreamVersion> {
+async fn fetch_remote_version(
+    refresh: bool,
+    progress: Option<FetchProgressTx>,
+) -> std::result::Result<UpstreamVersion, VersionFetchError> {
     // Check if we have a cached version
     if !refresh {
         let cache = REMOTE_VERSIONS.read().unwrap();
@@ -257,19 +378,34 @@ async fn fetch_remote_version(refresh: bool) -> Result<UpstreamVersion> {
         }
     }
 
+    let endpoint = cfg::endpoint()
+        .await
+        .map_err(|e| VersionFetchError::new(VersionFetchFailureKind::Unknown, e.into()))?;
+    let branch = cfg::branch()
+        .await
+        .map_err(|e| VersionFetchError::new(VersionFetchFailureKind::Unknown, e.into()))?;
     let url = format!(
         "{}{}{}",
-        cfg::endpoint().await?,
+        endpoint,
         constant::UPDATER_UPSTREAM_CONFIG_URL_SUFFIX,
-        cfg::branch().await?
+        branch
     );
 
     // Retry logic: attempt up to UPDATER_VERSION_CHECK_RETRIES times
     let max_retries = constant::UPDATER_VERSION_CHECK_RETRIES;
     let retry_delay = Duration::from_millis(constant::UPDATER_VERSION_CHECK_RETRY_DELAY);
-    let mut last_error: Option<anyhow::Error> = None;
+    let mut last_error: Option<VersionFetchError> = None;
 
     for attempt in 1..=max_retries {
+        if let Some(tx) = &progress {
+            if tx.send((attempt, max_retries)).await.is_err() {
+                // Receiver dropped (setup finished); keep fetching without UI updates.
+                eprintln!(
+                    "UPDATER: progress channel closed; continuing version fetch without TV updates"
+                );
+            }
+        }
+
         println!("UPDATER: Fetching version info from {url} (attempt {attempt}/{max_retries})");
 
         match fetch_remote_version_once(&url).await {
@@ -283,7 +419,8 @@ async fn fetch_remote_version(refresh: bool) -> Result<UpstreamVersion> {
             }
             Err(e) => {
                 eprintln!("UPDATER: Version check attempt {attempt}/{max_retries} failed: {e:#}");
-                last_error = Some(e);
+                let kind = classify_version_fetch_error(&e);
+                last_error = Some(VersionFetchError::new(kind, e));
 
                 // Don't sleep after the last attempt
                 if attempt < max_retries {
@@ -293,8 +430,12 @@ async fn fetch_remote_version(refresh: bool) -> Result<UpstreamVersion> {
         }
     }
 
-    Err(last_error
-        .unwrap_or_else(|| anyhow::anyhow!("Version check failed after {max_retries} attempts")))
+    Err(last_error.unwrap_or_else(|| {
+        VersionFetchError::new(
+            VersionFetchFailureKind::Unknown,
+            anyhow::anyhow!("Version check failed after {max_retries} attempts"),
+        )
+    }))
 }
 
 /// Single attempt to fetch remote version (no retry logic).

--- a/components/feral-setupd/src/updater.rs
+++ b/components/feral-setupd/src/updater.rs
@@ -475,7 +475,7 @@ async fn fetch_remote_version_once(url: &str) -> Result<UpstreamVersion> {
 
 #[cfg(test)]
 mod classify_version_fetch_error_tests {
-    use super::{classify_version_fetch_error, VersionFetchFailureKind};
+    use super::{VersionFetchFailureKind, classify_version_fetch_error};
     use anyhow::Context;
 
     #[test]
@@ -491,9 +491,8 @@ mod classify_version_fetch_error_tests {
 
     #[test]
     fn http_status_line_4xx_is_client() {
-        let e = anyhow::anyhow!(
-            "HTTP 404 Not Found from distributor at https://example.invalid: body"
-        );
+        let e =
+            anyhow::anyhow!("HTTP 404 Not Found from distributor at https://example.invalid: body");
         assert_eq!(
             classify_version_fetch_error(&e),
             VersionFetchFailureKind::Client

--- a/components/feral-setupd/src/updater.rs
+++ b/components/feral-setupd/src/updater.rs
@@ -152,7 +152,7 @@ pub async fn is_update_required(
 ) -> std::result::Result<bool, VersionFetchError> {
     let current = cfg::current_version()
         .await
-        .map_err(|e| VersionFetchError::new(VersionFetchFailureKind::Unknown, e.into()))?;
+        .map_err(|e| VersionFetchError::new(VersionFetchFailureKind::Unknown, e))?;
     let remote_versions = fetch_remote_version(false, progress).await?;
     Ok(current < remote_versions.min_runtime_version)
 }
@@ -163,7 +163,7 @@ pub async fn is_update_available(
 ) -> std::result::Result<bool, VersionFetchError> {
     let current = cfg::current_version()
         .await
-        .map_err(|e| VersionFetchError::new(VersionFetchFailureKind::Unknown, e.into()))?;
+        .map_err(|e| VersionFetchError::new(VersionFetchFailureKind::Unknown, e))?;
     let remote_versions = fetch_remote_version(false, progress).await?;
     Ok(current < remote_versions.latest_version)
 }
@@ -181,7 +181,7 @@ pub async fn is_too_old_to_upgrade(
 ) -> std::result::Result<bool, VersionFetchError> {
     let current = cfg::current_version()
         .await
-        .map_err(|e| VersionFetchError::new(VersionFetchFailureKind::Unknown, e.into()))?;
+        .map_err(|e| VersionFetchError::new(VersionFetchFailureKind::Unknown, e))?;
     let remote_versions = fetch_remote_version(false, progress).await?;
 
     if let Some(min_upgradeable) = &remote_versions.min_upgradeable_version {
@@ -380,10 +380,10 @@ async fn fetch_remote_version(
 
     let endpoint = cfg::endpoint()
         .await
-        .map_err(|e| VersionFetchError::new(VersionFetchFailureKind::Unknown, e.into()))?;
+        .map_err(|e| VersionFetchError::new(VersionFetchFailureKind::Unknown, e))?;
     let branch = cfg::branch()
         .await
-        .map_err(|e| VersionFetchError::new(VersionFetchFailureKind::Unknown, e.into()))?;
+        .map_err(|e| VersionFetchError::new(VersionFetchFailureKind::Unknown, e))?;
     let url = format!(
         "{}{}{}",
         endpoint,

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -253,7 +253,7 @@ The mobile app expects a BLE notification within a reasonable time after a write
 
 `feral-setupd` retries the remote version check up to `UPDATER_VERSION_CHECK_RETRIES` (3) times with a 2-second delay between retries before treating the check as failed.
 
-During `check_and_update_system`, each HTTP fetch attempt notifies a small progress channel so setup can navigate the TV to a short “checking for updates” line before the request runs. After retries are exhausted, the TV message is chosen from a coarse failure class (network vs HTTP 5xx vs HTTP 4xx vs parse/unexpected body vs unknown); BLE status code `6` (`BLE_ERR_CODE_VERSION_CHECK_FAILED`) is unchanged.
+During `check_and_update_system`, each HTTP fetch attempt notifies a small progress channel so setup can navigate the TV to a short “checking for updates” line before the request runs. When the subsequent required/available version comparison fails after those retries (the `is_update_required` / `is_update_available` error path), the TV message is chosen from a coarse failure class (network vs HTTP 5xx vs HTTP 4xx vs parse/unexpected body vs unknown); other branches may log and continue without that classified copy. BLE status code `6` (`BLE_ERR_CODE_VERSION_CHECK_FAILED`) is unchanged.
 
 ---
 

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -253,6 +253,8 @@ The mobile app expects a BLE notification within a reasonable time after a write
 
 `feral-setupd` retries the remote version check up to `UPDATER_VERSION_CHECK_RETRIES` (3) times with a 2-second delay between retries before treating the check as failed.
 
+During `check_and_update_system`, each HTTP fetch attempt notifies a small progress channel so setup can navigate the TV to a short “checking for updates” line before the request runs. After retries are exhausted, the TV message is chosen from a coarse failure class (network vs HTTP 5xx vs HTTP 4xx vs parse/unexpected body vs unknown); BLE status code `6` (`BLE_ERR_CODE_VERSION_CHECK_FAILED`) is unchanged.
+
 ---
 
 ## Protocol Invariants Agents Must Not Break


### PR DESCRIPTION
## Summary
- Show a short “checking for updates” line on the TV while distributor version metadata is fetched with HTTP retries during `check_and_update_system`, via an optional progress channel from `updater` (periodic refresh passes `None`).
- Classify version-fetch failures for differentiated TV copy; introduce `VersionFetchError` / `VersionFetchFailureKind`; URL-encode `show_message` query payloads.
- Add unit tests for `classify_version_fetch_error`; document in `AGENTS.md` and `docs/api-design.md`.
- Fix `mut prog_rx` for `mpsc::Receiver::recv` (E0596 on Rust 1.88 / edition 2024).

## Commits (vs `develop`)
- `feat(setupd): version-check TV progress and classified errors`
- `test(setupd): cover version-fetch error classification`
- `style(setupd): rustfmt classifier tests in updater`
- `fix(setupd): mut receiver for version-check progress channel`

## Test plan
- [ ] `make verify-setupd-lint` and `make verify-setupd-test` on Linux (or Docker) with `libdbus-1-dev`.
- [ ] Manual: unstable network during startup version check — progress line between retries; final message matches failure class.
- [ ] Confirm periodic remote version refresh does not drive the progress TV message.

Made with [Cursor](https://cursor.com)