### PR TITLE
fix: stabilize pairing QR screen

### DIFF
--- a/components/feral-setupd/src/main.rs
+++ b/components/feral-setupd/src/main.rs
@@ -39,7 +39,7 @@ fn unix_s() -> i64 {
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Page {
     None(i64),
-    QRCode(i64),
+    QRCode(i64, String),
     Message(i64, String),
     SystemUpgrade(i64),
     FactoryReset(i64),
@@ -50,7 +50,7 @@ impl Page {
     fn timestamp(&self) -> i64 {
         match self {
             Page::None(ts) => *ts,
-            Page::QRCode(ts) => *ts,
+            Page::QRCode(ts, _) => *ts,
             Page::Message(ts, _) => *ts,
             Page::SystemUpgrade(ts) => *ts,
             Page::FactoryReset(ts) => *ts,
@@ -61,11 +61,18 @@ impl Page {
     fn page_type(&self) -> &str {
         match self {
             Page::None(_) => "None",
-            Page::QRCode(_) => "QRCode",
+            Page::QRCode(_, _) => "QRCode",
             Page::Message(_, _) => "Message",
             Page::SystemUpgrade(_) => "SystemUpgrade",
             Page::FactoryReset(_) => "FactoryReset",
             Page::WebApp(_) => "WebApp",
+        }
+    }
+
+    fn qrcode_url(&self) -> Option<&str> {
+        match self {
+            Page::QRCode(_, url) => Some(url.as_str()),
+            _ => None,
         }
     }
 }
@@ -409,15 +416,20 @@ async fn wait_for_shutdown() {
 
 async fn show_qrcode(app_state: &Arc<AppState>, chrome: &Arc<Cdp>) -> Result<()> {
     let qrcode_url = build_qrcode_url(app_state).await;
-    // QRCode url is dynamically built
-    // So we always navigate to make sure the url is correct
     let mut page = app_state.page.lock().await;
+    // Replaying the same QR signal should not force Chromium to rebuild the
+    // screen. That churn keeps the renderer and GPU hot even though the
+    // visible state did not change.
+    if page.qrcode_url() == Some(qrcode_url.as_str()) {
+        return Ok(());
+    }
+
     chrome
         .navigate(&qrcode_url)
         .await
         .with_context(|| format!("navigating to {qrcode_url}"))?;
     println!("MAIN: Navigated to {qrcode_url}");
-    *page = Page::QRCode(unix_s());
+    *page = Page::QRCode(unix_s(), qrcode_url);
     Ok(())
 }
 
@@ -543,4 +555,20 @@ async fn show_factory_reset(chrome: &Arc<Cdp>, app_state: &Arc<AppState>) -> Res
     let mut page = app_state.page.lock().await;
     *page = Page::FactoryReset(unix_s());
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Page;
+
+    #[test]
+    fn page_tracks_qrcode_url() {
+        assert_eq!(
+            Page::QRCode(1, "file:///qr?a=1".to_string()).qrcode_url(),
+            Some("file:///qr?a=1")
+        );
+        assert_eq!(Page::WebApp(1).qrcode_url(), None);
+        assert_eq!(Page::Message(1, "hello".to_string()).qrcode_url(), None);
+        assert_eq!(Page::None(1).qrcode_url(), None);
+    }
 }


### PR DESCRIPTION
## Summary
- Skip re-navigating the QR screen when the exact same pairing URL is already visible.
- Preserve QR refreshes when the underlying QR payload changes, so the screen still updates when it should.
- This reduces Chromium reload churn that was keeping GPU usage pinned during pairing.

## Issue
Fixes #134

## Test plan
- `cargo fmt --all -- --check` in `components/feral-setupd`
- `cargo check --all-targets --all-features` in `components/feral-setupd` (blocked on host by missing system `dbus-1.pc`)
- `cargo test --all-targets --all-features` in `components/feral-setupd` (blocked on host by missing system `dbus-1.pc`)
- `ReadLints` on `components/feral-setupd/src/main.rs`

Made with [Cursor](https://cursor.com)