### PR TITLE
feat(controld): FF1-side command-storm protection in feral-controld (#208)

### DIFF
--- a/components/feral-controld/commandrouter/errors.go
+++ b/components/feral-controld/commandrouter/errors.go
@@ -1,0 +1,29 @@
+package commandrouter
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/feral-file/ffos-user/components/feral-controld/commands"
+)
+
+// RateLimitedError is returned by the command storm gate when a command is
+// rejected to protect the device from flooding. Callers (the LAN hub and the
+// relayer mediator) detect it to report a legible failure instead of treating
+// it as an internal error.
+type RateLimitedError struct {
+	// Command is the command type that was rejected.
+	Command commands.Type
+	// Reason describes which guard rejected the command (rate, concurrency).
+	Reason string
+}
+
+func (e *RateLimitedError) Error() string {
+	return fmt.Sprintf("command %q rejected by storm protection: %s", e.Command, e.Reason)
+}
+
+// IsRateLimited reports whether err is (or wraps) a RateLimitedError.
+func IsRateLimited(err error) bool {
+	var rle *RateLimitedError
+	return errors.As(err, &rle)
+}

--- a/components/feral-controld/commandrouter/gate.go
+++ b/components/feral-controld/commandrouter/gate.go
@@ -132,8 +132,11 @@ type gate struct {
 	cfg      GateConfig
 	limiters *limiterSet
 	sem      *semaphore.Weighted
-	flight   singleflight.Group
-	logger   *zap.Logger
+	// maxConcurrent mirrors cfg.MaxConcurrent (the semaphore size) so admit can
+	// clamp a command's weight to the budget. Only meaningful when sem != nil.
+	maxConcurrent int64
+	flight        singleflight.Group
+	logger        *zap.Logger
 }
 
 // NewGate wraps inner with command-storm protection. When cfg.Enabled is false
@@ -147,11 +150,12 @@ func NewGate(inner Handler, cfg GateConfig, logger *zap.Logger) Handler {
 		sem = semaphore.NewWeighted(cfg.MaxConcurrent)
 	}
 	return &gate{
-		inner:    inner,
-		cfg:      cfg,
-		limiters: newLimiterSet(cfg.now),
-		sem:      sem,
-		logger:   logger,
+		inner:         inner,
+		cfg:           cfg,
+		limiters:      newLimiterSet(cfg.now),
+		sem:           sem,
+		maxConcurrent: cfg.MaxConcurrent,
+		logger:        logger,
 	}
 }
 
@@ -213,6 +217,17 @@ func (g *gate) admit(ctx context.Context, command commands.Command, p Policy, ke
 		weight := p.Weight
 		if weight < 1 {
 			weight = 1
+		}
+		// Clamp the weight to the total budget. A configured MaxConcurrent
+		// smaller than a policy's Weight (e.g. a hand-tuned maxConcurrent of
+		// 1-3 against the default heavy Weight of 4) would otherwise make
+		// TryAcquire(weight) fail forever — even on a fully idle device —
+		// silently bricking that command type. Capping means a heavy command
+		// instead reserves the whole budget while in flight: throttled against
+		// other work, but never permanently rejected. maxConcurrent is >= 1
+		// here because sem is only non-nil when MaxConcurrent > 0.
+		if weight > g.maxConcurrent {
+			weight = g.maxConcurrent
 		}
 		if !g.sem.TryAcquire(weight) {
 			g.logger.Warn("Command rejected: concurrency budget exhausted",

--- a/components/feral-controld/commandrouter/gate.go
+++ b/components/feral-controld/commandrouter/gate.go
@@ -1,0 +1,245 @@
+package commandrouter
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"time"
+
+	"go.uber.org/zap"
+	"golang.org/x/sync/semaphore"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/feral-file/ffos-user/components/feral-controld/commands"
+)
+
+// Policy describes how the storm gate protects a single command type.
+type Policy struct {
+	// Group is the limiter key. Command types that share a non-empty Group
+	// share one token bucket (e.g. all input gestures share an "input" budget).
+	// When empty, the command type string is used as its own key.
+	Group string
+	// Rate is the sustained token-bucket refill rate in tokens per second.
+	// A value <= 0 disables rate limiting for this policy.
+	Rate float64
+	// Burst is the token-bucket capacity (max commands accepted in a spike).
+	Burst int
+	// Weight is the cost charged against the global concurrency budget while
+	// the command is in flight. Heavier commands reserve more of the budget.
+	Weight int64
+	// Dedupe collapses identical in-flight commands (same type + arguments)
+	// into a single execution whose result is shared. Suitable for idempotent
+	// commands such as casting a playlist or polling status.
+	Dedupe bool
+}
+
+// GateConfig configures the command storm gate.
+type GateConfig struct {
+	// Enabled toggles the whole gate. When false, NewGate returns the inner
+	// handler unchanged.
+	Enabled bool
+	// MaxConcurrent is the global concurrency budget shared by all commands
+	// (sum of in-flight Policy.Weight). A value <= 0 disables the concurrency
+	// guard.
+	MaxConcurrent int64
+	// Policies maps a command type to its policy. Types absent from the map use
+	// Default.
+	Policies map[commands.Type]Policy
+	// Default applies to command types with no explicit policy.
+	Default Policy
+
+	// now is an injectable clock for deterministic tests; nil means time.Now.
+	now func() time.Time
+}
+
+// inputGroup is the shared limiter key for high-frequency pointer/keyboard
+// gestures: a legitimate drag emits many events, so they share one generous
+// budget rather than each type being throttled in isolation.
+const inputGroup = "input"
+
+// DefaultGateConfig returns a tuned, ready-to-use configuration. It is safe with
+// zero external configuration and errs toward never blocking legitimate use
+// while capping floods of high-cost or disruptive commands.
+func DefaultGateConfig() GateConfig {
+	disruptive := Policy{Rate: 0.2, Burst: 2, Weight: 1, Dedupe: true} // ~1 per 5s
+	heavy := Policy{Rate: 1, Burst: 3, Weight: 4, Dedupe: true}        // casting / uploads
+	query := Policy{Rate: 5, Burst: 10, Weight: 1, Dedupe: true}       // status polls
+	input := Policy{Group: inputGroup, Rate: 50, Burst: 100, Weight: 1}
+	// slowWrite covers state-changing writes that shell out and are physically
+	// disruptive (DDC brightness/contrast/power), so they get a heavier weight
+	// than a cheap query but are not throttled as hard as a reboot.
+	slowWrite := Policy{Rate: 2, Burst: 5, Weight: 2}
+	// userAction covers latency-sensitive, user-initiated power toggles. They
+	// must not reject normal repeated taps, and the executor already coalesces
+	// sleep/wake bursts to the latest state, so the gate only needs a loose
+	// flood cap here rather than the disruptive 1-per-5s limit.
+	userAction := Policy{Rate: 2, Burst: 5, Weight: 1}
+
+	policies := map[commands.Type]Policy{
+		// Disruptive / system-level: tightly limited, deduped.
+		commands.CMD_REBOOT:             disruptive,
+		commands.CMD_SHUTDOWN:           disruptive,
+		commands.CMD_FACTORY_RESET:      disruptive,
+		commands.CMD_UPDATE_TO_LATEST:   disruptive,
+		commands.CMD_SET_SLEEP_SCHEDULE: disruptive,
+		commands.CMD_SET_SLEEP_MODE:     disruptive,
+		commands.CMD_SCREEN_ROTATION:    disruptive,
+
+		// User-initiated power toggles: loosely capped (executor coalesces).
+		commands.CMD_SLEEP_NOW: userAction,
+		commands.CMD_WAKE_NOW:  userAction,
+
+		// Heavy: the externally reachable cast path and other costly work.
+		commands.CMD_DISPLAY_PLAYLIST:         heavy,
+		commands.CMD_DISPLAY_DEFAULT_PLAYLIST: heavy,
+		commands.CMD_REFRESH_ARTWORK:          heavy,
+		commands.CMD_UPLOAD_LOGS:              heavy,
+		commands.CMD_SSH_ACCESS:               heavy,
+
+		// Slow, disruptive panel writes (DDC, incl. power): moderate + heavier.
+		commands.CMD_DDC_PANEL_CONTROL: slowWrite,
+
+		// Cheap queries: deduped so a poll storm collapses to one execution.
+		commands.CMD_DEVICE_STATUS:    query,
+		commands.CMD_PROFILE:          query,
+		commands.CMD_DDC_PANEL_STATUS: query,
+
+		// High-frequency input events: shared generous budget.
+		commands.CMD_KEYBOARD_EVENT:             input,
+		commands.CMD_MOUSE_DRAG_EVENT:           input,
+		commands.CMD_MOUSE_TAP_EVENT:            input,
+		commands.CMD_MOUSE_DOUBLE_TAP_EVENT:     input,
+		commands.CMD_MOUSE_LONG_PRESS_EVENT:     input,
+		commands.CMD_MOUSE_CLICK_AND_DRAG_EVENT: input,
+		commands.CMD_ZOOM_GESTURE:               input,
+	}
+
+	return GateConfig{
+		Enabled:       true,
+		MaxConcurrent: 16,
+		Policies:      policies,
+		// Anything unlisted (toggles, volume, panel control, connect, pairing):
+		// generous but bounded.
+		Default: Policy{Rate: 10, Burst: 20, Weight: 1},
+	}
+}
+
+// gate is a Handler decorator that enforces command-storm protection on the
+// shared command path, covering both the LAN hub and relayer ingress.
+type gate struct {
+	inner    Handler
+	cfg      GateConfig
+	limiters *limiterSet
+	sem      *semaphore.Weighted
+	flight   singleflight.Group
+	logger   *zap.Logger
+}
+
+// NewGate wraps inner with command-storm protection. When cfg.Enabled is false
+// it returns inner unchanged.
+func NewGate(inner Handler, cfg GateConfig, logger *zap.Logger) Handler {
+	if !cfg.Enabled {
+		return inner
+	}
+	var sem *semaphore.Weighted
+	if cfg.MaxConcurrent > 0 {
+		sem = semaphore.NewWeighted(cfg.MaxConcurrent)
+	}
+	return &gate{
+		inner:    inner,
+		cfg:      cfg,
+		limiters: newLimiterSet(cfg.now),
+		sem:      sem,
+		logger:   logger,
+	}
+}
+
+// policyFor returns the policy and limiter key for a command type.
+func (g *gate) policyFor(t commands.Type) (Policy, string) {
+	p, ok := g.cfg.Policies[t]
+	if !ok {
+		p = g.cfg.Default
+	}
+	key := p.Group
+	if key == "" {
+		key = string(t)
+	}
+	return p, key
+}
+
+func (g *gate) Process(ctx context.Context, command commands.Command) (interface{}, error) {
+	// Empty-type commands are a no-op in the inner handler; pass straight
+	// through so the gate adds no surprising behavior.
+	if command.Type == "" {
+		return g.inner.Process(ctx, command)
+	}
+
+	p, key := g.policyFor(command.Type)
+
+	// Deduped commands collapse identical in-flight requests into one
+	// execution. Only the leader consumes rate/concurrency budget; followers
+	// share its result. Doing this before the rate check means a burst of
+	// identical casts costs a single token rather than being rejected.
+	//
+	// Followers share the leader's outcome, including its error: if the leader
+	// is rate-limited every follower sees RateLimitedError, and if the leader's
+	// underlying execution fails transiently (e.g. a cast backend error) the
+	// coalesced followers see that same failure rather than re-running. This is
+	// intended — only truly concurrent, byte-identical commands coalesce, the
+	// failure is legible to every caller, and any caller may simply retry.
+	if p.Dedupe {
+		flightKey := key + "\x00" + argsHash(command.Arguments)
+		res, err, _ := g.flight.Do(flightKey, func() (interface{}, error) {
+			return g.admit(ctx, command, p, key)
+		})
+		return res, err
+	}
+
+	return g.admit(ctx, command, p, key)
+}
+
+// admit applies the rate-limit and concurrency guards, then runs the command.
+func (g *gate) admit(ctx context.Context, command commands.Command, p Policy, key string) (interface{}, error) {
+	if !g.limiters.allow(key, p) {
+		g.logger.Warn("Command rejected: rate limit exceeded",
+			zap.String("command", command.Type.String()),
+			zap.String("limiterKey", key),
+		)
+		return nil, &RateLimitedError{Command: command.Type, Reason: "rate limit exceeded"}
+	}
+
+	if g.sem != nil {
+		weight := p.Weight
+		if weight < 1 {
+			weight = 1
+		}
+		if !g.sem.TryAcquire(weight) {
+			g.logger.Warn("Command rejected: concurrency budget exhausted",
+				zap.String("command", command.Type.String()),
+				zap.Int64("weight", weight),
+			)
+			return nil, &RateLimitedError{Command: command.Type, Reason: "concurrency budget exhausted"}
+		}
+		defer g.sem.Release(weight)
+	}
+
+	return g.inner.Process(ctx, command)
+}
+
+// argsHash returns a stable hash of command arguments for dedupe keying.
+// json.Marshal emits map keys in sorted order, so identical argument maps hash
+// identically regardless of Go's randomized map iteration order. Arguments that
+// cannot be marshaled fall back to an empty hash, which simply means such
+// commands dedupe by type alone — a safe conservative behavior.
+func argsHash(args map[string]any) string {
+	if len(args) == 0 {
+		return ""
+	}
+	encoded, err := json.Marshal(args)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(encoded)
+	return hex.EncodeToString(sum[:])
+}

--- a/components/feral-controld/commandrouter/gate.go
+++ b/components/feral-controld/commandrouter/gate.go
@@ -159,11 +159,29 @@ func NewGate(inner Handler, cfg GateConfig, logger *zap.Logger) Handler {
 	}
 }
 
-// policyFor returns the policy and limiter key for a command type.
+// defaultLimiterKey is the shared token-bucket key for every command type that
+// falls through to GateConfig.Default. Keying an unclassified type by its own
+// name would hand each attacker-chosen command string (unknown-1, unknown-2,
+// ...) a fresh burst budget AND allocate a token bucket per name without bound,
+// defeating storm protection for arbitrary CDP-forwarded names. A single fixed
+// key shares the default budget across all of them and caps limiter state at
+// one bucket. The leading NUL keeps it distinct from any real command type or
+// Group, which are printable identifiers.
+const defaultLimiterKey = "\x00default"
+
+// policyFor returns the policy and limiter key for a command type. Classified
+// types (present in cfg.Policies) key by their Group or their own name — a
+// fixed, bounded set. Unclassified types all share defaultLimiterKey so the
+// default budget is genuinely shared and limiter state stays bounded.
 func (g *gate) policyFor(t commands.Type) (Policy, string) {
 	p, ok := g.cfg.Policies[t]
 	if !ok {
 		p = g.cfg.Default
+		key := p.Group
+		if key == "" {
+			key = defaultLimiterKey
+		}
+		return p, key
 	}
 	key := p.Group
 	if key == "" {

--- a/components/feral-controld/commandrouter/gate_test.go
+++ b/components/feral-controld/commandrouter/gate_test.go
@@ -172,6 +172,59 @@ func TestGate_ConcurrencyBudgetExhausted(t *testing.T) {
 	assert.Equal(t, int64(2), inner.calls.Load(), "rejected command never reached inner")
 }
 
+// A configured MaxConcurrent smaller than a command's policy weight must not
+// permanently disable that command. Before the clamp, TryAcquire(weight) on a
+// too-small semaphore failed forever — even on an idle device — silently
+// bricking heavy commands (e.g. the default Weight 4 against a hand-tuned
+// maxConcurrent of 1-3). Regression for the command-storm review finding.
+func TestGate_WeightAboveBudgetStillAdmitsWhenIdle(t *testing.T) {
+	inner := &stubHandler{result: "ok"}
+	cfg := GateConfig{
+		Enabled:       true,
+		MaxConcurrent: 2, // below the policy weight of 4
+		Policies:      map[commands.Type]Policy{testCmd: {Rate: 0, Weight: 4}},
+		now:           frozenClock(),
+	}
+	g := NewGate(inner, cfg, zap.NewNop())
+
+	res, err := g.Process(context.Background(), commands.Command{Type: testCmd, Arguments: map[string]any{"i": 1}})
+	require.NoError(t, err, "a weight-above-budget command must still be admitted when idle")
+	assert.Equal(t, "ok", res)
+	assert.Equal(t, int64(1), inner.calls.Load())
+}
+
+// With the weight clamped to the budget, a heavy command reserves the whole
+// budget while in flight, so a concurrent heavy command is rejected (legibly
+// rate-limited) rather than silently never admitted.
+func TestGate_WeightAboveBudgetClampsToFullBudget(t *testing.T) {
+	inner := &stubHandler{
+		result:  "ok",
+		block:   make(chan struct{}),
+		entered: make(chan struct{}, 1),
+	}
+	cfg := GateConfig{
+		Enabled:       true,
+		MaxConcurrent: 2, // below the policy weight of 4
+		Policies:      map[commands.Type]Policy{testCmd: {Rate: 0, Weight: 4}},
+		now:           frozenClock(),
+	}
+	g := NewGate(inner, cfg, zap.NewNop())
+
+	// Hold one heavy command in flight; clamped to weight 2 it occupies the
+	// entire budget.
+	go func() {
+		_, _ = g.Process(context.Background(), commands.Command{Type: testCmd, Arguments: map[string]any{"i": 1}})
+	}()
+	<-inner.entered
+
+	_, err := g.Process(context.Background(), commands.Command{Type: testCmd, Arguments: map[string]any{"i": 2}})
+	require.Error(t, err)
+	assert.True(t, IsRateLimited(err), "second heavy command is rejected while the budget is reserved")
+
+	close(inner.block)
+	assert.Equal(t, int64(1), inner.calls.Load(), "rejected command never reached inner")
+}
+
 func TestArgsHash(t *testing.T) {
 	// Order-independent: maps built in different orders hash identically.
 	a := map[string]any{"a": 1.0, "b": "x", "c": true}

--- a/components/feral-controld/commandrouter/gate_test.go
+++ b/components/feral-controld/commandrouter/gate_test.go
@@ -1,0 +1,222 @@
+package commandrouter
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/feral-file/ffos-user/components/feral-controld/commands"
+)
+
+// stubHandler is a controllable inner Handler for gate tests.
+type stubHandler struct {
+	calls atomic.Int64
+	// block, when non-nil, is received from inside Process so tests can hold a
+	// command "in flight" to exercise concurrency/dedupe behavior.
+	block chan struct{}
+	// entered is signaled once per Process entry (after the call is counted).
+	entered chan struct{}
+	result  interface{}
+	err     error
+}
+
+func (s *stubHandler) Process(ctx context.Context, command commands.Command) (interface{}, error) {
+	s.calls.Add(1)
+	if s.entered != nil {
+		s.entered <- struct{}{}
+	}
+	if s.block != nil {
+		<-s.block
+	}
+	return s.result, s.err
+}
+
+const testCmd = commands.Type("test")
+
+func frozenClock() func() time.Time {
+	now := time.Unix(0, 0)
+	return func() time.Time { return now }
+}
+
+func TestNewGate_DisabledReturnsInner(t *testing.T) {
+	inner := &stubHandler{}
+	g := NewGate(inner, GateConfig{Enabled: false}, zap.NewNop())
+	assert.Same(t, inner, g, "disabled gate must return the inner handler unchanged")
+}
+
+func TestGate_EmptyTypePassesThrough(t *testing.T) {
+	inner := &stubHandler{result: "ok"}
+	cfg := GateConfig{Enabled: true, MaxConcurrent: 1, now: frozenClock()}
+	g := NewGate(inner, cfg, zap.NewNop())
+
+	_, err := g.Process(context.Background(), commands.Command{Type: ""})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), inner.calls.Load())
+}
+
+func TestGate_RateLimitRejectsBeyondBurst(t *testing.T) {
+	inner := &stubHandler{result: "ok"}
+	cfg := GateConfig{
+		Enabled:       true,
+		MaxConcurrent: 16,
+		Policies:      map[commands.Type]Policy{testCmd: {Rate: 1, Burst: 2, Weight: 1}},
+		now:           frozenClock(), // no refill during the test
+	}
+	g := NewGate(inner, cfg, zap.NewNop())
+
+	cmd := commands.Command{Type: testCmd, Arguments: map[string]any{"i": 1}}
+
+	_, err1 := g.Process(context.Background(), cmd)
+	_, err2 := g.Process(context.Background(), cmd)
+	_, err3 := g.Process(context.Background(), cmd)
+
+	require.NoError(t, err1)
+	require.NoError(t, err2)
+	require.Error(t, err3)
+	assert.True(t, IsRateLimited(err3), "third call rejected by rate limit")
+	assert.Equal(t, int64(2), inner.calls.Load(), "only burst-many commands reach inner")
+}
+
+func TestGate_DedupeCollapsesConcurrentIdentical(t *testing.T) {
+	inner := &stubHandler{
+		result:  "shared",
+		block:   make(chan struct{}),
+		entered: make(chan struct{}, 1),
+	}
+	cfg := GateConfig{
+		Enabled:       true,
+		MaxConcurrent: 16,
+		// Rate 0 => unlimited, so dedupe (not rate) is what's under test.
+		Policies: map[commands.Type]Policy{testCmd: {Rate: 0, Weight: 1, Dedupe: true}},
+		now:      frozenClock(),
+	}
+	g := NewGate(inner, cfg, zap.NewNop())
+	cmd := commands.Command{Type: testCmd, Arguments: map[string]any{"url": "feed"}}
+
+	const n = 8
+	var wg sync.WaitGroup
+	results := make([]interface{}, n)
+	errs := make([]error, n)
+
+	// Launch the leader first and wait until it is inside inner.Process so the
+	// followers join the same in-flight singleflight call.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		results[0], errs[0] = g.Process(context.Background(), cmd)
+	}()
+	<-inner.entered
+
+	for i := 1; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			results[idx], errs[idx] = g.Process(context.Background(), cmd)
+		}(i)
+	}
+
+	// Give followers a moment to coalesce onto the leader, then release.
+	time.Sleep(50 * time.Millisecond)
+	close(inner.block)
+	wg.Wait()
+
+	assert.Equal(t, int64(1), inner.calls.Load(), "identical in-flight commands collapse to one execution")
+	for i := 0; i < n; i++ {
+		require.NoError(t, errs[i])
+		assert.Equal(t, "shared", results[i])
+	}
+}
+
+func TestGate_ConcurrencyBudgetExhausted(t *testing.T) {
+	inner := &stubHandler{
+		result:  "ok",
+		block:   make(chan struct{}),
+		entered: make(chan struct{}, 2),
+	}
+	cfg := GateConfig{
+		Enabled:       true,
+		MaxConcurrent: 2,
+		// Rate 0 => unlimited; distinct args avoid dedupe so each call competes
+		// for a concurrency slot.
+		Policies: map[commands.Type]Policy{testCmd: {Rate: 0, Weight: 1}},
+		now:      frozenClock(),
+	}
+	g := NewGate(inner, cfg, zap.NewNop())
+
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			cmd := commands.Command{Type: testCmd, Arguments: map[string]any{"i": idx}}
+			_, _ = g.Process(context.Background(), cmd)
+		}(i)
+	}
+	// Wait until both slots are held inside inner.Process.
+	<-inner.entered
+	<-inner.entered
+
+	// A third command cannot acquire a slot and is rejected immediately.
+	_, err := g.Process(context.Background(), commands.Command{Type: testCmd, Arguments: map[string]any{"i": 99}})
+	require.Error(t, err)
+	assert.True(t, IsRateLimited(err), "concurrency budget exhausted is reported as rate limited")
+
+	close(inner.block)
+	wg.Wait()
+	assert.Equal(t, int64(2), inner.calls.Load(), "rejected command never reached inner")
+}
+
+func TestArgsHash(t *testing.T) {
+	// Order-independent: maps built in different orders hash identically.
+	a := map[string]any{"a": 1.0, "b": "x", "c": true}
+	b := map[string]any{"c": true, "b": "x", "a": 1.0}
+	assert.Equal(t, argsHash(a), argsHash(b))
+
+	// Different values hash differently.
+	assert.NotEqual(t, argsHash(a), argsHash(map[string]any{"a": 2.0, "b": "x", "c": true}))
+
+	// Empty/nil hash to the empty string (dedupe by type alone).
+	assert.Equal(t, "", argsHash(nil))
+	assert.Equal(t, "", argsHash(map[string]any{}))
+
+	// Nested structures are handled deterministically.
+	n1 := map[string]any{"outer": map[string]any{"x": 1.0, "y": 2.0}}
+	n2 := map[string]any{"outer": map[string]any{"y": 2.0, "x": 1.0}}
+	assert.Equal(t, argsHash(n1), argsHash(n2))
+}
+
+func TestDefaultGateConfig_ClassifiesCommands(t *testing.T) {
+	cfg := DefaultGateConfig()
+	require.True(t, cfg.Enabled)
+
+	// Disruptive commands are deduped and tightly limited.
+	reboot := cfg.Policies[commands.CMD_REBOOT]
+	assert.True(t, reboot.Dedupe)
+	assert.Less(t, reboot.Rate, 1.0)
+
+	// The externally reachable cast path is heavier-weight than a cheap query.
+	cast := cfg.Policies[commands.CMD_DISPLAY_PLAYLIST]
+	query := cfg.Policies[commands.CMD_DEVICE_STATUS]
+	assert.Greater(t, cast.Weight, query.Weight)
+
+	// Input gestures share one limiter group.
+	assert.Equal(t, inputGroup, cfg.Policies[commands.CMD_MOUSE_DRAG_EVENT].Group)
+	assert.Equal(t, inputGroup, cfg.Policies[commands.CMD_ZOOM_GESTURE].Group)
+
+	// Slow, disruptive panel writes (incl. power) are not left at the generous
+	// default: they carry a heavier weight than a cheap query.
+	ddc := cfg.Policies[commands.CMD_DDC_PANEL_CONTROL]
+	assert.Greater(t, ddc.Weight, query.Weight)
+	assert.NotEqual(t, cfg.Default.Rate, ddc.Rate, "DDC control is explicitly classified, not Default")
+
+	// User-initiated wake must not be throttled as hard as a reboot, so rapid
+	// taps are not rejected (the executor coalesces bursts safely).
+	wake := cfg.Policies[commands.CMD_WAKE_NOW]
+	assert.Greater(t, wake.Rate, reboot.Rate)
+}

--- a/components/feral-controld/commandrouter/gate_test.go
+++ b/components/feral-controld/commandrouter/gate_test.go
@@ -2,6 +2,7 @@ package commandrouter
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -223,6 +224,45 @@ func TestGate_WeightAboveBudgetClampsToFullBudget(t *testing.T) {
 
 	close(inner.block)
 	assert.Equal(t, int64(1), inner.calls.Load(), "rejected command never reached inner")
+}
+
+// A storm of unique, attacker-controlled command names must share the single
+// default budget, not each receive a fresh token bucket. Otherwise storm
+// protection is trivially bypassed (every new name buys a fresh burst) and
+// limiter state grows without bound — one bucket per attacker string. Both
+// hazards are regressions from the command-storm review.
+func TestGate_UnclassifiedCommandsShareDefaultBudget(t *testing.T) {
+	inner := &stubHandler{result: "ok"}
+	cfg := GateConfig{
+		Enabled:       true,
+		MaxConcurrent: 16,
+		// No explicit policies: every command falls through to Default. Rate > 0
+		// so the bucket actually limits; the frozen clock means no mid-test refill.
+		Default: Policy{Rate: 1, Burst: 3, Weight: 1},
+		now:     frozenClock(),
+	}
+	g := NewGate(inner, cfg, zap.NewNop())
+
+	accepted := 0
+	var lastErr error
+	for i := 0; i < 20; i++ {
+		cmd := commands.Command{Type: commands.Type(fmt.Sprintf("unknown-%d", i))}
+		if _, err := g.Process(context.Background(), cmd); err == nil {
+			accepted++
+		} else {
+			lastErr = err
+		}
+	}
+
+	// Only burst-many commands pass, even though every name is unique: they
+	// share one bucket. Per-name buckets would have accepted all 20.
+	assert.Equal(t, 3, accepted, "unclassified commands share the default burst budget")
+	require.Error(t, lastErr)
+	assert.True(t, IsRateLimited(lastErr))
+
+	// And the whole storm allocated exactly one token bucket.
+	gate := g.(*gate)
+	assert.Equal(t, 1, len(gate.limiters.buckets), "a storm of unique names must not allocate one bucket per name")
 }
 
 func TestArgsHash(t *testing.T) {

--- a/components/feral-controld/commandrouter/limiter.go
+++ b/components/feral-controld/commandrouter/limiter.go
@@ -1,0 +1,93 @@
+package commandrouter
+
+import (
+	"sync"
+	"time"
+)
+
+// tokenBucket is a simple token-bucket rate limiter. Tokens refill continuously
+// at `rate` tokens per second up to `burst` capacity. It is safe for concurrent
+// use. The clock is injectable so behavior is deterministic under test.
+//
+// A rate of 0 means "unlimited" — allow always.
+type tokenBucket struct {
+	mu     sync.Mutex
+	rate   float64 // tokens per second
+	burst  float64 // maximum tokens
+	tokens float64
+	last   time.Time
+	now    func() time.Time
+}
+
+func newTokenBucket(rate float64, burst int, now func() time.Time) *tokenBucket {
+	if now == nil {
+		now = time.Now
+	}
+	return &tokenBucket{
+		rate:   rate,
+		burst:  float64(burst),
+		tokens: float64(burst),
+		last:   now(),
+		now:    now,
+	}
+}
+
+// allow consumes a single token if one is available, returning true. When the
+// limiter is unlimited (rate <= 0) it always returns true.
+func (b *tokenBucket) allow() bool {
+	if b.rate <= 0 {
+		return true
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	now := b.now()
+	elapsed := now.Sub(b.last).Seconds()
+	if elapsed > 0 {
+		b.tokens += elapsed * b.rate
+		if b.tokens > b.burst {
+			b.tokens = b.burst
+		}
+		b.last = now
+	}
+
+	if b.tokens >= 1 {
+		b.tokens--
+		return true
+	}
+	return false
+}
+
+// limiterSet holds one token bucket per limiter key (a command type or a shared
+// group such as "input"). Buckets are created lazily on first use; all command
+// types that share a group key therefore share a single bucket.
+type limiterSet struct {
+	mu      sync.Mutex
+	buckets map[string]*tokenBucket
+	now     func() time.Time
+}
+
+func newLimiterSet(now func() time.Time) *limiterSet {
+	if now == nil {
+		now = time.Now
+	}
+	return &limiterSet{
+		buckets: make(map[string]*tokenBucket),
+		now:     now,
+	}
+}
+
+// allow reports whether a command governed by policy p (under the given limiter
+// key) may proceed.
+func (s *limiterSet) allow(key string, p Policy) bool {
+	s.mu.Lock()
+	bucket, ok := s.buckets[key]
+	if !ok {
+		bucket = newTokenBucket(p.Rate, p.Burst, s.now)
+		s.buckets[key] = bucket
+	}
+	s.mu.Unlock()
+
+	return bucket.allow()
+}

--- a/components/feral-controld/commandrouter/limiter_test.go
+++ b/components/feral-controld/commandrouter/limiter_test.go
@@ -1,0 +1,71 @@
+package commandrouter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTokenBucket_BurstThenRefill(t *testing.T) {
+	now := time.Unix(0, 0)
+	clock := func() time.Time { return now }
+
+	// 1 token/sec, capacity 2.
+	b := newTokenBucket(1, 2, clock)
+
+	// Burst capacity allows the first two immediately.
+	assert.True(t, b.allow(), "first request within burst")
+	assert.True(t, b.allow(), "second request within burst")
+	assert.False(t, b.allow(), "third request exceeds burst")
+
+	// After half a second, no whole token has refilled yet.
+	now = now.Add(500 * time.Millisecond)
+	assert.False(t, b.allow(), "still no token after 0.5s")
+
+	// After a full second from the last refill, one token is available.
+	now = now.Add(500 * time.Millisecond)
+	assert.True(t, b.allow(), "one token refilled after 1s")
+	assert.False(t, b.allow(), "only one token refilled")
+}
+
+func TestTokenBucket_RefillCapsAtBurst(t *testing.T) {
+	now := time.Unix(0, 0)
+	clock := func() time.Time { return now }
+	b := newTokenBucket(1, 2, clock)
+
+	// Drain.
+	assert.True(t, b.allow())
+	assert.True(t, b.allow())
+	assert.False(t, b.allow())
+
+	// Idle for a long time; tokens must not accumulate beyond burst.
+	now = now.Add(1 * time.Hour)
+	assert.True(t, b.allow())
+	assert.True(t, b.allow())
+	assert.False(t, b.allow(), "accumulated tokens are capped at burst")
+}
+
+func TestTokenBucket_Unlimited(t *testing.T) {
+	now := time.Unix(0, 0)
+	clock := func() time.Time { return now }
+	b := newTokenBucket(0, 0, clock)
+
+	for i := 0; i < 1000; i++ {
+		assert.True(t, b.allow(), "rate <= 0 always allows")
+	}
+}
+
+func TestLimiterSet_SharedGroupKey(t *testing.T) {
+	now := time.Unix(0, 0)
+	clock := func() time.Time { return now }
+	set := newLimiterSet(clock)
+
+	p := Policy{Group: inputGroup, Rate: 1, Burst: 2}
+
+	// Two distinct command types that share the same group key draw from one
+	// bucket: three calls across them exhaust the shared burst of 2.
+	assert.True(t, set.allow(inputGroup, p))
+	assert.True(t, set.allow(inputGroup, p))
+	assert.False(t, set.allow(inputGroup, p), "shared bucket exhausted")
+}

--- a/components/feral-controld/config.example.json
+++ b/components/feral-controld/config.example.json
@@ -17,5 +17,9 @@
   "openpanel": {
     "clientId": "YOUR_OPENPANEL_CLIENT_ID",
     "clientSecret": "YOUR_OPENPANEL_CLIENT_SECRET"
+  },
+  "commandStorm": {
+    "disabled": false,
+    "maxConcurrent": 0
   }
 } 

--- a/components/feral-controld/config/config.go
+++ b/components/feral-controld/config/config.go
@@ -28,12 +28,23 @@ type RelayerConfig struct {
 	APIKey   string `json:"apiKey"`
 }
 
+// CommandStormConfig tunes device-side command-storm protection in the command
+// router. All fields are optional; an absent section keeps the built-in
+// defaults, which are safe with zero configuration.
+type CommandStormConfig struct {
+	// Disabled turns the storm gate off entirely. Default (false) keeps it on.
+	Disabled bool `json:"disabled"`
+	// MaxConcurrent overrides the global in-flight command budget when > 0.
+	MaxConcurrent int64 `json:"maxConcurrent"`
+}
+
 // Configuration for all components
 type Config struct {
 	CDPConfig     *CDPConfig           `json:"cdp"`
 	RelayerConfig *RelayerConfig       `json:"relayer"`
 	SentryConfig  *logger.SentryConfig `json:"sentry"`
 	EnableHub     bool                 `json:"enableHub"`
+	CommandStorm  *CommandStormConfig  `json:"commandStorm,omitempty"`
 
 	// MACInfo contains MAC addresses for all network interfaces
 	// e.g., map[string]string{"enp1s0":"aa:bb:cc:dd:ee:ff","wlp2s0":"11:22:33:44:55:66"}

--- a/components/feral-controld/hub/hub.go
+++ b/components/feral-controld/hub/hub.go
@@ -24,6 +24,12 @@ const (
 	READ_TIMEOUT        = 30 * time.Second
 	WRITE_TIMEOUT       = 30 * time.Second
 	IDLE_TIMEOUT        = 60 * time.Second
+
+	// MAX_INFLIGHT_CASTS caps concurrent /api/cast handlers so a LAN command
+	// storm (including floods of byte-identical commands that the command
+	// router dedupes downstream) cannot pile up unbounded HTTP goroutines.
+	// Excess requests are rejected with 429 rather than blocking.
+	MAX_INFLIGHT_CASTS = 64
 )
 
 //go:generate mockgen -source=hub.go -destination=../mocks/hub.go -package=mocks -mock_names=Hub=MockHub
@@ -39,6 +45,7 @@ type hub struct {
 	wsHandler  ws.WS
 	cmdHandler commandrouter.Handler
 	json       wrapper.JSON
+	castSlots  chan struct{}
 }
 
 func New(
@@ -67,6 +74,7 @@ func New(
 		json:       json,
 		server:     server,
 		logger:     logger,
+		castSlots:  make(chan struct{}, MAX_INFLIGHT_CASTS),
 	}
 	h.routes()
 	return h
@@ -113,6 +121,16 @@ func (h *hub) Start() {
 func (h *hub) handleCast(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Post method is required", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Bound concurrent in-flight casts so a LAN storm cannot exhaust goroutines.
+	select {
+	case h.castSlots <- struct{}{}:
+		defer func() { <-h.castSlots }()
+	default:
+		h.logger.Warn("Cast rejected: hub at capacity")
+		http.Error(w, "Too many concurrent commands, slow down", http.StatusTooManyRequests)
 		return
 	}
 

--- a/components/feral-controld/hub/hub.go
+++ b/components/feral-controld/hub/hub.go
@@ -133,6 +133,11 @@ func (h *hub) handleCast(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.cmdHandler.Process(h.ctx, payload)
 	if err != nil {
+		if commandrouter.IsRateLimited(err) {
+			h.logger.Warn("Cast request rejected by storm protection", zap.Error(err))
+			http.Error(w, "Too many commands, slow down", http.StatusTooManyRequests)
+			return
+		}
 		h.logger.Error("Failed to process cast request", zap.Error(err))
 		http.Error(w, "Failed to process cast request", http.StatusInternalServerError)
 		return

--- a/components/feral-controld/hub/hub_test.go
+++ b/components/feral-controld/hub/hub_test.go
@@ -683,6 +683,37 @@ func (c *countingHandler) Process(_ context.Context, _ commands.Command) (interf
 	return nil, nil
 }
 
+// TestHandleCast_RejectsWhenAtCapacity verifies the LAN hub bounds concurrent
+// casts: once the in-flight budget is exhausted, further casts are rejected
+// with 429 before decoding or reaching the command handler, so a storm cannot
+// pile up unbounded HTTP goroutines (feral-file/ffos-user#208).
+func TestHandleCast_RejectsWhenAtCapacity(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	hubImpl := ts.hub.(*hub)
+
+	// Saturate the in-flight cast budget; nothing releases these in the test.
+	for i := 0; i < MAX_INFLIGHT_CASTS; i++ {
+		hubImpl.castSlots <- struct{}{}
+	}
+
+	req := httptest.NewRequest(
+		"POST",
+		"/api/cast",
+		strings.NewReader(`{"command":"displayPlaylist"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	// No mockCmd.Process / mockJSON.NewDecoder expectations: the capacity check
+	// runs before either, so a satisfied gomock controller asserts they are
+	// never reached.
+	hubImpl.handleCast(w, req)
+
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+}
+
 // TestHandleCast_StormProtection drives a burst of cast requests through the LAN
 // hub ingress wrapped with a real command-storm gate. Beyond the configured
 // burst the hub must answer 429 and the inner handler must never see the

--- a/components/feral-controld/hub/hub_test.go
+++ b/components/feral-controld/hub/hub_test.go
@@ -3,9 +3,11 @@ package hub
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,6 +16,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
+	"github.com/feral-file/ffos-user/components/feral-controld/commandrouter"
 	"github.com/feral-file/ffos-user/components/feral-controld/commands"
 	"github.com/feral-file/ffos-user/components/feral-controld/mocks"
 	"github.com/feral-file/ffos-user/components/feral-controld/wrapper"
@@ -667,4 +670,62 @@ func TestRespondJSON_Success(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+}
+
+// countingHandler is a real inner Handler that counts how many commands reach
+// it, used to prove the storm gate sheds excess before they hit the device.
+type countingHandler struct {
+	calls atomic.Int64
+}
+
+func (c *countingHandler) Process(_ context.Context, _ commands.Command) (interface{}, error) {
+	c.calls.Add(1)
+	return nil, nil
+}
+
+// TestHandleCast_StormProtection drives a burst of cast requests through the LAN
+// hub ingress wrapped with a real command-storm gate. Beyond the configured
+// burst the hub must answer 429 and the inner handler must never see the
+// excess (feral-file/ffos-user#208).
+func TestHandleCast_StormProtection(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	logger := zaptest.NewLogger(t, zaptest.Level(zap.FatalLevel))
+	ctx := context.Background()
+
+	mockWS := mocks.NewMockWS(ctrl)
+	mockServer := mocks.NewMockHTTPServer(ctrl)
+	mockServer.EXPECT().Handler().Return(http.NewServeMux()).AnyTimes()
+
+	stub := &countingHandler{}
+	gateCfg := commandrouter.GateConfig{
+		Enabled:       true,
+		MaxConcurrent: 16,
+		// Unlisted command type falls to Default: a tight burst of 2.
+		Default: commandrouter.Policy{Rate: 1, Burst: 2, Weight: 1},
+	}
+	gated := commandrouter.NewGate(stub, gateCfg, logger)
+
+	h := New(ctx, mockWS, gated, mockServer, wrapper.NewJSON(), logger).(*hub)
+
+	const total = 5
+	var accepted, limited int
+	for i := 0; i < total; i++ {
+		body := fmt.Sprintf(`{"command":"stormtest","request":{"i":%d}}`, i)
+		req := httptest.NewRequest("POST", "/api/cast", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		h.handleCast(w, req)
+
+		if w.Code == http.StatusTooManyRequests {
+			limited++
+		} else {
+			accepted++
+		}
+	}
+
+	assert.Equal(t, 2, accepted, "only the burst of 2 is accepted")
+	assert.Equal(t, total-2, limited, "the rest are rejected with 429")
+	assert.Equal(t, int64(2), stub.calls.Load(), "shed commands never reach the inner handler")
 }

--- a/components/feral-controld/main.go
+++ b/components/feral-controld/main.go
@@ -424,8 +424,20 @@ func initializeApp(
 	// DP1
 	dp1 := dp1.New(ffIndexer, httpClient, json, io, logger, debug)
 
-	// Command handler
+	// Command handler, wrapped with command-storm protection so both the
+	// relayer and LAN-hub ingress paths share one set of rate/concurrency
+	// guards (see feral-file/ffos-user#208).
 	cmdHandler := commandrouter.New(executor, cdp, dp1, poller, json, logger)
+	gateCfg := commandrouter.DefaultGateConfig()
+	if cs := config.Get().CommandStorm; cs != nil {
+		if cs.Disabled {
+			gateCfg.Enabled = false
+		}
+		if cs.MaxConcurrent > 0 {
+			gateCfg.MaxConcurrent = cs.MaxConcurrent
+		}
+	}
+	cmdHandler = commandrouter.NewGate(cmdHandler, gateCfg, logger)
 
 	// Playlist refresher
 	playlistRefresher := playlist_refresher.New(context, dp1, poller, cdp, clock, logger)

--- a/components/feral-controld/main.go
+++ b/components/feral-controld/main.go
@@ -424,10 +424,12 @@ func initializeApp(
 	// DP1
 	dp1 := dp1.New(ffIndexer, httpClient, json, io, logger, debug)
 
-	// Command handler, wrapped with command-storm protection so both the
-	// relayer and LAN-hub ingress paths share one set of rate/concurrency
-	// guards (see feral-file/ffos-user#208).
-	cmdHandler := commandrouter.New(executor, cdp, dp1, poller, json, logger)
+	// Command handler. The raw handler serves internal daemon lifecycle flows
+	// (e.g. OOM recovery) directly; external ingress (relayer + LAN hub) is
+	// wrapped with command-storm protection so both paths share one set of
+	// rate/concurrency guards (see feral-file/ffos-user#208). Internal recovery
+	// must never be shed by external client traffic, so it bypasses the gate.
+	rawCmdHandler := commandrouter.New(executor, cdp, dp1, poller, json, logger)
 	gateCfg := commandrouter.DefaultGateConfig()
 	if cs := config.Get().CommandStorm; cs != nil {
 		if cs.Disabled {
@@ -437,13 +439,13 @@ func initializeApp(
 			gateCfg.MaxConcurrent = cs.MaxConcurrent
 		}
 	}
-	cmdHandler = commandrouter.NewGate(cmdHandler, gateCfg, logger)
+	cmdHandler := commandrouter.NewGate(rawCmdHandler, gateCfg, logger)
 
 	// Playlist refresher
 	playlistRefresher := playlist_refresher.New(context, dp1, poller, cdp, clock, logger)
 
-	// OOM Recoverer
-	oomRecoverer := oomrecovery.New(poller, cmdHandler, logger)
+	// OOM Recoverer — internal lifecycle flow, uses the raw (ungated) handler.
+	oomRecoverer := oomrecovery.New(poller, rawCmdHandler, logger)
 
 	// Mediator
 	mediator := mediator.New(relayer, dbusClient, cdp, cmdHandler, executor, playlistRefresher, json, logger)

--- a/components/feral-controld/mediator/mediator.go
+++ b/components/feral-controld/mediator/mediator.go
@@ -222,6 +222,24 @@ func (m *mediator) handleRelayerMessage(ctx context.Context, payload relayer.Pay
 		}
 		result, err := m.cmdHandler.Process(ctx, command)
 		if err != nil {
+			if commandrouter.IsRateLimited(err) {
+				// Report a legible rejection back to the caller rather than
+				// dropping the command silently (feral-file/ffos-user#208).
+				m.logger.Warn("Command rejected by storm protection",
+					zap.String("command", commandType.String()),
+					zap.Error(err),
+				)
+				resp := relayer.Response{
+					Type:      "RPC",
+					MessageID: payload.MessageID,
+					Message: map[string]any{
+						"error":   "rate_limited",
+						"command": commandType.String(),
+						"message": err.Error(),
+					},
+				}
+				return m.relayer.Send(ctx, resp)
+			}
 			m.logger.Error("Failed to process command", zap.Error(err))
 			return err
 		}

--- a/components/feral-controld/mediator/mediator_test.go
+++ b/components/feral-controld/mediator/mediator_test.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap/zaptest"
 
 	"github.com/feral-file/ffos-user/components/feral-controld/cdp"
+	"github.com/feral-file/ffos-user/components/feral-controld/commandrouter"
 	"github.com/feral-file/ffos-user/components/feral-controld/commands"
 	"github.com/feral-file/ffos-user/components/feral-controld/dbus"
 	"github.com/feral-file/ffos-user/components/feral-controld/mdns"
@@ -786,5 +787,60 @@ func TestMediator_HandleRelayerMessage_ProcessCommand(t *testing.T) {
 				assert.NoError(t, err)
 			}
 		})
+	}
+}
+
+// TestMediator_HandleRelayerMessage_RateLimited verifies the relayer ingress
+// path reports command-storm rejections legibly: when the command router
+// rejects a command with a RateLimitedError, the mediator sends a structured
+// "rate_limited" RPC response back to the caller instead of dropping it
+// silently (feral-file/ffos-user#208).
+func TestMediator_HandleRelayerMessage_RateLimited(t *testing.T) {
+	ts := setup(t)
+	defer ts.teardown()
+
+	cmd := string(commands.CMD_DISPLAY_PLAYLIST)
+	args := map[string]interface{}{"url": "https://example/feed"}
+	payload := relayer.Payload{
+		MessageID: "msg-rate-limited",
+		Message: relayer.Message{
+			Command: &cmd,
+			Request: args,
+		},
+	}
+
+	ts.mockJSON.EXPECT().Marshal(gomock.Any()).Return([]byte("{}"), nil).AnyTimes()
+
+	ts.mockCommandHandler.EXPECT().
+		Process(gomock.Any(), commands.Command{Type: commands.Type(cmd), Arguments: args}).
+		Return(nil, &commandrouter.RateLimitedError{Command: commands.Type(cmd), Reason: "rate limit exceeded"}).
+		Times(1)
+
+	var sent relayer.Response
+	ts.mockRelayer.EXPECT().
+		Send(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, data interface{}) error {
+			sent = data.(relayer.Response)
+			return nil
+		}).
+		Times(1)
+
+	var capturedHandler relayer.Handler
+	ts.mockDbus.EXPECT().OnBusSignal(gomock.Any()).Times(1)
+	ts.mockRelayer.EXPECT().
+		OnRelayerMessage(gomock.Any()).
+		DoAndReturn(func(handler relayer.Handler) { capturedHandler = handler }).
+		Times(1)
+
+	ts.mediator.Start()
+	err := capturedHandler(ts.ctx, payload)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "RPC", sent.Type)
+	assert.Equal(t, "msg-rate-limited", sent.MessageID)
+	msg, ok := sent.Message.(map[string]any)
+	if assert.True(t, ok, "rate-limited response carries a structured body") {
+		assert.Equal(t, "rate_limited", msg["error"])
+		assert.Equal(t, cmd, msg["command"])
 	}
 }

--- a/components/feral-controld/mocks/websocket.go
+++ b/components/feral-controld/mocks/websocket.go
@@ -133,6 +133,20 @@ func (mr *MockWebSocketConnMockRecorder) SetReadDeadline(t interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetReadDeadline", reflect.TypeOf((*MockWebSocketConn)(nil).SetReadDeadline), t)
 }
 
+// SetWriteDeadline mocks base method.
+func (m *MockWebSocketConn) SetWriteDeadline(t time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetWriteDeadline", t)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetWriteDeadline indicates an expected call of SetWriteDeadline.
+func (mr *MockWebSocketConnMockRecorder) SetWriteDeadline(t interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWriteDeadline", reflect.TypeOf((*MockWebSocketConn)(nil).SetWriteDeadline), t)
+}
+
 // WriteControl mocks base method.
 func (m *MockWebSocketConn) WriteControl(messageType int, data []byte, deadline time.Time) error {
 	m.ctrl.T.Helper()

--- a/components/feral-controld/relayer/relayer.go
+++ b/components/feral-controld/relayer/relayer.go
@@ -54,12 +54,13 @@ const (
 
 	// MAX_INFLIGHT_SHED_RESPONSES caps the goroutines emitting "rate_limited"
 	// replies for shed commands. The replies are written off the read loop
-	// (Send takes the connection lock and writes with no deadline), so under the
-	// very storm we are shedding a slow/backpressured socket must not be able to
-	// wedge reads, pong handling, and pings behind one blocking write. When all
-	// slots are busy the reply is dropped: a best-effort courtesy reply is worth
-	// less than a responsive read loop, and a genuinely dead socket is torn down
-	// by the keepalive path instead.
+	// (Send takes the connection lock; its write is deadline-bounded but still
+	// holds the lock for up to WRITE_WAIT), so under the very storm we are
+	// shedding a slow/backpressured socket must not be able to wedge reads, pong
+	// handling, and pings behind one blocking write. When all slots are busy the
+	// reply is dropped: a best-effort courtesy reply is worth less than a
+	// responsive read loop, and a genuinely dead socket is torn down by the
+	// keepalive path instead.
 	MAX_INFLIGHT_SHED_RESPONSES = 16
 )
 
@@ -551,12 +552,13 @@ func (r *relayer) runHandlers(ctx context.Context, payload Payload, handlers []H
 }
 
 // shedResponseAsync emits a shed "rate_limited" reply without blocking the
-// caller (the read loop). Send takes the connection lock and writes to the
-// websocket with no deadline, so writing inline under a storm could stall
-// reads, pong handling, and pings behind one slow write. Hand the reply to a
-// bounded set of writer goroutines instead, and drop it when they are all busy:
-// a dropped best-effort reply is preferable to a wedged read loop, and a
-// genuinely dead socket is detected and reconnected by the keepalive path.
+// caller (the read loop). Send takes the connection lock and its write, though
+// now deadline-bounded, can still hold that lock for up to WRITE_WAIT, so
+// writing inline under a storm could stall reads, pong handling, and pings
+// behind one slow write. Hand the reply to a bounded set of writer goroutines
+// instead, and drop it when they are all busy: a dropped best-effort reply is
+// preferable to a wedged read loop, and a genuinely dead socket is detected and
+// reconnected by the keepalive path.
 // Writes stay serialized for gorilla's single-writer requirement because every
 // writer goroutine, like ping and Send, takes the connection lock.
 func (r *relayer) shedResponseAsync(ctx context.Context, payload Payload) {

--- a/components/feral-controld/relayer/relayer.go
+++ b/components/feral-controld/relayer/relayer.go
@@ -35,6 +35,16 @@ const (
 	PING_INTERVAL     = 15 * time.Second
 	PONG_WAIT         = 3 * time.Second
 
+	// WRITE_WAIT bounds how long any single websocket write may block. gorilla's
+	// WriteMessage/WriteJSON hold no internal timeout, so without a deadline a
+	// backpressured peer can park a write — and the connection mutex it holds —
+	// indefinitely, wedging ping(), Close(), reconnect, and any handler that is
+	// trying to reply (e.g. a storm of gate rejections). A deadline turns that
+	// unbounded stall into a bounded error that the read loop converts into a
+	// reconnect. The connection is single-writer (serialized by the mutex), so a
+	// per-write deadline is safe.
+	WRITE_WAIT = 5 * time.Second
+
 	// MAX_INFLIGHT_HANDLERS caps concurrent message-handler goroutines so a
 	// relayer command storm cannot spawn unbounded goroutines and exhaust
 	// device memory. Per-command rate limiting still happens downstream in the
@@ -465,62 +475,78 @@ func (r *relayer) background(ctx context.Context) {
 	}()
 }
 
-// dispatchMessage fans a single decoded payload out to the registered handlers.
+// dispatchMessage routes a single decoded payload to the registered handlers.
 //
-// Command fan-out is bounded by a dispatch slot per handler so a command storm
-// cannot spawn unbounded goroutines and exhaust device memory. Control-plane
-// messages (topic/system state) are rare and must NOT be shed by command
-// pressure, so they bypass the slot entirely.
+// Backpressure is accounted PER PAYLOAD, not per handler: one dispatch slot
+// covers the whole fan-out and a saturated command is shed exactly once. This
+// matters because more than one handler can be registered at a time — the
+// mediator is permanent, but dbus.GetRelayerTopicID temporarily registers a
+// control-plane listener. Per-handler accounting would otherwise shed the same
+// command once per listener (duplicate rate_limited replies for one messageID)
+// and make effective command capacity depend on how many listeners happen to
+// be installed.
 //
-// One slot is reserved per handler; with the expected single registered handler
-// (the mediator) that is one slot per message. If multiple handlers are ever
-// registered, revisit slot accounting before relying on more than one handler.
+// Control-plane messages (topic/system state) are rare and must NOT be shed by
+// command pressure, so they bypass the dispatch budget entirely. Either way the
+// handlers run off the read loop so a slow handler cannot stall reads.
 //
 // Extracted from the read loop so the saturation/shed path is unit-testable
 // without the full connection machinery.
 func (r *relayer) dispatchMessage(ctx context.Context, payload Payload) {
-	isControlPlane := payload.MessageID == MESSAGE_ID_SYSTEM
-	for _, handler := range r.handlers {
-		acquired := false
-		if !isControlPlane {
-			select {
-			case r.dispatchSem <- struct{}{}:
-				acquired = true
-			default:
-				// Saturated: shed this command, but reply legibly so the caller
-				// sees a rate-limit rejection instead of a silent timeout
-				// (feral-file/ffos-user#208). The reply is emitted off the read
-				// loop (shedResponseAsync) so a blocked write cannot wedge it.
-				r.logger.Warn("Relayer dispatch saturated, shedding command",
-					zap.String("messageID", payload.MessageID),
-					zap.String("command", derefString(payload.Message.Command)),
-				)
-				r.shedResponseAsync(ctx, payload)
-				continue
-			}
-		}
+	// Snapshot handlers under the lock: OnRelayerMessage/RemoveRelayerMessage
+	// mutate the slice concurrently (e.g. the temporary D-Bus listener), so the
+	// read loop must not iterate it directly.
+	r.Lock()
+	handlers := append([]Handler(nil), r.handlers...)
+	r.Unlock()
+	if len(handlers) == 0 {
+		return
+	}
 
-		// Run the handler in a separate goroutine to avoid blocking the read loop.
-		go func(ctx context.Context, payload Payload, handler Handler, acquired bool) {
-			if acquired {
-				defer func() { <-r.dispatchSem }()
-			}
-			select {
-			case <-ctx.Done():
-				return
-			case <-r.done:
-				return
-			default:
-				if err := handler(ctx, payload); err != nil {
-					r.logger.Error("Failed to handle message",
-						zap.Error(err),
-						zap.String("messageID", payload.MessageID),
-						zap.String("command", derefString(payload.Message.Command)),
-					)
-				}
-				return
-			}
-		}(ctx, payload, handler, acquired)
+	// Control-plane traffic bypasses the command budget.
+	if payload.MessageID == MESSAGE_ID_SYSTEM {
+		go r.runHandlers(ctx, payload, handlers, false)
+		return
+	}
+
+	select {
+	case r.dispatchSem <- struct{}{}:
+		go r.runHandlers(ctx, payload, handlers, true)
+	default:
+		// Saturated: shed this command once, but reply legibly so the caller
+		// sees a rate-limit rejection instead of a silent timeout
+		// (feral-file/ffos-user#208). The reply is emitted off the read loop
+		// (shedResponseAsync) so a blocked write cannot wedge it.
+		r.logger.Warn("Relayer dispatch saturated, shedding command",
+			zap.String("messageID", payload.MessageID),
+			zap.String("command", derefString(payload.Message.Command)),
+		)
+		r.shedResponseAsync(ctx, payload)
+	}
+}
+
+// runHandlers invokes every registered handler for one payload, off the read
+// loop. When acquired is true it owns a single dispatch slot for the whole
+// fan-out and releases it when all handlers return.
+func (r *relayer) runHandlers(ctx context.Context, payload Payload, handlers []Handler, acquired bool) {
+	if acquired {
+		defer func() { <-r.dispatchSem }()
+	}
+	select {
+	case <-ctx.Done():
+		return
+	case <-r.done:
+		return
+	default:
+	}
+	for _, handler := range handlers {
+		if err := handler(ctx, payload); err != nil {
+			r.logger.Error("Failed to handle message",
+				zap.Error(err),
+				zap.String("messageID", payload.MessageID),
+				zap.String("command", derefString(payload.Message.Command)),
+			)
+		}
 	}
 }
 
@@ -598,6 +624,14 @@ func (r *relayer) Send(ctx context.Context, data interface{}) error {
 		zap.Int("message_length", len(jsonData)),
 	)
 
+	// Bound the write so a backpressured peer cannot hold the connection mutex
+	// (and therefore block ping/Close/reconnect, or pin a caller's dispatch
+	// slot) indefinitely. A failed deadline set still lets the write proceed —
+	// it is only a best-effort safeguard, not a hard precondition.
+	if err := r.conn.SetWriteDeadline(r.clock.Now().Add(WRITE_WAIT)); err != nil {
+		r.logger.Warn("Failed to set write deadline before send", zap.Error(err))
+	}
+
 	return r.conn.WriteMessage(websocket.TextMessage, jsonData)
 }
 
@@ -620,6 +654,13 @@ func (r *relayer) ping() {
 
 	if err := r.conn.WriteControl(websocket.PingMessage, nil, deadline); err != nil {
 		r.logger.Error("Failed to send transport ping", zap.Error(err))
+	}
+
+	// WriteControl takes its own deadline, but WriteJSON relies on the
+	// connection write deadline; bound it so a stuck application-ping write
+	// cannot hold the mutex (and starve Close/reconnect) indefinitely.
+	if err := r.conn.SetWriteDeadline(r.clock.Now().Add(WRITE_WAIT)); err != nil {
+		r.logger.Error("Failed to set write deadline before application ping", zap.Error(err))
 	}
 
 	if err := r.conn.WriteJSON(map[string]string{"type": "ping"}); err != nil {

--- a/components/feral-controld/relayer/relayer.go
+++ b/components/feral-controld/relayer/relayer.go
@@ -34,6 +34,13 @@ const (
 	MESSAGE_ID_SYSTEM = "system"
 	PING_INTERVAL     = 15 * time.Second
 	PONG_WAIT         = 3 * time.Second
+
+	// MAX_INFLIGHT_HANDLERS caps concurrent message-handler goroutines so a
+	// relayer command storm cannot spawn unbounded goroutines and exhaust
+	// device memory. Per-command rate limiting still happens downstream in the
+	// command router; this is a coarse crash-prevention backstop for the
+	// dispatch fan-out itself.
+	MAX_INFLIGHT_HANDLERS = 256
 )
 
 type Message struct {
@@ -119,6 +126,7 @@ type relayer struct {
 	done         chan struct{}
 	pingDoneChan chan struct{}
 	handlers     []Handler
+	dispatchSem  chan struct{}
 
 	// Logger
 	logger *zap.Logger
@@ -136,16 +144,17 @@ func New(
 	logger *zap.Logger,
 ) Relayer {
 	return &relayer{
-		endpoint:   endpoint,
-		apiKey:     apiKey,
-		dialer:     dialer,
-		randomizer: randomizer,
-		clock:      clock,
-		done:       make(chan struct{}),
-		os:         os,
-		json:       json,
-		logger:     logger,
-		handlers:   []Handler{},
+		endpoint:    endpoint,
+		apiKey:      apiKey,
+		dialer:      dialer,
+		randomizer:  randomizer,
+		clock:       clock,
+		done:        make(chan struct{}),
+		os:          os,
+		json:        json,
+		logger:      logger,
+		handlers:    []Handler{},
+		dispatchSem: make(chan struct{}, MAX_INFLIGHT_HANDLERS),
 	}
 }
 
@@ -432,13 +441,34 @@ func (r *relayer) background(ctx context.Context) {
 					continue
 				}
 
-				// Forward payload to handlers
+				// Forward payload to handlers. One dispatch slot is reserved
+				// per handler; with the expected single registered handler
+				// (the mediator) that is one slot per message. If multiple
+				// handlers are ever registered, a saturated semaphore could
+				// dispatch a message to some handlers and shed it for others —
+				// revisit slot accounting (acquire per message) before relying
+				// on more than one handler.
 				for _, handler := range r.handlers {
 					p := payload
 					h := handler
 
+					// Reserve a dispatch slot before spawning. When the
+					// fan-out is saturated (command storm), shed the message
+					// rather than spawning unbounded goroutines. Commands that
+					// get through are still rate limited in the command router.
+					select {
+					case r.dispatchSem <- struct{}{}:
+					default:
+						r.logger.Warn("Relayer dispatch saturated, shedding message",
+							zap.String("messageID", payload.MessageID),
+							zap.String("command", derefString(payload.Message.Command)),
+						)
+						continue
+					}
+
 					// Run the handler in a separate goroutine to avoid blocking the main thread
 					go func(ctx context.Context, payload Payload, handler Handler) {
+						defer func() { <-r.dispatchSem }()
 						select {
 						case <-ctx.Done():
 							return

--- a/components/feral-controld/relayer/relayer.go
+++ b/components/feral-controld/relayer/relayer.go
@@ -41,6 +41,16 @@ const (
 	// command router; this is a coarse crash-prevention backstop for the
 	// dispatch fan-out itself.
 	MAX_INFLIGHT_HANDLERS = 256
+
+	// MAX_INFLIGHT_SHED_RESPONSES caps the goroutines emitting "rate_limited"
+	// replies for shed commands. The replies are written off the read loop
+	// (Send takes the connection lock and writes with no deadline), so under the
+	// very storm we are shedding a slow/backpressured socket must not be able to
+	// wedge reads, pong handling, and pings behind one blocking write. When all
+	// slots are busy the reply is dropped: a best-effort courtesy reply is worth
+	// less than a responsive read loop, and a genuinely dead socket is torn down
+	// by the keepalive path instead.
+	MAX_INFLIGHT_SHED_RESPONSES = 16
 )
 
 type Message struct {
@@ -127,6 +137,7 @@ type relayer struct {
 	pingDoneChan chan struct{}
 	handlers     []Handler
 	dispatchSem  chan struct{}
+	shedSem      chan struct{}
 
 	// Logger
 	logger *zap.Logger
@@ -155,6 +166,7 @@ func New(
 		logger:      logger,
 		handlers:    []Handler{},
 		dispatchSem: make(chan struct{}, MAX_INFLIGHT_HANDLERS),
+		shedSem:     make(chan struct{}, MAX_INFLIGHT_SHED_RESPONSES),
 	}
 }
 
@@ -300,6 +312,12 @@ func (r *relayer) Connect(ctx context.Context) error {
 	if r.pingDoneChan == nil {
 		r.pingDoneChan = make(chan struct{})
 	}
+	// Capture the stop channel locally before launching the goroutine. reconnect
+	// and Close reassign r.pingDoneChan (to nil) under the lock; selecting on the
+	// field directly would race with that write on every loop iteration. The
+	// local snapshot is the exact channel this goroutine must watch for its own
+	// lifetime, so closing the field's channel still wakes it.
+	pingDone := r.pingDoneChan
 
 	// Start pinging
 	ticker := r.clock.NewTicker(PING_INTERVAL)
@@ -312,7 +330,7 @@ func (r *relayer) Connect(ctx context.Context) error {
 			case <-r.done:
 				ticker.Stop()
 				return
-			case <-r.pingDoneChan:
+			case <-pingDone:
 				ticker.Stop()
 				return
 			case <-ticker.C():
@@ -441,64 +459,93 @@ func (r *relayer) background(ctx context.Context) {
 					continue
 				}
 
-				// Forward payload to handlers. Command fan-out is bounded by a
-				// dispatch slot per handler so a command storm cannot spawn
-				// unbounded goroutines. Control-plane messages (topic/system
-				// state) are rare and must NOT be shed by command pressure, so
-				// they bypass the slot entirely.
-				//
-				// One slot is reserved per handler; with the expected single
-				// registered handler (the mediator) that is one slot per
-				// message. If multiple handlers are ever registered, revisit
-				// slot accounting before relying on more than one handler.
-				for _, handler := range r.handlers {
-					p := payload
-					h := handler
-
-					isControlPlane := payload.MessageID == MESSAGE_ID_SYSTEM
-					acquired := false
-					if !isControlPlane {
-						select {
-						case r.dispatchSem <- struct{}{}:
-							acquired = true
-						default:
-							// Saturated: shed this command, but reply legibly so
-							// the caller sees a rate-limit rejection instead of a
-							// silent timeout (feral-file/ffos-user#208).
-							r.logger.Warn("Relayer dispatch saturated, shedding command",
-								zap.String("messageID", payload.MessageID),
-								zap.String("command", derefString(payload.Message.Command)),
-							)
-							r.sendShedResponse(ctx, p)
-							continue
-						}
-					}
-
-					// Run the handler in a separate goroutine to avoid blocking the main thread
-					go func(ctx context.Context, payload Payload, handler Handler, acquired bool) {
-						if acquired {
-							defer func() { <-r.dispatchSem }()
-						}
-						select {
-						case <-ctx.Done():
-							return
-						case <-r.done:
-							return
-						default:
-							if err := handler(ctx, payload); err != nil {
-								r.logger.Error("Failed to handle message",
-									zap.Error(err),
-									zap.String("messageID", payload.MessageID),
-									zap.String("command", derefString(payload.Message.Command)),
-								)
-							}
-							return
-						}
-					}(ctx, p, h, acquired)
-				}
+				r.dispatchMessage(ctx, payload)
 			}
 		}
 	}()
+}
+
+// dispatchMessage fans a single decoded payload out to the registered handlers.
+//
+// Command fan-out is bounded by a dispatch slot per handler so a command storm
+// cannot spawn unbounded goroutines and exhaust device memory. Control-plane
+// messages (topic/system state) are rare and must NOT be shed by command
+// pressure, so they bypass the slot entirely.
+//
+// One slot is reserved per handler; with the expected single registered handler
+// (the mediator) that is one slot per message. If multiple handlers are ever
+// registered, revisit slot accounting before relying on more than one handler.
+//
+// Extracted from the read loop so the saturation/shed path is unit-testable
+// without the full connection machinery.
+func (r *relayer) dispatchMessage(ctx context.Context, payload Payload) {
+	isControlPlane := payload.MessageID == MESSAGE_ID_SYSTEM
+	for _, handler := range r.handlers {
+		acquired := false
+		if !isControlPlane {
+			select {
+			case r.dispatchSem <- struct{}{}:
+				acquired = true
+			default:
+				// Saturated: shed this command, but reply legibly so the caller
+				// sees a rate-limit rejection instead of a silent timeout
+				// (feral-file/ffos-user#208). The reply is emitted off the read
+				// loop (shedResponseAsync) so a blocked write cannot wedge it.
+				r.logger.Warn("Relayer dispatch saturated, shedding command",
+					zap.String("messageID", payload.MessageID),
+					zap.String("command", derefString(payload.Message.Command)),
+				)
+				r.shedResponseAsync(ctx, payload)
+				continue
+			}
+		}
+
+		// Run the handler in a separate goroutine to avoid blocking the read loop.
+		go func(ctx context.Context, payload Payload, handler Handler, acquired bool) {
+			if acquired {
+				defer func() { <-r.dispatchSem }()
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-r.done:
+				return
+			default:
+				if err := handler(ctx, payload); err != nil {
+					r.logger.Error("Failed to handle message",
+						zap.Error(err),
+						zap.String("messageID", payload.MessageID),
+						zap.String("command", derefString(payload.Message.Command)),
+					)
+				}
+				return
+			}
+		}(ctx, payload, handler, acquired)
+	}
+}
+
+// shedResponseAsync emits a shed "rate_limited" reply without blocking the
+// caller (the read loop). Send takes the connection lock and writes to the
+// websocket with no deadline, so writing inline under a storm could stall
+// reads, pong handling, and pings behind one slow write. Hand the reply to a
+// bounded set of writer goroutines instead, and drop it when they are all busy:
+// a dropped best-effort reply is preferable to a wedged read loop, and a
+// genuinely dead socket is detected and reconnected by the keepalive path.
+// Writes stay serialized for gorilla's single-writer requirement because every
+// writer goroutine, like ping and Send, takes the connection lock.
+func (r *relayer) shedResponseAsync(ctx context.Context, payload Payload) {
+	select {
+	case r.shedSem <- struct{}{}:
+		go func(payload Payload) {
+			defer func() { <-r.shedSem }()
+			r.sendShedResponse(ctx, payload)
+		}(payload)
+	default:
+		r.logger.Warn("Relayer shed-response writers saturated, dropping rate-limited reply",
+			zap.String("messageID", payload.MessageID),
+			zap.String("command", derefString(payload.Message.Command)),
+		)
+	}
 }
 
 // sendShedResponse replies to a command that was shed under dispatch

--- a/components/feral-controld/relayer/relayer.go
+++ b/components/feral-controld/relayer/relayer.go
@@ -62,6 +62,19 @@ const (
 	// responsive read loop, and a genuinely dead socket is torn down by the
 	// keepalive path instead.
 	MAX_INFLIGHT_SHED_RESPONSES = 16
+
+	// MAX_INFLIGHT_CONTROL_HANDLERS caps concurrent handler goroutines for
+	// control-plane (messageID == "system") traffic. That discriminator comes
+	// straight off the decoded inbound envelope, so it is attacker-controllable:
+	// a hostile or malformed relayer-side storm could label every payload as
+	// "system" to escape the command dispatch budget (dispatchSem) entirely,
+	// spawning unbounded goroutines and hammering the mediator's topic-state
+	// save path. Control-plane traffic keeps its own lane so command pressure
+	// never sheds it, but that lane MUST still be bounded. The bound is small
+	// because legitimate control-plane messages (topic-state updates) are rare;
+	// excess is dropped rather than queued, since system messages carry no
+	// caller awaiting a reply by messageID.
+	MAX_INFLIGHT_CONTROL_HANDLERS = 8
 )
 
 type Message struct {
@@ -148,6 +161,7 @@ type relayer struct {
 	pingDoneChan chan struct{}
 	handlers     []Handler
 	dispatchSem  chan struct{}
+	controlSem   chan struct{}
 	shedSem      chan struct{}
 
 	// Logger
@@ -177,6 +191,7 @@ func New(
 		logger:      logger,
 		handlers:    []Handler{},
 		dispatchSem: make(chan struct{}, MAX_INFLIGHT_HANDLERS),
+		controlSem:  make(chan struct{}, MAX_INFLIGHT_CONTROL_HANDLERS),
 		shedSem:     make(chan struct{}, MAX_INFLIGHT_SHED_RESPONSES),
 	}
 }
@@ -491,8 +506,10 @@ func (r *relayer) background(ctx context.Context) {
 // be installed.
 //
 // Control-plane messages (topic/system state) are rare and must NOT be shed by
-// command pressure, so they bypass the dispatch budget entirely. Either way the
-// handlers run off the read loop so a slow handler cannot stall reads.
+// command pressure, so they run in a separate, smaller bounded lane (controlSem)
+// instead of the command budget. The separate lane is itself capped because the
+// "system" discriminator is attacker-controllable; see MAX_INFLIGHT_CONTROL_HANDLERS.
+// Either way the handlers run off the read loop so a slow handler cannot stall reads.
 //
 // Extracted from the read loop so the saturation/shed path is unit-testable
 // without the full connection machinery.
@@ -507,15 +524,30 @@ func (r *relayer) dispatchMessage(ctx context.Context, payload Payload) {
 		return
 	}
 
-	// Control-plane traffic bypasses the command budget.
+	// Control-plane traffic runs in its own bounded lane so command pressure
+	// never sheds it — but the lane is still bounded, because messageID is
+	// attacker-controllable (it is read straight off the decoded envelope). A
+	// storm of payloads labeled "system" must not escape every budget and spawn
+	// unbounded goroutines / repeatedly hit the mediator's topic-state save path.
 	if payload.MessageID == MESSAGE_ID_SYSTEM {
-		go r.runHandlers(ctx, payload, handlers, false)
+		select {
+		case r.controlSem <- struct{}{}:
+			go r.runHandlers(ctx, payload, handlers, r.controlSem)
+		default:
+			// Control lane saturated: drop. System messages carry no caller
+			// awaiting a reply by messageID (sendShedResponse skips them), so a
+			// legible rejection is neither expected nor possible — dropping is
+			// the correct backstop against a spoofed control-plane storm.
+			r.logger.Warn("Relayer control-plane lane saturated, dropping system message",
+				zap.String("topicID", derefString(payload.Message.TopicID)),
+			)
+		}
 		return
 	}
 
 	select {
 	case r.dispatchSem <- struct{}{}:
-		go r.runHandlers(ctx, payload, handlers, true)
+		go r.runHandlers(ctx, payload, handlers, r.dispatchSem)
 	default:
 		// Saturated: shed this command once, but reply legibly so the caller
 		// sees a rate-limit rejection instead of a silent timeout
@@ -530,11 +562,12 @@ func (r *relayer) dispatchMessage(ctx context.Context, payload Payload) {
 }
 
 // runHandlers invokes every registered handler for one payload, off the read
-// loop. When acquired is true it owns a single dispatch slot for the whole
-// fan-out and releases it when all handlers return.
-func (r *relayer) runHandlers(ctx context.Context, payload Payload, handlers []Handler, acquired bool) {
-	if acquired {
-		defer func() { <-r.dispatchSem }()
+// loop. When sem is non-nil it owns a single slot in that semaphore (dispatchSem
+// for commands, controlSem for control-plane) for the whole fan-out and releases
+// it when all handlers return.
+func (r *relayer) runHandlers(ctx context.Context, payload Payload, handlers []Handler, sem chan struct{}) {
+	if sem != nil {
+		defer func() { <-sem }()
 	}
 	select {
 	case <-ctx.Done():

--- a/components/feral-controld/relayer/relayer.go
+++ b/components/feral-controld/relayer/relayer.go
@@ -441,34 +441,44 @@ func (r *relayer) background(ctx context.Context) {
 					continue
 				}
 
-				// Forward payload to handlers. One dispatch slot is reserved
-				// per handler; with the expected single registered handler
-				// (the mediator) that is one slot per message. If multiple
-				// handlers are ever registered, a saturated semaphore could
-				// dispatch a message to some handlers and shed it for others —
-				// revisit slot accounting (acquire per message) before relying
-				// on more than one handler.
+				// Forward payload to handlers. Command fan-out is bounded by a
+				// dispatch slot per handler so a command storm cannot spawn
+				// unbounded goroutines. Control-plane messages (topic/system
+				// state) are rare and must NOT be shed by command pressure, so
+				// they bypass the slot entirely.
+				//
+				// One slot is reserved per handler; with the expected single
+				// registered handler (the mediator) that is one slot per
+				// message. If multiple handlers are ever registered, revisit
+				// slot accounting before relying on more than one handler.
 				for _, handler := range r.handlers {
 					p := payload
 					h := handler
 
-					// Reserve a dispatch slot before spawning. When the
-					// fan-out is saturated (command storm), shed the message
-					// rather than spawning unbounded goroutines. Commands that
-					// get through are still rate limited in the command router.
-					select {
-					case r.dispatchSem <- struct{}{}:
-					default:
-						r.logger.Warn("Relayer dispatch saturated, shedding message",
-							zap.String("messageID", payload.MessageID),
-							zap.String("command", derefString(payload.Message.Command)),
-						)
-						continue
+					isControlPlane := payload.MessageID == MESSAGE_ID_SYSTEM
+					acquired := false
+					if !isControlPlane {
+						select {
+						case r.dispatchSem <- struct{}{}:
+							acquired = true
+						default:
+							// Saturated: shed this command, but reply legibly so
+							// the caller sees a rate-limit rejection instead of a
+							// silent timeout (feral-file/ffos-user#208).
+							r.logger.Warn("Relayer dispatch saturated, shedding command",
+								zap.String("messageID", payload.MessageID),
+								zap.String("command", derefString(payload.Message.Command)),
+							)
+							r.sendShedResponse(ctx, p)
+							continue
+						}
 					}
 
 					// Run the handler in a separate goroutine to avoid blocking the main thread
-					go func(ctx context.Context, payload Payload, handler Handler) {
-						defer func() { <-r.dispatchSem }()
+					go func(ctx context.Context, payload Payload, handler Handler, acquired bool) {
+						if acquired {
+							defer func() { <-r.dispatchSem }()
+						}
 						select {
 						case <-ctx.Done():
 							return
@@ -484,11 +494,38 @@ func (r *relayer) background(ctx context.Context) {
 							}
 							return
 						}
-					}(ctx, p, h)
+					}(ctx, p, h, acquired)
 				}
 			}
 		}
 	}()
+}
+
+// sendShedResponse replies to a command that was shed under dispatch
+// saturation with the same structured "rate_limited" RPC body the command
+// router uses, so callers see a legible rejection instead of a silent timeout.
+// Only RPC command messages carry a caller awaiting a response by messageID;
+// messages without one (or control-plane traffic) are skipped.
+func (r *relayer) sendShedResponse(ctx context.Context, payload Payload) {
+	if payload.MessageID == "" || payload.MessageID == MESSAGE_ID_SYSTEM {
+		return
+	}
+
+	resp := Response{
+		Type:      "RPC",
+		MessageID: payload.MessageID,
+		Message: map[string]any{
+			"error":   "rate_limited",
+			"command": derefString(payload.Message.Command),
+			"message": "device is shedding a command storm; retry shortly",
+		},
+	}
+	if err := r.Send(ctx, resp); err != nil {
+		r.logger.Warn("Failed to send shed rate-limited response",
+			zap.Error(err),
+			zap.String("messageID", payload.MessageID),
+		)
+	}
 }
 
 // Send sends a message to the Relayer server

--- a/components/feral-controld/relayer/relayer_test.go
+++ b/components/feral-controld/relayer/relayer_test.go
@@ -1153,6 +1153,20 @@ func TestClient_ReceiveMessage_Success(t *testing.T) {
 		Return(0, pb, nil).
 		AnyTimes()
 
+	// This test drives the read loop in a tight loop (ReadMessage AnyTimes) with
+	// a handler that blocks on an unbuffered channel, so the dispatch semaphore
+	// saturates and excess commands are shed. Shed commands now receive a
+	// legible rate_limited response, so allow the relayer to serialize and write
+	// them (it does not affect the handler-routing assertions below).
+	ts.mockJSON.EXPECT().
+		Marshal(gomock.Any()).
+		Return([]byte("{}"), nil).
+		AnyTimes()
+	ts.mockConn.EXPECT().
+		WriteMessage(gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
 	// Expect cleanup when connection closes
 	ts.mockConn.EXPECT().
 		WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""), gomock.Any()).

--- a/components/feral-controld/relayer/relayer_test.go
+++ b/components/feral-controld/relayer/relayer_test.go
@@ -64,6 +64,13 @@ func setup(t *testing.T) *testSetup {
 		Return(nil).
 		AnyTimes()
 
+	// Writes (sends and the application ping) now set a write deadline first;
+	// accept it everywhere so individual tests need not restate it.
+	mockConn.EXPECT().
+		SetWriteDeadline(gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
 	client := relayer.New("ws://localhost:8080", "test-api-key", mockDialer, mockRandomizer, mockClock, mockOS, mockJSON, logger)
 
 	return &testSetup{
@@ -1290,6 +1297,12 @@ func TestClient_ReceiveMessage_Error(t *testing.T) {
 	// Expect second conn to set read deadline
 	mockConn2.EXPECT().
 		SetReadDeadline(gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	// Expect second conn to set write deadline before writes
+	mockConn2.EXPECT().
+		SetWriteDeadline(gomock.Any()).
 		Return(nil).
 		AnyTimes()
 

--- a/components/feral-controld/relayer/shed_response_test.go
+++ b/components/feral-controld/relayer/shed_response_test.go
@@ -19,7 +19,7 @@ import (
 // A hand-rolled fake avoids importing the generated mocks package, which would
 // create an import cycle in this in-package (white-box) test.
 //
-// It is concurrency-safe because shed replies are now written from a separate
+// It is concurrency-safe because shed replies are written from a separate
 // writer goroutine (see shedResponseAsync), so the read-loop test and the
 // writer race on the recorded writes under -race otherwise.
 type fakeShedConn struct {
@@ -28,9 +28,17 @@ type fakeShedConn struct {
 	// onWrite, when non-nil, is signaled (non-blocking) after each write so a
 	// test can wait for an asynchronous shed reply to land.
 	onWrite chan struct{}
+	// writeStarted, when non-nil, is signaled (non-blocking) on entry to
+	// WriteMessage so a test can observe that a write is in flight (and thus
+	// holding the connection mutex) before it completes.
+	writeStarted chan struct{}
 	// block, when non-nil, holds WriteMessage until the channel is closed/sent,
 	// simulating a slow or backpressured socket.
 	block chan struct{}
+	// writeDeadlineSet records whether SetWriteDeadline was called, and the last
+	// deadline passed, so tests can assert writes are deadline-bounded.
+	writeDeadlineSet  bool
+	lastWriteDeadline time.Time
 }
 
 func (f *fakeShedConn) WriteJSON(interface{}) error { return nil }
@@ -38,6 +46,12 @@ func (f *fakeShedConn) ReadMessage() (int, []byte, error) {
 	return 0, nil, nil
 }
 func (f *fakeShedConn) WriteMessage(_ int, data []byte) error {
+	if f.writeStarted != nil {
+		select {
+		case f.writeStarted <- struct{}{}:
+		default:
+		}
+	}
 	if f.block != nil {
 		<-f.block
 	}
@@ -55,7 +69,14 @@ func (f *fakeShedConn) WriteMessage(_ int, data []byte) error {
 func (f *fakeShedConn) WriteControl(int, []byte, time.Time) error { return nil }
 func (f *fakeShedConn) SetPongHandler(func(string) error)         {}
 func (f *fakeShedConn) SetReadDeadline(time.Time) error           { return nil }
-func (f *fakeShedConn) Close() error                              { return nil }
+func (f *fakeShedConn) SetWriteDeadline(t time.Time) error {
+	f.mu.Lock()
+	f.writeDeadlineSet = true
+	f.lastWriteDeadline = t
+	f.mu.Unlock()
+	return nil
+}
+func (f *fakeShedConn) Close() error { return nil }
 
 func (f *fakeShedConn) writeCount() int {
 	f.mu.Lock()
@@ -69,16 +90,34 @@ func (f *fakeShedConn) writeAt(i int) []byte {
 	return f.writes[i]
 }
 
+func (f *fakeShedConn) deadlineWasSet() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.writeDeadlineSet
+}
+
+// newShedRelayer builds a white-box relayer wired only with what the shed/
+// dispatch paths need. A real clock is required because Send now stamps a write
+// deadline via clock.Now().
+func newShedRelayer(t *testing.T, conn wrapper.WebSocketConn, handlers ...Handler) *relayer {
+	return &relayer{
+		json:        wrapper.NewJSON(),
+		clock:       wrapper.NewClock(),
+		conn:        conn,
+		logger:      zaptest.NewLogger(t),
+		done:        make(chan struct{}),
+		dispatchSem: make(chan struct{}, 1),
+		shedSem:     make(chan struct{}, MAX_INFLIGHT_SHED_RESPONSES),
+		handlers:    handlers,
+	}
+}
+
 // A shed command must receive a legible rate_limited RPC response mirroring the
 // command router's shape, so callers see a rejection instead of a silent
 // timeout (feral-file/ffos-user#208).
 func TestSendShedResponse_RepliesToCommand(t *testing.T) {
 	conn := &fakeShedConn{}
-	r := &relayer{
-		json:   wrapper.NewJSON(),
-		conn:   conn,
-		logger: zaptest.NewLogger(t),
-	}
+	r := newShedRelayer(t, conn)
 
 	command := "displayPlaylist"
 	r.sendShedResponse(context.Background(), Payload{
@@ -103,11 +142,7 @@ func TestSendShedResponse_RepliesToCommand(t *testing.T) {
 // reply by messageID, so they must not trigger a shed response.
 func TestSendShedResponse_SkipsSystemAndEmpty(t *testing.T) {
 	conn := &fakeShedConn{}
-	r := &relayer{
-		json:   wrapper.NewJSON(),
-		conn:   conn,
-		logger: zaptest.NewLogger(t),
-	}
+	r := newShedRelayer(t, conn)
 
 	r.sendShedResponse(context.Background(), Payload{MessageID: MESSAGE_ID_SYSTEM})
 	r.sendShedResponse(context.Background(), Payload{MessageID: ""})
@@ -121,20 +156,10 @@ func TestSendShedResponse_SkipsSystemAndEmpty(t *testing.T) {
 func TestDispatchMessage_ShedsSaturatedCommand(t *testing.T) {
 	conn := &fakeShedConn{onWrite: make(chan struct{}, 1)}
 	var handlerCalls atomic.Int32
-	r := &relayer{
-		json:        wrapper.NewJSON(),
-		conn:        conn,
-		logger:      zaptest.NewLogger(t),
-		done:        make(chan struct{}),
-		dispatchSem: make(chan struct{}, 1),
-		shedSem:     make(chan struct{}, 1),
-		handlers: []Handler{
-			func(context.Context, Payload) error {
-				handlerCalls.Add(1)
-				return nil
-			},
-		},
-	}
+	r := newShedRelayer(t, conn, func(context.Context, Payload) error {
+		handlerCalls.Add(1)
+		return nil
+	})
 
 	// Pre-saturate the only dispatch slot so the incoming command is shed.
 	r.dispatchSem <- struct{}{}
@@ -165,21 +190,53 @@ func TestDispatchMessage_ShedsSaturatedCommand(t *testing.T) {
 	assert.Equal(t, "displayPlaylist", body["command"])
 }
 
+// A saturated command must be shed exactly ONCE per payload, regardless of how
+// many handlers are registered. Production can have more than one handler (the
+// mediator plus a temporary D-Bus topic-ID listener); per-handler shedding
+// would emit duplicate rate_limited replies for one messageID and couple
+// command capacity to listener count.
+func TestDispatchMessage_ShedsOncePerPayloadAcrossHandlers(t *testing.T) {
+	conn := &fakeShedConn{onWrite: make(chan struct{}, 4)}
+	var h1, h2 atomic.Int32
+	r := newShedRelayer(t, conn,
+		func(context.Context, Payload) error { h1.Add(1); return nil },
+		func(context.Context, Payload) error { h2.Add(1); return nil },
+	)
+
+	// Pre-saturate the only dispatch slot so the incoming command is shed.
+	r.dispatchSem <- struct{}{}
+
+	command := "displayPlaylist"
+	r.dispatchMessage(context.Background(), Payload{
+		MessageID: "msg-1",
+		Message:   Message{Command: &command},
+	})
+
+	// Exactly one reply lands...
+	select {
+	case <-conn.onWrite:
+	case <-time.After(time.Second):
+		t.Fatal("expected one shed rate_limited reply")
+	}
+	// ...and no second reply is produced for the additional handler.
+	select {
+	case <-conn.onWrite:
+		t.Fatal("shed reply must be emitted once per payload, not once per handler")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	assert.Equal(t, 1, conn.writeCount(), "one payload sheds one reply")
+	assert.Equal(t, int32(0), h1.Load(), "no handler runs for a shed command")
+	assert.Equal(t, int32(0), h2.Load(), "no handler runs for a shed command")
+}
+
 // The shed reply must be emitted off the read loop: a slow/backpressured socket
 // (the very condition we shed under) must not be able to wedge dispatch behind
 // a single blocking write.
 func TestDispatchMessage_ShedReplyDoesNotBlockReadLoop(t *testing.T) {
 	release := make(chan struct{})
 	conn := &fakeShedConn{block: release}
-	r := &relayer{
-		json:        wrapper.NewJSON(),
-		conn:        conn,
-		logger:      zaptest.NewLogger(t),
-		done:        make(chan struct{}),
-		dispatchSem: make(chan struct{}, 1),
-		shedSem:     make(chan struct{}, 1),
-		handlers:    []Handler{func(context.Context, Payload) error { return nil }},
-	}
+	r := newShedRelayer(t, conn, func(context.Context, Payload) error { return nil })
 
 	// Saturate the dispatch slot so the command takes the shed path, whose write
 	// is now stuck on the blocked socket.
@@ -204,4 +261,114 @@ func TestDispatchMessage_ShedReplyDoesNotBlockReadLoop(t *testing.T) {
 
 	// Release the parked writer goroutine so the test leaves nothing wedged.
 	close(release)
+}
+
+// Send must stamp a write deadline before writing so a backpressured peer
+// cannot hold the connection mutex (and thus block ping/Close/reconnect, or pin
+// a caller's dispatch slot) indefinitely.
+func TestSend_AppliesWriteDeadline(t *testing.T) {
+	conn := &fakeShedConn{}
+	r := newShedRelayer(t, conn)
+
+	require.NoError(t, r.Send(context.Background(), map[string]string{"k": "v"}))
+
+	assert.True(t, conn.deadlineWasSet(), "Send must set a write deadline before writing")
+	assert.False(t, conn.lastWriteDeadline.IsZero(), "write deadline must be a real (future) time")
+	require.Equal(t, 1, conn.writeCount())
+}
+
+// A handler that replies via Send (as the mediator does for gate rejections)
+// runs while holding a dispatch slot. If its write blocks on a backpressured
+// socket the slot stays held — but only until the write returns, which the
+// write deadline bounds. This proves a storm of rejection replies cannot pin
+// the dispatch backstop indefinitely.
+func TestDispatchMessage_SlotReleasedAfterHandlerSendCompletes(t *testing.T) {
+	release := make(chan struct{})
+	conn := &fakeShedConn{block: release, writeStarted: make(chan struct{}, 1)}
+	r := newShedRelayer(t, conn)
+	// Handler mimics mediator.handleRelayerMessage's rejection reply: it Sends,
+	// and that write blocks on the stuck socket while the slot is held.
+	r.handlers = []Handler{
+		func(ctx context.Context, p Payload) error {
+			return r.Send(ctx, Response{Type: "RPC", MessageID: p.MessageID, Message: "reply"})
+		},
+	}
+
+	command := "displayPlaylist"
+	r.dispatchMessage(context.Background(), Payload{
+		MessageID: "msg-1",
+		Message:   Message{Command: &command},
+	})
+
+	// The handler's Send is in flight, holding the only dispatch slot (cap 1).
+	select {
+	case <-conn.writeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("handler send never started")
+	}
+	select {
+	case r.dispatchSem <- struct{}{}:
+		<-r.dispatchSem
+		t.Fatal("dispatch slot must stay held while the handler's send is in flight")
+	default:
+	}
+
+	// Once the write returns (bounded by WRITE_WAIT in production), the slot is
+	// freed and the backstop recovers.
+	close(release)
+	require.Eventually(t, func() bool {
+		select {
+		case r.dispatchSem <- struct{}{}:
+			<-r.dispatchSem
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 5*time.Millisecond, "dispatch slot must be released after the handler's send completes")
+}
+
+// Lifecycle progress: a write blocked in WriteMessage holds the connection
+// mutex, so Close cannot complete until that write returns — but it MUST
+// complete once it does. In production WRITE_WAIT guarantees the write returns
+// within a bound (see TestSend_AppliesWriteDeadline), so Close/ping/reconnect
+// make bounded progress instead of wedging forever.
+func TestClose_ProceedsOnceBlockedWriteReleases(t *testing.T) {
+	release := make(chan struct{})
+	conn := &fakeShedConn{block: release, writeStarted: make(chan struct{}, 1)}
+	r := newShedRelayer(t, conn)
+
+	// Start a send that blocks inside WriteMessage while holding the mutex.
+	sendReturned := make(chan struct{})
+	go func() {
+		_ = r.Send(context.Background(), map[string]string{"k": "v"})
+		close(sendReturned)
+	}()
+
+	select {
+	case <-conn.writeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("write never started")
+	}
+
+	// Close blocks on the mutex held by the in-flight write...
+	closeReturned := make(chan struct{})
+	go func() {
+		r.Close()
+		close(closeReturned)
+	}()
+	select {
+	case <-closeReturned:
+		t.Fatal("Close returned while a write still held the connection mutex")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// ...and proceeds promptly once the write returns (the deadline guarantees
+	// this happens within WRITE_WAIT in production).
+	close(release)
+	select {
+	case <-closeReturned:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not proceed after the blocked write released")
+	}
+	<-sendReturned
 }

--- a/components/feral-controld/relayer/shed_response_test.go
+++ b/components/feral-controld/relayer/shed_response_test.go
@@ -3,6 +3,8 @@ package relayer
 import (
 	"context"
 	"encoding/json"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -16,8 +18,19 @@ import (
 // fakeShedConn is a minimal WebSocketConn that records WriteMessage payloads.
 // A hand-rolled fake avoids importing the generated mocks package, which would
 // create an import cycle in this in-package (white-box) test.
+//
+// It is concurrency-safe because shed replies are now written from a separate
+// writer goroutine (see shedResponseAsync), so the read-loop test and the
+// writer race on the recorded writes under -race otherwise.
 type fakeShedConn struct {
+	mu     sync.Mutex
 	writes [][]byte
+	// onWrite, when non-nil, is signaled (non-blocking) after each write so a
+	// test can wait for an asynchronous shed reply to land.
+	onWrite chan struct{}
+	// block, when non-nil, holds WriteMessage until the channel is closed/sent,
+	// simulating a slow or backpressured socket.
+	block chan struct{}
 }
 
 func (f *fakeShedConn) WriteJSON(interface{}) error { return nil }
@@ -25,13 +38,36 @@ func (f *fakeShedConn) ReadMessage() (int, []byte, error) {
 	return 0, nil, nil
 }
 func (f *fakeShedConn) WriteMessage(_ int, data []byte) error {
-	f.writes = append(f.writes, data)
+	if f.block != nil {
+		<-f.block
+	}
+	f.mu.Lock()
+	f.writes = append(f.writes, append([]byte(nil), data...))
+	f.mu.Unlock()
+	if f.onWrite != nil {
+		select {
+		case f.onWrite <- struct{}{}:
+		default:
+		}
+	}
 	return nil
 }
 func (f *fakeShedConn) WriteControl(int, []byte, time.Time) error { return nil }
 func (f *fakeShedConn) SetPongHandler(func(string) error)         {}
 func (f *fakeShedConn) SetReadDeadline(time.Time) error           { return nil }
 func (f *fakeShedConn) Close() error                              { return nil }
+
+func (f *fakeShedConn) writeCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.writes)
+}
+
+func (f *fakeShedConn) writeAt(i int) []byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.writes[i]
+}
 
 // A shed command must receive a legible rate_limited RPC response mirroring the
 // command router's shape, so callers see a rejection instead of a silent
@@ -50,10 +86,10 @@ func TestSendShedResponse_RepliesToCommand(t *testing.T) {
 		Message:   Message{Command: &command},
 	})
 
-	require.Len(t, conn.writes, 1, "exactly one shed response should be written")
+	require.Equal(t, 1, conn.writeCount(), "exactly one shed response should be written")
 
 	var resp Response
-	require.NoError(t, json.Unmarshal(conn.writes[0], &resp))
+	require.NoError(t, json.Unmarshal(conn.writeAt(0), &resp))
 	assert.Equal(t, "RPC", resp.Type)
 	assert.Equal(t, "msg-1", resp.MessageID)
 
@@ -76,5 +112,96 @@ func TestSendShedResponse_SkipsSystemAndEmpty(t *testing.T) {
 	r.sendShedResponse(context.Background(), Payload{MessageID: MESSAGE_ID_SYSTEM})
 	r.sendShedResponse(context.Background(), Payload{MessageID: ""})
 
-	assert.Empty(t, conn.writes, "no response should be sent for system/empty message IDs")
+	assert.Zero(t, conn.writeCount(), "no response should be sent for system/empty message IDs")
+}
+
+// When the dispatch semaphore is saturated, a command must be shed: the
+// registered handler must NOT run, and the caller must receive a legible
+// rate_limited RPC reply (feral-file/ffos-user#208).
+func TestDispatchMessage_ShedsSaturatedCommand(t *testing.T) {
+	conn := &fakeShedConn{onWrite: make(chan struct{}, 1)}
+	var handlerCalls atomic.Int32
+	r := &relayer{
+		json:        wrapper.NewJSON(),
+		conn:        conn,
+		logger:      zaptest.NewLogger(t),
+		done:        make(chan struct{}),
+		dispatchSem: make(chan struct{}, 1),
+		shedSem:     make(chan struct{}, 1),
+		handlers: []Handler{
+			func(context.Context, Payload) error {
+				handlerCalls.Add(1)
+				return nil
+			},
+		},
+	}
+
+	// Pre-saturate the only dispatch slot so the incoming command is shed.
+	r.dispatchSem <- struct{}{}
+
+	command := "displayPlaylist"
+	r.dispatchMessage(context.Background(), Payload{
+		MessageID: "msg-1",
+		Message:   Message{Command: &command},
+	})
+
+	// The shed reply is written off the read loop, so wait for it to land.
+	select {
+	case <-conn.onWrite:
+	case <-time.After(time.Second):
+		t.Fatal("expected a shed rate_limited reply to be written")
+	}
+
+	assert.Equal(t, int32(0), handlerCalls.Load(), "handler must not run for a shed command")
+	require.Equal(t, 1, conn.writeCount())
+
+	var resp Response
+	require.NoError(t, json.Unmarshal(conn.writeAt(0), &resp))
+	assert.Equal(t, "RPC", resp.Type)
+	assert.Equal(t, "msg-1", resp.MessageID)
+	body, ok := resp.Message.(map[string]interface{})
+	require.True(t, ok, "shed response body must be a structured map")
+	assert.Equal(t, "rate_limited", body["error"])
+	assert.Equal(t, "displayPlaylist", body["command"])
+}
+
+// The shed reply must be emitted off the read loop: a slow/backpressured socket
+// (the very condition we shed under) must not be able to wedge dispatch behind
+// a single blocking write.
+func TestDispatchMessage_ShedReplyDoesNotBlockReadLoop(t *testing.T) {
+	release := make(chan struct{})
+	conn := &fakeShedConn{block: release}
+	r := &relayer{
+		json:        wrapper.NewJSON(),
+		conn:        conn,
+		logger:      zaptest.NewLogger(t),
+		done:        make(chan struct{}),
+		dispatchSem: make(chan struct{}, 1),
+		shedSem:     make(chan struct{}, 1),
+		handlers:    []Handler{func(context.Context, Payload) error { return nil }},
+	}
+
+	// Saturate the dispatch slot so the command takes the shed path, whose write
+	// is now stuck on the blocked socket.
+	r.dispatchSem <- struct{}{}
+
+	command := "displayPlaylist"
+	returned := make(chan struct{})
+	go func() {
+		r.dispatchMessage(context.Background(), Payload{
+			MessageID: "msg-1",
+			Message:   Message{Command: &command},
+		})
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+		// Good: dispatch returned even though the shed write is blocked.
+	case <-time.After(time.Second):
+		t.Fatal("dispatchMessage blocked on a slow shed-response write")
+	}
+
+	// Release the parked writer goroutine so the test leaves nothing wedged.
+	close(release)
 }

--- a/components/feral-controld/relayer/shed_response_test.go
+++ b/components/feral-controld/relayer/shed_response_test.go
@@ -1,0 +1,80 @@
+package relayer
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/feral-file/ffos-user/components/feral-controld/wrapper"
+)
+
+// fakeShedConn is a minimal WebSocketConn that records WriteMessage payloads.
+// A hand-rolled fake avoids importing the generated mocks package, which would
+// create an import cycle in this in-package (white-box) test.
+type fakeShedConn struct {
+	writes [][]byte
+}
+
+func (f *fakeShedConn) WriteJSON(interface{}) error { return nil }
+func (f *fakeShedConn) ReadMessage() (int, []byte, error) {
+	return 0, nil, nil
+}
+func (f *fakeShedConn) WriteMessage(_ int, data []byte) error {
+	f.writes = append(f.writes, data)
+	return nil
+}
+func (f *fakeShedConn) WriteControl(int, []byte, time.Time) error { return nil }
+func (f *fakeShedConn) SetPongHandler(func(string) error)         {}
+func (f *fakeShedConn) SetReadDeadline(time.Time) error           { return nil }
+func (f *fakeShedConn) Close() error                              { return nil }
+
+// A shed command must receive a legible rate_limited RPC response mirroring the
+// command router's shape, so callers see a rejection instead of a silent
+// timeout (feral-file/ffos-user#208).
+func TestSendShedResponse_RepliesToCommand(t *testing.T) {
+	conn := &fakeShedConn{}
+	r := &relayer{
+		json:   wrapper.NewJSON(),
+		conn:   conn,
+		logger: zaptest.NewLogger(t),
+	}
+
+	command := "displayPlaylist"
+	r.sendShedResponse(context.Background(), Payload{
+		MessageID: "msg-1",
+		Message:   Message{Command: &command},
+	})
+
+	require.Len(t, conn.writes, 1, "exactly one shed response should be written")
+
+	var resp Response
+	require.NoError(t, json.Unmarshal(conn.writes[0], &resp))
+	assert.Equal(t, "RPC", resp.Type)
+	assert.Equal(t, "msg-1", resp.MessageID)
+
+	body, ok := resp.Message.(map[string]interface{})
+	require.True(t, ok, "shed response body must be a structured map")
+	assert.Equal(t, "rate_limited", body["error"])
+	assert.Equal(t, "displayPlaylist", body["command"])
+}
+
+// Control-plane (system) and response-less messages have no caller awaiting a
+// reply by messageID, so they must not trigger a shed response.
+func TestSendShedResponse_SkipsSystemAndEmpty(t *testing.T) {
+	conn := &fakeShedConn{}
+	r := &relayer{
+		json:   wrapper.NewJSON(),
+		conn:   conn,
+		logger: zaptest.NewLogger(t),
+	}
+
+	r.sendShedResponse(context.Background(), Payload{MessageID: MESSAGE_ID_SYSTEM})
+	r.sendShedResponse(context.Background(), Payload{MessageID: ""})
+
+	assert.Empty(t, conn.writes, "no response should be sent for system/empty message IDs")
+}

--- a/components/feral-controld/relayer/shed_response_test.go
+++ b/components/feral-controld/relayer/shed_response_test.go
@@ -107,6 +107,7 @@ func newShedRelayer(t *testing.T, conn wrapper.WebSocketConn, handlers ...Handle
 		logger:      zaptest.NewLogger(t),
 		done:        make(chan struct{}),
 		dispatchSem: make(chan struct{}, 1),
+		controlSem:  make(chan struct{}, MAX_INFLIGHT_CONTROL_HANDLERS),
 		shedSem:     make(chan struct{}, MAX_INFLIGHT_SHED_RESPONSES),
 		handlers:    handlers,
 	}
@@ -261,6 +262,112 @@ func TestDispatchMessage_ShedReplyDoesNotBlockReadLoop(t *testing.T) {
 
 	// Release the parked writer goroutine so the test leaves nothing wedged.
 	close(release)
+}
+
+// A storm of messageID == "system" payloads must NOT escape into unbounded
+// goroutines or repeated topic-state work. The "system" discriminator is read
+// straight off the decoded inbound envelope, so a hostile/malformed relayer can
+// spoof it to dodge the command dispatch budget (dispatchSem). The control-plane
+// lane (controlSem) bounds this: once its slots are full, further system
+// payloads are dropped rather than queued, so handler invocations — which is
+// where the mediator's topic-state save runs — can never exceed the lane
+// capacity for in-flight work, no matter how large the storm.
+func TestDispatchMessage_BoundsControlPlaneStorm(t *testing.T) {
+	const laneCap = 2
+	conn := &fakeShedConn{}
+
+	release := make(chan struct{})
+	var started, running atomic.Int32
+	r := newShedRelayer(t, conn, func(context.Context, Payload) error {
+		started.Add(1)
+		running.Add(1)
+		defer running.Add(-1)
+		<-release // hold the slot so the storm meets a saturated lane
+		return nil
+	})
+	// Shrink the control lane to a deterministic capacity for the assertions.
+	r.controlSem = make(chan struct{}, laneCap)
+
+	// Slot acquisition happens synchronously in dispatchMessage, so the first
+	// laneCap payloads take a slot (and block in the handler), and every payload
+	// after that meets a saturated lane and is dropped — never queued.
+	topicID := "topic-1"
+	const storm = 200
+	for i := 0; i < storm; i++ {
+		r.dispatchMessage(context.Background(), Payload{
+			MessageID: MESSAGE_ID_SYSTEM,
+			Message:   Message{TopicID: &topicID},
+		})
+	}
+
+	// Exactly the admitted handlers run; the bound is never exceeded.
+	require.Eventually(t, func() bool {
+		return started.Load() == int32(laneCap)
+	}, time.Second, 5*time.Millisecond, "control lane must admit exactly its capacity under a storm")
+
+	// Give any erroneously-spawned extra goroutines a chance to run before
+	// asserting the bound held.
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, int32(laneCap), started.Load(),
+		"a system-message storm must not run more handlers than the control lane capacity")
+	assert.LessOrEqual(t, running.Load(), int32(laneCap),
+		"in-flight control-plane handlers must never exceed the lane capacity")
+
+	// System messages carry no caller awaiting a reply by messageID, so the
+	// dropped storm must produce no responses on the wire.
+	assert.Zero(t, conn.writeCount(), "dropped system messages must not write any reply")
+
+	// Releasing the held slots drains the admitted handlers; the dropped payloads
+	// never run, so no further topic-state work occurs.
+	close(release)
+	require.Eventually(t, func() bool {
+		return running.Load() == 0
+	}, time.Second, 5*time.Millisecond, "admitted handlers must drain after release")
+	assert.Equal(t, int32(laneCap), started.Load(),
+		"dropped system messages must never execute handlers (no extra topic-state work)")
+}
+
+// A dropped control-plane payload must free nothing it never held and must leave
+// the lane usable: once in-flight system handlers finish, new system traffic is
+// admitted again. This proves the bound is a transient backpressure cap, not a
+// permanent wedge.
+func TestDispatchMessage_ControlLaneRecoversAfterDrain(t *testing.T) {
+	conn := &fakeShedConn{}
+	var started atomic.Int32
+	gate := make(chan struct{})
+	r := newShedRelayer(t, conn, func(context.Context, Payload) error {
+		started.Add(1)
+		<-gate
+		return nil
+	})
+	r.controlSem = make(chan struct{}, 1)
+
+	topicID := "topic-1"
+	sys := func() {
+		r.dispatchMessage(context.Background(), Payload{
+			MessageID: MESSAGE_ID_SYSTEM,
+			Message:   Message{TopicID: &topicID},
+		})
+	}
+
+	// First admitted and held; second dropped (lane saturated).
+	sys()
+	require.Eventually(t, func() bool { return started.Load() == 1 }, time.Second, 5*time.Millisecond)
+	sys()
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, int32(1), started.Load(), "second system message must be dropped while the lane is full")
+
+	// Drain the first, then a fresh system message is admitted again.
+	close(gate)
+	require.Eventually(t, func() bool {
+		select {
+		case r.controlSem <- struct{}{}:
+			<-r.controlSem
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 5*time.Millisecond, "control lane must free its slot after the handler returns")
 }
 
 // Send must stamp a write deadline before writing so a backpressured peer

--- a/components/feral-controld/wrapper/websocket.go
+++ b/components/feral-controld/wrapper/websocket.go
@@ -22,6 +22,7 @@ type WebSocketConn interface {
 	WriteControl(messageType int, data []byte, deadline time.Time) error
 	SetPongHandler(h func(appData string) error)
 	SetReadDeadline(t time.Time) error
+	SetWriteDeadline(t time.Time) error
 	Close() error
 }
 
@@ -67,6 +68,10 @@ func (c *webSocketConn) SetPongHandler(h func(appData string) error) {
 
 func (c *webSocketConn) SetReadDeadline(t time.Time) error {
 	return c.conn.SetReadDeadline(t)
+}
+
+func (c *webSocketConn) SetWriteDeadline(t time.Time) error {
+	return c.conn.SetWriteDeadline(t)
 }
 
 func (c *webSocketConn) Close() error {

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -240,7 +240,7 @@ It is on by default with tuned defaults. The optional `commandStorm` config sect
 ```
 
 - `disabled` (default `false`) — turn the gate off entirely.
-- `maxConcurrent` (default `16`, used when `> 0`) — global in-flight command budget.
+- `maxConcurrent` (default `16`, used when `> 0`) — global in-flight command budget. A command's internal weight is clamped to this budget, so setting it below a heavy command's weight throttles that command (it reserves the whole budget while in flight) rather than rejecting it forever.
 
 ### BLE error codes
 

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -210,7 +210,37 @@ Use `dbus.NewError(message, []interface{}{})` for all D-Bus method errors. The f
 
 ### Relayer errors
 
-There is no standardized error response envelope defined yet. When an executor command fails, `controld` logs the error and does not send an explicit error response to the relayer unless the command protocol requires a reply. When adding new commands that need error responses, document the response shape in code comments near the command handler.
+Most command failures are not standardized: when an executor command fails, `controld` logs the error and does not send an explicit error response to the relayer unless the command protocol requires a reply. When adding new commands that need error responses, document the response shape in code comments near the command handler.
+
+**Command-storm rejection (standardized).** Command-storm protection (see below) is the one path with a defined controller-visible error envelope. When the command router rejects a command (rate limit or concurrency budget) or the relayer sheds a command under dispatch saturation, the controller receives an RPC response whose `message` body is:
+
+```json
+{
+  "error": "rate_limited",
+  "command": "displayPlaylist",
+  "message": "human-readable reason"
+}
+```
+
+The LAN-hub ingress reports the same condition with HTTP `429 Too Many Requests`. Controllers should treat both as "device busy" and back off; the command was not applied.
+
+### Command-storm protection
+
+`feral-controld` protects the shared command path from flooding across both the relayer and LAN-hub ingress (see feral-file/ffos-user#208). High-cost or disruptive commands are rate-limited, deduped, and bounded by a global concurrency budget; internal lifecycle flows (e.g. OOM recovery) bypass the gate so client traffic cannot shed them.
+
+It is on by default with tuned defaults. The optional `commandStorm` config section tunes it:
+
+```json
+{
+  "commandStorm": {
+    "disabled": false,
+    "maxConcurrent": 16
+  }
+}
+```
+
+- `disabled` (default `false`) — turn the gate off entirely.
+- `maxConcurrent` (default `16`, used when `> 0`) — global in-flight command budget.
 
 ### BLE error codes
 

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -222,6 +222,8 @@ Most command failures are not standardized: when an executor command fails, `con
 }
 ```
 
+The command-router rejection reply (rate limit / concurrency budget) is reliable. The relayer-side shed reply under **dispatch saturation** is **best-effort**: to avoid blocking its read loop under a sustained storm, the relayer drops the reply when its shed-response writers are all busy. Controllers must not rely on receiving it for that case and should fall back to a request timeout and retry.
+
 The LAN-hub ingress reports the same condition with HTTP `429 Too Many Requests`. Controllers should treat both as "device busy" and back off; the command was not applied.
 
 ### Command-storm protection

--- a/docs/controld-inbound-controller-messages.md
+++ b/docs/controld-inbound-controller-messages.md
@@ -77,6 +77,13 @@ sends an RPC response whose `message` body is:
 }
 ```
 
+The command-router rejection reply (rate limit / concurrency budget) is
+reliable. The relayer-side shed reply under **dispatch saturation** is
+**best-effort**: to keep its read loop responsive under a sustained storm, the
+relayer drops the reply when its shed-response writers are all busy. Controllers
+must not depend on receiving it in that case and should fall back to a request
+timeout and retry.
+
 The LAN-hub ingress reports the same condition as HTTP `429`. Controllers
 should treat this as "device busy", back off, and retry; the command was not
 applied. Control-plane messages (e.g. the `system`/topic-state message above)

--- a/docs/controld-inbound-controller-messages.md
+++ b/docs/controld-inbound-controller-messages.md
@@ -60,9 +60,27 @@ for relayer topic assignment:
 
 Current relayer error behavior is important: if command processing fails,
 `feral-controld` logs and returns an internal handler error. It does not
-currently send a standardized RPC error response over the relayer. New inbound
-message families that require controller-visible errors must define their own
-response shape.
+send a standardized RPC error response over the relayer for most failures, so
+new inbound message families that require controller-visible errors must define
+their own response shape.
+
+The one standardized exception is **command-storm rejection**. When the device
+sheds a command to protect itself from flooding (rate limit, concurrency
+budget, or relayer dispatch saturation — see feral-file/ffos-user#208), it
+sends an RPC response whose `message` body is:
+
+```json
+{
+  "error": "rate_limited",
+  "command": "displayPlaylist",
+  "message": "human-readable reason"
+}
+```
+
+The LAN-hub ingress reports the same condition as HTTP `429`. Controllers
+should treat this as "device busy", back off, and retry; the command was not
+applied. Control-plane messages (e.g. the `system`/topic-state message above)
+are never shed by command pressure.
 
 ## Shared Success Responses
 


### PR DESCRIPTION
## Summary

Adds device-side command-storm protection to `feral-controld` so an FF1 cannot be flooded or crashed via either ingress path, ahead of the objkt external-site casting flow (feral-file/feral-file#3434). Per that thread's decision, the **device** — not the relayer — is the primary safety gate, because `feral-controld` is the only place that sees both the relayer (cloud WebSocket) and LAN-Hub ingress.

Closes #208.

## Approach

Both ingress paths converge on `commandrouter.Handler.Process`, so protection is implemented as a **gate decorator** wrapping that single interface, wired once in `main.go`. One set of guards covers both paths without touching call-site logic.

Per command type, the gate applies:
- **Global weighted concurrency semaphore** (fail-fast `TryAcquire`) — bounds total in-flight work; prevents OOM from the relayer's per-message goroutine fan-out.
- **Token-bucket rate limiter** — tight for disruptive commands (`reboot`, `shutdown`, `factoryReset`, `updateToLatestVersion`, …), moderate for the heavy cast path (`displayPlaylist`, `refreshArtwork`, `uploadLogs`) and slow DDC panel writes, generous shared budget for input gestures.
- **Single-flight dedupe** — collapses byte-identical in-flight commands (e.g. a flood of identical casts) into one execution.

### Legible failures (never silent)
- LAN hub → HTTP **429**
- Relayer mediator → structured `rate_limited` RPC response

### Backstop
The relayer message fan-out gains a bounded dispatch semaphore (`MAX_INFLIGHT_HANDLERS`) so a storm can't spawn unbounded goroutines.

### Config
On by default with safe tuned defaults. Optional `commandStorm` config section can disable the gate or override the concurrency budget.

## Tests
- `commandrouter/limiter_test.go` — token bucket (burst, refill, cap, unlimited, shared group)
- `commandrouter/gate_test.go` — dedupe collapse, rate-limit & concurrency rejection, disabled passthrough, classification, arg hashing
- `hub/hub_test.go` — end-to-end storm through the LAN hub asserting the 429 transition and that shed commands never reach the inner handler
- `mediator/mediator_test.go` — relayer ingress reports `rate_limited` legibly

Verification: `go build ./...`, `go vet`, `golangci-lint` (new code) all clean; full suite passes; `go test -race ./commandrouter/` clean.

## Reviewer notes / follow-ups
- **H1 (sign-off requested):** on the dedupe cast path, truly-concurrent byte-identical commands share the leader's outcome, including a transient failure. Intended (failure is legible, any caller may retry) and documented in code — please confirm it's acceptable for go-live.
- **Out of scope (pre-existing):** `go test -race ./relayer/` reports data races that already exist on `develop`, unrelated to this change — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)